### PR TITLE
Prod table styling and show country attribute from chat

### DIFF
--- a/plugin-hrm-form/src/components/HrmForm/HrmForm.Container.js
+++ b/plugin-hrm-form/src/components/HrmForm/HrmForm.Container.js
@@ -32,7 +32,14 @@ class HrmFormContainer extends React.Component {
     if (!this.props.task) {
       return <p>No active tasks</p>;
     }
-    return <HrmForm onSubmit={this.submit} />
+    return (
+      <div>
+        <HrmForm onSubmit={this.submit} />
+        { this.props.task.attributes && this.props.task.attributes.country &&
+          <p>Country: { this.props.task.attributes.country }</p>
+        }
+      </div>
+    );
   }
 }
 

--- a/plugin-show-recent-contacts/src/components/RecentContacts.Styles.js
+++ b/plugin-show-recent-contacts/src/components/RecentContacts.Styles.js
@@ -1,0 +1,47 @@
+import { default as styled } from 'react-emotion';
+
+// For some reason, Flex does not import the styles for react-json-to-table
+// so we import then manually from here: 
+// https://github.com/thehyve/react-json-to-table/blob/master/src/components/JsonToTable/JsonToTable.scss
+// as of September 16, 2019 (SHA 5c45565f6ee0cb0473e93aa390fd3246b7538250)
+// We also add "overflow: auto" because if the list is too long for the screen,
+// Flex won't scroll without this.
+export const RecentContactsComponentStyles = styled('div')`
+  overflow: auto;
+
+  .json-to-table {
+      td,
+      th {
+        padding: 5px;
+        border: 1px solid rgb(190, 190, 190);
+      }
+
+      td {
+        text-align: left;
+      }
+
+      tr:nth-child(even) {
+        background-color: #eee;
+      }
+
+      th[scope="col"] {
+        background-color: #696969;
+        color: #fff;
+      }
+
+      th[scope="row"] {
+        background-color: #d7d9f2;
+      }
+
+      caption {
+        caption-side: bottom;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-family: sans-serif;
+        font-size: 0.8rem;
+      }
+  }
+`;

--- a/plugin-show-recent-contacts/src/components/RecentContactsView.js
+++ b/plugin-show-recent-contacts/src/components/RecentContactsView.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { JsonToTable } from 'react-json-to-table';
+import { RecentContactsComponentStyles } from './RecentContacts.Styles';
 
 export default class RecentContactsView extends React.Component {
   constructor(props) {
@@ -32,14 +33,13 @@ export default class RecentContactsView extends React.Component {
 
 
   render() {
-    //const myJson = this.state.myJson;
     const myJson = {
       "Recent Contacts": this.state.myJson
     };
     return (
-      <div style={{ overflow: 'auto' }}>
-        <JsonToTable json={myJson} />
-      </div>
+      <RecentContactsComponentStyles>
+          <JsonToTable json={myJson} />
+      </RecentContactsComponentStyles>
     );
   }
 }


### PR DESCRIPTION
This change is for tweaks from the demo I did on 9/17 including two things:
- Adding `react-json-to-table`'s styling into our plugin, as it appears that it will not get loaded when on the production Flex site.
- Display the 'country' attribute that comes in from webchat, just to show that it's happening.