### PR TITLE
Bug fix for version 0.0.1 of plugin-hrm-form: Removes field-level validation and just does submit validation with alert box

### DIFF
--- a/plugin-hrm-form/src/components/HrmForm/HrmForm.Container.js
+++ b/plugin-hrm-form/src/components/HrmForm/HrmForm.Container.js
@@ -1,34 +1,68 @@
 import React from 'react'
 import HrmForm from './HrmForm'
+import { SubmissionError } from 'redux-form'
+
+
+const makeErrorString = errors => {
+  var myString = "Cannot complete task due to errors: \n";
+  Object.keys(errors).forEach( key => {
+    myString += "- " + key + ": " + errors[key] + "\n";
+  });
+  return myString;
+}
 
 class HrmFormContainer extends React.Component {
   submit = values => {
     const url = 'https://hrm.tl.barbarianrobot.com';
     // const url = 'http://localhost:8080';
+    const errors = {};
+    if (!values.ageBracket) {
+      errors.ageBracket = 'Age bracket is required';
+    }
+    if (!values.subcategory) {
+      errors.subcategory = 'Subcategory is required';
+    }
+    if (Object.keys(errors).length !== 0) {
+      alert(makeErrorString(errors));
+      throw new SubmissionError(errors);
+    }
     let formdata = {
       ...values,
       timestamp: 0,
       taskId: this.props.task.taskSid,
       reservationId: this.props.task.sid
     };
+    const completeTaskFunc = this.props.onCompleteTask;
+    const sid = this.props.task.sid;
     // print the form values to the console
-    console.log(formdata);
-    fetch(url + '/contacts', {
+    console.log("Sending: " + JSON.stringify(formdata));
+    return fetch(url + '/contacts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(formdata)
     })
     .then(function(response) {
+      if (!response.ok) {
+        console.log("Form error: " + response.statusText);
+        throw new SubmissionError({
+          _error: 'Unable to save form: ' + response.statusText
+        });
+      }
       return response.json();
     })
     .then(function(myJson) {
-      console.log(JSON.stringify(myJson));
+      console.log("Received: " + JSON.stringify(myJson));
+      return completeTaskFunc(sid);
     })
     .catch(function(response) {
-      alert("Failed!: " + response);
+      console.log("Caught something");
+      throw new SubmissionError({
+        _error: 'Unable to save data to server'
+      });
     });
-    this.props.onCompleteTask(this.props.task.sid);
   }
+
+
 
   render() {
     if (!this.props.task) {
@@ -36,7 +70,10 @@ class HrmFormContainer extends React.Component {
     }
     return (
       <div>
-        <HrmForm onSubmit={this.submit} form={ this.props.task.taskSid } />
+        <HrmForm 
+          onSubmit={this.submit}
+          form={ this.props.task.taskSid }
+        />
         { this.props.task.attributes && this.props.task.attributes.country &&
           <p>Country: { this.props.task.attributes.country }</p>
         }

--- a/plugin-hrm-form/src/components/HrmForm/HrmForm.jsx
+++ b/plugin-hrm-form/src/components/HrmForm/HrmForm.jsx
@@ -18,12 +18,9 @@ const renderSelect = ({
           return (<option value={val}>{val}</option>)
         })}
       </select>
-      {touched && error && <span>{error}</span>}
     </div>
   </div>
 )
-
-const nonEmpty = value => (value ? undefined : 'Required')
 
 let HrmForm = props => {
   const { handleSubmit } = props;
@@ -35,14 +32,12 @@ let HrmForm = props => {
             name="ageBracket"
             component={renderSelect}
             label="AgeBracket"
-            validate={nonEmpty}
             options={["0-3", "4-6", "7-9", "10-12", "13-15", "16-17", "18-25"]}
           />
           <Field
             name="subcategory"
             component={renderSelect}
             label="Subcategory"
-            validate={nonEmpty}
             options={[
               "Emotional abuse",
               "Gang violence",
@@ -55,7 +50,7 @@ let HrmForm = props => {
             ]}
           />
         </div>
-        <button type="submit" disabled={!props.valid}>COMPLETE</button>
+        <button type="submit">COMPLETE</button>
       </form>
     </HrmFormComponentStyles>
   );


### PR DESCRIPTION
Soon after deploying https://github.com/tech-matters/flex-plugins/pull/9 I realized that there were some bugs in validation that were too awful to ignore.  There were two main issues:
* If a counselor accepts two or more simultaneous tasks, all after the first would show the "Complete" button in a valid state and it would be clickable, even though data was not entered.
* The "Required" message that popped up after a field was touched had erratic behavior, often not showing up when it should, or taking multiple clicks.

The root cause is that `redux-form` assumes that there's only one form.  We've hacked `redux-form` to toggle between different keys in the redux store by passing the task as the "form" prop:

```
 <HrmForm onSubmit={this.submit} form={ this.props.task.taskSid }  />
```

This works fine for toggling back and forth.  However, as soon as we start trying to do things that require a certain workflow, such as validation, things go awry.  `redux-form` registers fields when the form is first created, and will check whether there are errors and whether the form is valid.  But then when switching to a different task, the `form` prop gets updated but `redux-form` does not think it needs to re-register fields, since it has the same fields.  This means that validation is not run for the new form, and `valid` does not get set to false.  And given that there are items missing in the new task's form because it did not go through the initialization process, there continues to be weird behavior.

Achieving the behavior we'd really like -- such as a disabled button when the form is not valid, and field-level error communication -- seems to require diving further into how `redux-form` works to find the right settings to make all the different forms operate differently even while in the same component.  That may be a slog.  For now, we'll back off to less-exciting functionality that still gets the job done.

This PR backs off to the following:
* Using only Submit Validation; validating only when a submit is attempted.  This means the submit button is never shown as disabled, but we still prevent invalid forms from being submitted.
* Only communicating invalid fields via an alert box on submit.  This removes the janky field-level validation behavior, but it's not nearly as nice.
