### PR TITLE
Add task info to HRM; recent contacts filters by queue

### DIFF
--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-hrm-form",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -37,7 +37,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     });
 
     flex.Actions.addListener("beforeCompleteTask", (payload, abortFunction) => {
-      manager.store.dispatch(Actions.saveContactState(payload.task.taskSid, abortFunction));
+      manager.store.dispatch(Actions.saveContactState(payload.task, abortFunction));
     });
 
     flex.Actions.addListener("afterCompleteTask", (payload) => {

--- a/plugin-hrm-form/src/components/HrmFormController.js
+++ b/plugin-hrm-form/src/components/HrmFormController.js
@@ -8,7 +8,7 @@ import { Actions } from '../states/ContactState';
 import { validateFormBeforeSubmit } from '../states/ValidationRules';
 
 // should this be a static method on the class or separate.  Or should it even be here at all?
-export function saveToHrm(form, abortFunction) {
+export function saveToHrm(task, form, abortFunction) {
   if (!validateFormBeforeSubmit(form)) {
     // we get "twilio-flex.min.js:274 Uncaught (in promise) Error: Action cancelled by before event"
     // is that okay?
@@ -16,6 +16,23 @@ export function saveToHrm(form, abortFunction) {
       abortFunction();
     }
     return false;
+  }
+
+  // TODO(nick): we should really clone this before modifying it.  If the send fails and there's more editing
+  // then we'll have a problem
+
+  // Remove the internal state stuff
+  form.internal = undefined;
+
+  // Add task info
+  form.channel = task.channelType;
+  form.queueName = task.queueName;
+  if (task.channelType === 'facebook') {
+    form.number = task.defaultFrom.replace('messenger:', '');
+  } else if (task.channelType === 'whatsapp') {
+    form.number = task.defaultFrom.replace('whatsapp:', '');
+  } else {
+    form.number = task.defaultFrom;
   }
   
   const url = 'https://hrm.tl.barbarianrobot.com';

--- a/plugin-hrm-form/src/states/ContactState.js
+++ b/plugin-hrm-form/src/states/ContactState.js
@@ -139,7 +139,7 @@ export class Actions {
   static handleCallTypeButtonClick = (taskId, value, e) => ({type: HANDLE_CHANGE, name: 'callType', taskId: taskId, value: value, parents: []});
   static initializeContactState = (taskId) => ({type: INITIALIZE_CONTACT_STATE, taskId: taskId});
   // I'm really not sure if this should live here, but it seems like we need to come through the store
-  static saveContactState = (taskId, abortFunction) => ({type: SAVE_CONTACT_STATE, taskId: taskId, abortFunction: abortFunction});
+  static saveContactState = (task, abortFunction) => ({type: SAVE_CONTACT_STATE, task: task, abortFunction: abortFunction});
   static removeContactState = (taskId) => ({type: REMOVE_CONTACT_STATE, taskId: taskId});
 }
 
@@ -200,7 +200,7 @@ export function reduce(state = initialState, action) {
 
     case SAVE_CONTACT_STATE: {
       // TODO(nick): Make this a Promise instead?
-      saveToHrm(state.tasks[action.taskId], action.abortFunction);
+      saveToHrm(action.task, state.tasks[action.task.taskSid], action.abortFunction);
       return state;
     }
 

--- a/plugin-show-recent-contacts/package-lock.json
+++ b/plugin-show-recent-contacts/package-lock.json
@@ -12513,38 +12513,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
-    "react-json-to-table": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/react-json-to-table/-/react-json-to-table-0.1.5.tgz",
-      "integrity": "sha512-86QVW8HcMMC8S7z5q5rN3BBMap6U8XYugSzJaRGzT7eXxa62v5CQZe+EX9JMaghQsl47fvfJRTjfXYTRmFGehA==",
-      "requires": {
-        "react": "^16.7.0",
-        "react-dom": "^16.7.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-          "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-          "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.15.0"
-          }
-        }
-      }
-    },
     "react-jss": {
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.6.1.tgz",

--- a/plugin-show-recent-contacts/package.json
+++ b/plugin-show-recent-contacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-show-recent-contacts",
-  "version": "0.0.0",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",
@@ -30,7 +30,6 @@
     "flex-plugin-scripts": "^3.8.0-beta.0",
     "react": "16.5.2",
     "react-dom": "16.5.2",
-    "react-json-to-table": "^0.1.5",
     "react-scripts": "^3.0.0",
     "react-test-renderer": "^16.8.6"
   },

--- a/plugin-show-recent-contacts/src/ShowRecentContactsPlugin.js
+++ b/plugin-show-recent-contacts/src/ShowRecentContactsPlugin.js
@@ -19,13 +19,16 @@ export default class ShowRecentContactsPlugin extends FlexPlugin {
    * @param manager { import('@twilio/flex-ui').Manager }
    */
   init(flex, manager) {
+    const helpline = manager.store.getState().flex.worker.attributes.helpline;
+    console.log("Helpline = " + helpline);
+
     flex.SideNav.Content.add(
       <RecentContactsSidebarButton key="recent-contacts-button" />
     );
 
     flex.ViewCollection.Content.add(
       <View name="recent-contacts" key="recent-contacts">
-        <RecentContactsView />
+        <RecentContactsView helpline={helpline} />
       </View>
     );
   }

--- a/plugin-show-recent-contacts/src/components/RecentContacts.Styles.js
+++ b/plugin-show-recent-contacts/src/components/RecentContacts.Styles.js
@@ -9,39 +9,41 @@ import { default as styled } from 'react-emotion';
 export const RecentContactsComponentStyles = styled('div')`
   overflow: auto;
 
-  .json-to-table {
-      td,
-      th {
-        padding: 5px;
-        border: 1px solid rgb(190, 190, 190);
-      }
+  h1 {
+    font-size: 20px;
+  }
 
-      td {
-        text-align: left;
-      }
+  td,
+  th {
+    padding: 5px;
+    border: 1px solid rgb(190, 190, 190);
+  }
 
-      tr:nth-child(even) {
-        background-color: #eee;
-      }
+  td {
+    text-align: left;
+  }
 
-      th[scope="col"] {
-        background-color: #696969;
-        color: #fff;
-      }
+  tr:nth-child(even) {
+    background-color: #eee;
+  }
 
-      th[scope="row"] {
-        background-color: #d7d9f2;
-      }
+  th[scope="col"] {
+    background-color: #696969;
+    color: #fff;
+  }
 
-      caption {
-        caption-side: bottom;
-      }
+  th[scope="row"] {
+    background-color: #d7d9f2;
+  }
 
-      table {
-        width: 100%;
-        border-collapse: collapse;
-        font-family: sans-serif;
-        font-size: 0.8rem;
-      }
+  caption {
+    caption-side: bottom;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: sans-serif;
+    font-size: 0.8rem;
   }
 `;

--- a/plugin-show-recent-contacts/src/components/RecentContactsView.js
+++ b/plugin-show-recent-contacts/src/components/RecentContactsView.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { JsonToTable } from 'react-json-to-table';
 import { RecentContactsComponentStyles } from './RecentContacts.Styles';
 
 export default class RecentContactsView extends React.Component {
@@ -13,8 +12,12 @@ export default class RecentContactsView extends React.Component {
   componentWillMount() {
     const self = this;
     const url = 'https://hrm.tl.barbarianrobot.com';
-    // const url = 'http://localhost:8080';
-    fetch(url + '/contacts/', {
+    // var url = 'http://localhost:8080';
+    url += '/contacts';
+    if (this.props.helpline) {
+      url += "?queueName=" + encodeURIComponent(this.props.helpline);
+    }
+    fetch(url, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' }
     })
@@ -31,15 +34,84 @@ export default class RecentContactsView extends React.Component {
     });
   }
 
+  formatDate(val) {
+    if (!val) return "n/a";
+    var d = new Date(val);
+    return d.toLocaleString();
+  }
 
+  valueOrNone(val) {
+    return val ? val : "n/a";
+  }
+
+  nameFor(val) {
+    if (!val) return "n/a";
+    const str = [val.firstName, val.lastName].filter(e => e).join(' ');
+    return str ? str : "n/a";
+  }
+
+  listCategories(form) {
+    if (!form || !form.caseInformation || !form.caseInformation.categories) return "n/a";
+    const categories = form.caseInformation.categories;
+    const categoryArray = Object.keys(categories).reduce((acc, key) => {
+      return acc.concat(Object.keys(categories[key]).filter(e => categories[key][e]).map(e => this.capitize(key) + ': ' + this.capitize(e)))
+    }, []);
+    console.log(categoryArray);
+    return (
+      <>
+        { categoryArray.map(e => {
+            return (
+              <>
+                {e}<br />
+              </>
+            );
+          })
+        }
+      </>
+    );
+  }
+
+  // yes, it's a stupid name.  Turns 'category1' into 'Category 1' and 'sub3' into 'Sub 3'
+  capitize(str) {
+    var spaced = str.replace(/(\d+)/, " $1" );
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+  }
 
   render() {
-    const myJson = {
-      "Recent Contacts": this.state.myJson
-    };
+    const myJson = this.state.myJson;
+    if (!Array.isArray(myJson)) return '';
     return (
       <RecentContactsComponentStyles>
-          <JsonToTable json={myJson} />
+          <h1>Latest contacts for {this.props.helpline ? this.props.helpline : "all helplines"}</h1>
+
+          <table>
+            <tbody>
+              <tr>
+                <th>Time</th>
+                <th>Contact Id</th>
+                <th>Channel</th>
+                <th>Number</th>
+                <th>Call type</th>
+                <th>Caller name</th>
+                <th>Child name</th>
+                <th>Categories</th>
+              </tr>
+              {myJson.map((element) => {
+                return (
+                  <tr>
+                    <td>{this.formatDate(element.Date)}</td>
+                    <td>{this.valueOrNone(element.id)}</td>
+                    <td>{this.valueOrNone(element.FormData && element.FormData.channel)}</td>
+                    <td>{this.valueOrNone(element.FormData && element.FormData.number)}</td>
+                    <td>{this.valueOrNone(element.FormData && element.FormData.callType)}</td>
+                    <td>{this.nameFor(element.FormData && element.FormData.callerInformation && element.FormData.callerInformation.name)}</td>
+                    <td>{this.nameFor(element.FormData && element.FormData.childInformation && element.FormData.callerInformation.name)}</td>
+                    <td>{this.listCategories(element.FormData)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
       </RecentContactsComponentStyles>
     );
   }


### PR DESCRIPTION
Includes task info such as phone number and queue name in the form data recorded in the HRM, primarily to be able to return it to the recent contacts view.  Some debt-inducing shortcuts like not cloning the form data object before modifying it.