### PR TITLE
Use Flex environment configuration for HRM URL

### DIFF
--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-hrm-form",
-  "version": "0.0.3",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -30,17 +30,28 @@ export default class HrmFormPlugin extends FlexPlugin {
       flex.Actions.invokeAction("CompleteTask", { sid, task } );
     }
 
+    const hrmBaseUrl = manager.serviceConfiguration.attributes.hrm_base_url;
+    // TODO(nick): Eventually remove this log line or set to debug
+    console.log("HRM URL: " + hrmBaseUrl);
+    if (hrmBaseUrl === undefined) {
+      console.error("HRM base URL not defined, you must provide this to save program data");
+    }
+
+    // TODO(nick): Can we avoid passing down the task prop, maybe using context?
     const options = { sortOrder: -1 };
     flex.CRMContainer
       .Content
-      .replace(<CustomCRMContainer key="custom-crm-container" handleCompleteTask={onCompleteTask} />, options);
+      .replace(<CustomCRMContainer
+                  key="custom-crm-container"
+                  handleCompleteTask={onCompleteTask}
+               />, options);
 
     flex.Actions.addListener("beforeAcceptTask", (payload) => {
       manager.store.dispatch(Actions.initializeContactState(payload.task.taskSid));
     });
 
     flex.Actions.addListener("beforeCompleteTask", (payload, abortFunction) => {
-      manager.store.dispatch(Actions.saveContactState(payload.task, abortFunction));
+      manager.store.dispatch(Actions.saveContactState(payload.task, abortFunction, hrmBaseUrl));
     });
 
     flex.Actions.addListener("afterCompleteTask", (payload) => {

--- a/plugin-hrm-form/src/components/CustomCRMContainer.js
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.js
@@ -10,7 +10,11 @@ const CustomCRMContainer = (props) => {
     <div>
       <NoTaskView key="no-task"/>
       {Array.from(tasks.values()).map(item => (
-        <HrmFormController thisTask={item} key={'controller-' + item.taskSid} handleCompleteTask={props.handleCompleteTask} />
+        <HrmFormController
+          thisTask={item}
+          key={'controller-' + item.taskSid}
+          handleCompleteTask={props.handleCompleteTask}
+        />
       ))}
     </div>
   );

--- a/plugin-hrm-form/src/components/HrmFormController.js
+++ b/plugin-hrm-form/src/components/HrmFormController.js
@@ -9,7 +9,7 @@ import { validateFormBeforeSubmit } from '../states/ValidationRules';
 import { secret } from '../private/secret.js';
 
 // should this be a static method on the class or separate.  Or should it even be here at all?
-export function saveToHrm(task, form, abortFunction) {
+export function saveToHrm(task, form, abortFunction, hrmBaseUrl) {
   if (!validateFormBeforeSubmit(form)) {
     // we get "twilio-flex.min.js:274 Uncaught (in promise) Error: Action cancelled by before event"
     // is that okay?
@@ -35,15 +35,14 @@ export function saveToHrm(task, form, abortFunction) {
   } else {
     form.number = task.defaultFrom;
   }
-  
-  const url = 'https://hrm.tl.barbarianrobot.com';
-  // const url = 'http://localhost:8080';
+
   let formdata = {
     form: form
   };
+  console.log("Using base url: " + hrmBaseUrl);
   // print the form values to the console
   console.log("Sending: " + JSON.stringify(formdata));
-  fetch(url + '/contacts', {
+  fetch(hrmBaseUrl + '/contacts', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json',
                'Authorization': `Basic ${btoa(secret)}` },

--- a/plugin-hrm-form/src/states/ContactState.js
+++ b/plugin-hrm-form/src/states/ContactState.js
@@ -139,7 +139,7 @@ export class Actions {
   static handleCallTypeButtonClick = (taskId, value, e) => ({type: HANDLE_CHANGE, name: 'callType', taskId: taskId, value: value, parents: []});
   static initializeContactState = (taskId) => ({type: INITIALIZE_CONTACT_STATE, taskId: taskId});
   // I'm really not sure if this should live here, but it seems like we need to come through the store
-  static saveContactState = (task, abortFunction) => ({type: SAVE_CONTACT_STATE, task: task, abortFunction: abortFunction});
+  static saveContactState = (task, abortFunction, hrmBaseUrl) => ({type: SAVE_CONTACT_STATE, task, abortFunction, hrmBaseUrl});
   static removeContactState = (taskId) => ({type: REMOVE_CONTACT_STATE, taskId: taskId});
 }
 
@@ -200,7 +200,7 @@ export function reduce(state = initialState, action) {
 
     case SAVE_CONTACT_STATE: {
       // TODO(nick): Make this a Promise instead?
-      saveToHrm(action.task, state.tasks[action.task.taskSid], action.abortFunction);
+      saveToHrm(action.task, state.tasks[action.task.taskSid], action.abortFunction, action.hrmBaseUrl);
       return state;
     }
 

--- a/plugin-show-recent-contacts/package.json
+++ b/plugin-show-recent-contacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-show-recent-contacts",
-  "version": "0.0.3",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",

--- a/plugin-show-recent-contacts/src/ShowRecentContactsPlugin.js
+++ b/plugin-show-recent-contacts/src/ShowRecentContactsPlugin.js
@@ -22,13 +22,20 @@ export default class ShowRecentContactsPlugin extends FlexPlugin {
     const helpline = manager.store.getState().flex.worker.attributes.helpline;
     console.log("Helpline = " + helpline);
 
+    const hrmBaseUrl = manager.serviceConfiguration.attributes.hrm_base_url;
+    // TODO(nick): Eventually remove this log line or set to debug
+    console.log("HRM URL (recent contacts): " + hrmBaseUrl);
+    if (hrmBaseUrl === undefined) {
+      console.error("HRM base URL not defined, you must provide this to retrieve program data");
+    }
+
     flex.SideNav.Content.add(
       <RecentContactsSidebarButton key="recent-contacts-button" />
     );
 
     flex.ViewCollection.Content.add(
       <View name="recent-contacts" key="recent-contacts">
-        <RecentContactsView helpline={helpline} />
+        <RecentContactsView helpline={helpline} hrmBaseUrl={hrmBaseUrl} />
       </View>
     );
   }

--- a/plugin-show-recent-contacts/src/components/RecentContactsView.js
+++ b/plugin-show-recent-contacts/src/components/RecentContactsView.js
@@ -17,8 +17,7 @@ export default class RecentContactsView extends React.Component {
     if (this.state.lastLoad && Date.now() - this.state.lastLoad < 5000) return;
 
     const self = this;
-    var url = 'https://hrm.tl.barbarianrobot.com';
-    // var url = 'http://localhost:8080';
+    var url = this.props.hrmBaseUrl;
     url += '/contacts';
     if (this.props.helpline) {
       url += "?queueName=" + encodeURIComponent(this.props.helpline);


### PR DESCRIPTION
This removes the hard-coded URL for the HRM and relies on Flex environment configuration.  See [this Twilio doc](https://www.twilio.com/docs/flex/creating-styling-custom-components#external-styles) for the inspiration for this.  Configuration has been set using the Flex Configuration API.  This change is for both the HRM and the Recent Contacts plugins.

This should not be deployed to production until the configuration is set on production, but it enables staging flex to use the staging HRM.

There are also some minor formatting changes included in this change.