### PR TITLE
Resolve failure to deploy

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-hrm-form",
-  "version": "0.0.1",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1318,9 +1318,9 @@
       "integrity": "sha512-eIRvJUr8gpt8VcCkfN89ZiBtUH96lG9H8ENYxzH/2R5DC3cFUsbHAy5lOWlypzhUyHYsARTWKry1AMyjnLBZzw=="
     },
     "@material-ui/core": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
-      "integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
+      "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0",
@@ -1579,13 +1579,13 @@
       }
     },
     "@twilio/flex-ui": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.14.0.tgz",
-      "integrity": "sha512-RPUw451VHYvjEqTSNTuTDlPw1GJ1d5ZGYjyk7fOmJbkV9y2tNa5ULPNYwi4lIMjF2K56oA6yjkFLmxxO8mmfCA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.14.1.tgz",
+      "integrity": "sha512-iwsBxSwGQrm7MoH2k13o3c2t5DMKQ1ma+zJO+tEZa2c/vGfk423pOTW8Jk10DNVxXxb4doEPD7CTG9ifXr3+eg==",
       "dev": true,
       "requires": {
         "@material-ui/core": "^3.9.3",
-        "@twilio/frame-ui": "^0.35.1",
+        "@twilio/frame-ui": "^0.35.2",
         "@twilio/wfo-identity-client-flex": "^0.9.1",
         "@types/lodash.merge": "^4.6.6",
         "async-sema": "^3.0.0",
@@ -1616,12 +1616,12 @@
         "twilio-chat": "~3.2",
         "twilio-client": "~1.9",
         "twilio-sync": "^0.11.0",
-        "twilio-taskrouter": "~0.4",
+        "twilio-taskrouter": "^0.4.1",
         "uuid": "^3.3.2"
       },
       "dependencies": {
         "@twilio/frame-ui": {
-          "version": "0.35.1",
+          "version": "0.35.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1648,9 +1648,9 @@
           }
         },
         "query-string": {
-          "version": "6.8.3",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.3.tgz",
-          "integrity": "sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==",
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.9.0.tgz",
+          "integrity": "sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==",
           "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -1782,9 +1782,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.144",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
-      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==",
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
       "dev": true
     },
     "@types/lodash.merge": {
@@ -1827,9 +1827,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
-      "version": "16.9.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.11.tgz",
-      "integrity": "sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==",
+      "version": "16.9.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
+      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -2530,9 +2530,9 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-sema": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.0.1.tgz",
-      "integrity": "sha512-fKT2riE8EHAvJEfLJXZiATQWqZttjx1+tfgnVshCDrH8vlw4YC8aECe0B8MU184g+aVRFVgmfxFlKZKaozSrNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.0.tgz",
+      "integrity": "sha512-+JpRq3r0zjpRLDruS6q/nC4V5tzsaiu07521677Mdi5i+AkaU/aNJH38rYHJVQ4zvz+SSkjgc8FUI7qIZrR+3g==",
       "dev": true
     },
     "asynckit": {
@@ -4421,9 +4421,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
       "dev": true
     },
     "cyclist": {
@@ -7401,9 +7401,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
       "dev": true,
       "requires": {
         "react-is": "^16.7.0"
@@ -12410,9 +12410,9 @@
       }
     },
     "react-flip-move": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.3.tgz",
-      "integrity": "sha512-gR2jvjUgIXI7ceFWJkr8owX4vKhV0IJoXIf/Dt7gESFe5OKiSz2H6d10mKTW8fN134NDI16J4HgEgq9pKqJd5A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz",
+      "integrity": "sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==",
       "dev": true
     },
     "react-is": {
@@ -12490,9 +12490,9 @@
           "dev": true
         },
         "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "dev": true,
           "requires": {
             "isarray": "0.0.1"
@@ -13415,9 +13415,9 @@
       }
     },
     "sdp": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.10.0.tgz",
-      "integrity": "sha512-H+VjfyQpRz9GezhshJmkXTtCAT9/2g9az3GFDPYfGOz0eAOQU1fCrL3S9Dq/eUT9FtOyLi/czdR9PzK3fKUYOQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw==",
       "dev": true
     },
     "select-hose": {
@@ -14726,9 +14726,9 @@
       }
     },
     "twilio-client": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/twilio-client/-/twilio-client-1.9.3.tgz",
-      "integrity": "sha512-ZbmQQig+W4u7ptPhAqJKe5LqIL7rQRx9025xD9On4KTn94sC7YHlb1xVObFA/PMD18ZdW6QSyBUmyvSZlrX4ag==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/twilio-client/-/twilio-client-1.9.7.tgz",
+      "integrity": "sha512-od55ewdYRBk7JIxaMQ3Df1So7vSTIGrOmilL047Fb/axSQHG2hENjgvEfY0QYk72tK5s7avoDgG8DshfnHCzjw==",
       "dev": true,
       "requires": {
         "@twilio/audioplayer": "1.0.6",
@@ -14797,9 +14797,9 @@
       }
     },
     "twilio-sync": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.11.4.tgz",
-      "integrity": "sha512-1Vyvrs5YsSQT+1vrqRWFIenVSCj3p7JwfeGqW60V04eFgrQPrs7huBKPGCZE1RkZ8P2PKOIiYBGnuLa+o81E7Q==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.11.5.tgz",
+      "integrity": "sha512-Gsr2Xms4HdnTzOnqayalMiIRD7A8iWUAk2UG83l0KFttH0sEXkU79QClm7j2qla1MD6s4niqrRAekVMYqeo/7Q==",
       "dev": true,
       "requires": {
         "loglevel": "^1.6.3",
@@ -14879,9 +14879,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
       "dev": true
     },
     "uglify-js": {

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-hrm-form",
-  "version": "0.0.1",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-hrm-form",
-  "version": "0.2.1",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
     "bootstrap": "flex-plugin check-start",

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -25,7 +25,7 @@
     "react-scripts": "3.2.0"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "^1",
+    "@twilio/flex-ui": "1.14.1",
     "babel-polyfill": "^6.26.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0"

--- a/plugin-show-recent-contacts/package-lock.json
+++ b/plugin-show-recent-contacts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-show-recent-contacts",
-  "version": "0.0.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1292,9 +1292,9 @@
       "integrity": "sha512-eIRvJUr8gpt8VcCkfN89ZiBtUH96lG9H8ENYxzH/2R5DC3cFUsbHAy5lOWlypzhUyHYsARTWKry1AMyjnLBZzw=="
     },
     "@material-ui/core": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
-      "integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
+      "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0",
@@ -1544,23 +1544,24 @@
       }
     },
     "@twilio/audioplayer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@twilio/audioplayer/-/audioplayer-1.0.4.tgz",
-      "integrity": "sha512-efSieo3FzTJWbhhdYI59/7WmU4jdqgLeYOvtBRvE3Rbq5yWz0lYswLEM6fOaubnAeTt1c5JYF3J9W5VzemjOwg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@twilio/audioplayer/-/audioplayer-1.0.6.tgz",
+      "integrity": "sha512-c9cjX/ifICgXqShtyAQdVMqfe7odnxougiuRMXBJtn3dZ320mFdt7kmuKedpNnc3ZJ6irOZ9M9MZi9/vuEqHiw==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0"
       }
     },
     "@twilio/flex-ui": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.13.0.tgz",
-      "integrity": "sha512-swzWnhYWNqeSA0pBSOGJs1/AN4A8XgNgY2oQcn3dyIHEd9yrCaNt1fvaU2QI0NdG6K30AIiuhJW+z8xrtwfAtw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.14.1.tgz",
+      "integrity": "sha512-iwsBxSwGQrm7MoH2k13o3c2t5DMKQ1ma+zJO+tEZa2c/vGfk423pOTW8Jk10DNVxXxb4doEPD7CTG9ifXr3+eg==",
       "dev": true,
       "requires": {
         "@material-ui/core": "^3.9.3",
-        "@twilio/frame-ui": "^0.34.0",
+        "@twilio/frame-ui": "^0.35.2",
         "@twilio/wfo-identity-client-flex": "^0.9.1",
+        "@types/lodash.merge": "^4.6.6",
         "async-sema": "^3.0.0",
         "axios": "^0.19.0",
         "emotion": "9.2.6",
@@ -1569,6 +1570,7 @@
         "history": "^4.7.2",
         "hoist-non-react-statics": "^3.3.0",
         "lodash.debounce": "^4.0.8",
+        "lodash.merge": "^4.6.2",
         "loglevel": "^1.6.1",
         "query-string": "^6.1.0",
         "react": "^16.5.2",
@@ -1586,21 +1588,20 @@
         "reselect": "^4.0.0",
         "semver": "^5.5.0",
         "twilio-chat": "~3.2",
-        "twilio-client": "~1.7",
+        "twilio-client": "~1.9",
         "twilio-sync": "^0.11.0",
-        "twilio-taskrouter": "~0.4",
+        "twilio-taskrouter": "^0.4.1",
         "uuid": "^3.3.2"
       },
       "dependencies": {
         "@twilio/frame-ui": {
-          "version": "0.34.0",
+          "version": "0.35.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@material-ui/core": "^3.9.3",
             "@material-ui/icons": "^2.0.0",
             "@types/loglevel": "^1.5.3",
-            "@types/node": "^7.0.52",
             "emotion": "9.2.6",
             "emotion-theming": "9.2.6",
             "handlebars": "^4.0.12",
@@ -1620,12 +1621,6 @@
             "uuid": "^3.3.2"
           }
         },
-        "@types/node": {
-          "version": "7.10.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.7.tgz",
-          "integrity": "sha512-4I7+hXKyq7e1deuzX9udu0hPIYqSSkdKXtjow6fMnQ3OR9qkxIErGHbGY08YrfZJrCS1ajK8lOuzd0k3n2WM4A==",
-          "dev": true
-        },
         "eventemitter3": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
@@ -1633,6 +1628,12 @@
           "dev": true
         }
       }
+    },
+    "@twilio/voice-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@twilio/voice-errors/-/voice-errors-1.0.1.tgz",
+      "integrity": "sha512-iXzCuiOhNMhrr8DVjRRzI14YwGUIBM83kWSWcDktxmXim0Tz9xoCth4QFAQcMkNL2h9DlfXlob6noH+3h2iA4A==",
+      "dev": true
     },
     "@twilio/wfo-identity-client-flex": {
       "version": "0.9.1",
@@ -1734,6 +1735,21 @@
         "indefinite-observable": "^1.0.1"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
+    "@types/lodash.merge": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
+      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/loglevel": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@types/loglevel/-/loglevel-1.6.3.tgz",
@@ -1754,9 +1770,9 @@
       "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
     "@types/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA==",
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
       "dev": true
     },
     "@types/q": {
@@ -1765,9 +1781,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
-      "version": "16.9.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.2.tgz",
-      "integrity": "sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==",
+      "version": "16.9.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
+      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -2408,9 +2424,9 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "async-sema": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.0.1.tgz",
-      "integrity": "sha512-fKT2riE8EHAvJEfLJXZiATQWqZttjx1+tfgnVshCDrH8vlw4YC8aECe0B8MU184g+aVRFVgmfxFlKZKaozSrNw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.0.tgz",
+      "integrity": "sha512-+JpRq3r0zjpRLDruS6q/nC4V5tzsaiu07521677Mdi5i+AkaU/aNJH38rYHJVQ4zvz+SSkjgc8FUI7qIZrR+3g==",
       "dev": true
     },
     "asynckit": {
@@ -4753,9 +4769,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
-      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
+      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
       "dev": true
     },
     "cyclist": {
@@ -7144,9 +7160,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
       "dev": true,
       "requires": {
         "react-is": "^16.7.0"
@@ -9686,6 +9702,12 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
@@ -11111,9 +11133,9 @@
       }
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==",
       "dev": true
     },
     "portfinder": {
@@ -12198,9 +12220,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.3.tgz",
-      "integrity": "sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.9.0.tgz",
+      "integrity": "sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==",
       "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -12503,9 +12525,9 @@
       }
     },
     "react-flip-move": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.3.tgz",
-      "integrity": "sha512-gR2jvjUgIXI7ceFWJkr8owX4vKhV0IJoXIf/Dt7gESFe5OKiSz2H6d10mKTW8fN134NDI16J4HgEgq9pKqJd5A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz",
+      "integrity": "sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==",
       "dev": true
     },
     "react-is": {
@@ -12541,13 +12563,13 @@
       "dev": true
     },
     "react-redux": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
+      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.1.0",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4",
         "loose-envify": "^1.1.0",
         "prop-types": "^15.6.1",
@@ -12583,9 +12605,9 @@
           "dev": true
         },
         "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "dev": true,
           "requires": {
             "isarray": "0.0.1"
@@ -12687,14 +12709,14 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
-      "integrity": "sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==",
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.5.2.tgz",
+      "integrity": "sha512-AGbJYbCVx1J6jdUgI4s0hNp+9LxlgzKvXl0ROA3DHTrtjAr00Po1RhDZ/eAq2VC/ww8AHgpDXULh5V2rhEqqJg==",
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.9.0",
-        "scheduler": "^0.15.0"
+        "react-is": "^16.5.2",
+        "schedule": "^0.5.0"
       }
     },
     "react-transition-group": {
@@ -13442,15 +13464,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "scheduler": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-      "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "schema-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -13462,9 +13475,9 @@
       }
     },
     "sdp": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.10.0.tgz",
-      "integrity": "sha512-H+VjfyQpRz9GezhshJmkXTtCAT9/2g9az3GFDPYfGOz0eAOQU1fCrL3S9Dq/eUT9FtOyLi/czdR9PzK3fKUYOQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw==",
       "dev": true
     },
     "select-hose": {
@@ -14805,12 +14818,13 @@
       }
     },
     "twilio-client": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/twilio-client/-/twilio-client-1.7.6.tgz",
-      "integrity": "sha512-2b0mFsPeFm5ndq2PnKVjJUlRnr8B+kUGAwx2AznPKkK8RI/LlidY7uhI6HnnTf6jNXu68KbSeTgNOo+Dil/osQ==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/twilio-client/-/twilio-client-1.9.7.tgz",
+      "integrity": "sha512-od55ewdYRBk7JIxaMQ3Df1So7vSTIGrOmilL047Fb/axSQHG2hENjgvEfY0QYk72tK5s7avoDgG8DshfnHCzjw==",
       "dev": true,
       "requires": {
-        "@twilio/audioplayer": "1.0.4",
+        "@twilio/audioplayer": "1.0.6",
+        "@twilio/voice-errors": "1.0.1",
         "backoff": "2.5.0",
         "rtcpeerconnection-shim": "1.2.8",
         "ws": "6.1.3",
@@ -14884,9 +14898,9 @@
       }
     },
     "twilio-sync": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.11.4.tgz",
-      "integrity": "sha512-1Vyvrs5YsSQT+1vrqRWFIenVSCj3p7JwfeGqW60V04eFgrQPrs7huBKPGCZE1RkZ8P2PKOIiYBGnuLa+o81E7Q==",
+      "version": "0.11.5",
+      "resolved": "https://registry.npmjs.org/twilio-sync/-/twilio-sync-0.11.5.tgz",
+      "integrity": "sha512-Gsr2Xms4HdnTzOnqayalMiIRD7A8iWUAk2UG83l0KFttH0sEXkU79QClm7j2qla1MD6s4niqrRAekVMYqeo/7Q==",
       "dev": true,
       "requires": {
         "loglevel": "^1.6.3",
@@ -14898,9 +14912,9 @@
       }
     },
     "twilio-taskrouter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.0.tgz",
-      "integrity": "sha512-Oc6I8nzoDRDdXQ8HQAUu2F6ol8ToZr+lDbSBNo8mz2Ufc8oyY+oIGX64DKNsNueKun9fFTu0i+5fQRzoYmgs2g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.1.tgz",
+      "integrity": "sha512-+gIn5/BsUs088dBb5qvNqgAqh0sGgnzEMdjkURhInmRLyY18GFIgqQpUwthbq4RCEXP2tFduX+g/eH1/fG339w==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5",
@@ -14966,9 +14980,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
       "dev": true
     },
     "uglify-js": {

--- a/plugin-show-recent-contacts/package.json
+++ b/plugin-show-recent-contacts/package.json
@@ -17,7 +17,7 @@
     "eject": "flex-plugin eject"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "^1"
+    "@twilio/flex-ui": "1.14.1"
   },
   "dependencies": {
     "@craco/craco": "^5.0.2",
@@ -31,7 +31,7 @@
     "react": "16.5.2",
     "react-dom": "16.5.2",
     "react-scripts": "^3.0.0",
-    "react-test-renderer": "^16.8.6"
+    "react-test-renderer": "16.5.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
See (TM internal) [JIRA issue](https://bugs.benetech.org/browse/CHI-25).  Plugin deployments were failing on "Error: Optional dependency keytar was not installed." for inexplicable reasons.  Fixed with

```
rm -rf node_modules/
npm install
```

in both plugins and it now works.  Made a small number of `package.json` changes, most important of which is to lock `@twilio/flex-ui` to `1.14.1`.  We will upgrade this explicitly as we upgrade hosted Flex versions... namely, upgrading `package.json` first in order to test before rolling to staging and prod.

This PR contains the `package.json` changes and the `package-lock.json` changes that were allowed to happen.