### PR TITLE
Send a message to the caller when the counselor has ended the chat

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -25,9 +25,13 @@ export default class HrmFormPlugin extends FlexPlugin {
     console.log(`Welcome to ${PLUGIN_NAME} Version ${PLUGIN_VERSION}`);
     this.registerReducers(manager);
 
-    const onCompleteTask = (sid, task) => {
-      if (task.channelType === 'voice' && task.status !== 'wrapping') {
-        flex.Actions.invokeAction('HangupCall', { sid, task });
+    const onCompleteTask = async (sid, task) => {
+      if (task.status !== 'wrapping') {
+        if (task.channelType === 'voice') {
+          await flex.Actions.invokeAction('HangupCall', { sid, task });
+        } else {
+          await flex.Actions.invokeAction('WrapupTask', { sid, task });
+        }
       }
       flex.Actions.invokeAction('CompleteTask', { sid, task });
     };
@@ -56,24 +60,21 @@ export default class HrmFormPlugin extends FlexPlugin {
       manager.store.dispatch(Actions.initializeContactState(payload.task.taskSid));
     });
 
-    const exitMsg = 'All done here. Thanks!';
-    flex.Actions.replaceAction('WrapupTask', (payload, original) => {
-      // do not alter non-chat tasks
-      if(payload.task.taskChannelUniqueName !== 'chat') {
+    const exitMsg =
+      'Thank you for contacting the helpline. The counselor has left the chat but ' +
+      "don't hesitate to reach out again if you need help.";
+    const sendGoodbyeMessage = async (payload, original) => {
+      if (payload.task.taskChannelUniqueName === 'chat') {
+        await flex.Actions.invokeAction('SendMessage', {
+          body: exitMsg,
+          channelSid: payload.task.attributes.channelSid,
+        });
         original(payload);
       } else {
-        return new Promise(resolve => {
-          // send the message
-          flex.Actions.invokeAction('SendMessage', {
-            body: exitMsg,
-            channelSid: payload.task.attributes.channelSid,
-          }).then(response => {
-            // only after the message is sent, move task to wrap up
-            resolve(original(payload));
-          });
-        });
+        original(payload);
       }
-    });
+    };
+    flex.Actions.replaceAction('WrapupTask', sendGoodbyeMessage);
 
     flex.Actions.addListener('beforeCompleteTask', (payload, abortFunction) => {
       manager.store.dispatch(Actions.saveContactState(payload.task, abortFunction, hrmBaseUrl));

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -56,6 +56,23 @@ export default class HrmFormPlugin extends FlexPlugin {
       manager.store.dispatch(Actions.initializeContactState(payload.task.taskSid));
     });
 
+    flex.Actions.addListener('beforeWrapupTask', payload => {
+      const chatClient = manager.chatClient;
+      const channelSid = payload.task.attributes.channelSid;
+      console.log(`Channel SID = ${channelSid}`);
+      // chatClient.getUserChannelDescriptors().then(function(paginator) {
+      //   for (let i=0; i<paginator.items.length; i++) {
+      //     var channel = paginator.items[i];
+      //     if (channel.sid === channelSid) {
+      //       console.log(`Found channel with sid ${channel.sid}`);
+      //       console.log(`Type is ${Object.prototype.toString.call(channel)}`);
+      //       channel.sendMessage('All done here. Thanks!');
+      //     }
+      //   }
+      // });
+      chatClient.getChannelBySid(channelSid).then(channel => channel.sendMessage('All done here. Thanks!'));
+    });
+
     flex.Actions.addListener('beforeCompleteTask', (payload, abortFunction) => {
       manager.store.dispatch(Actions.saveContactState(payload.task, abortFunction, hrmBaseUrl));
     });


### PR DESCRIPTION
The next-highest priority story for us after search/previous contacts is to be able to send a message back to a user of the helpline if the counselor has left the chat.  This applies to SMS, WhatsApp, Facebook Messenger and webchat conversations.

The code here uses the [Twilio Actions Framework](https://www.twilio.com/docs/flex/actions-framework) to send a message whenever a text-based task is set to "wrapping".  (Also see [Lifecycle of a Task](https://www.twilio.com/docs/taskrouter/lifecycle-task-state) to understand what that means.)  There are two changed code blocks:
* There was an existing block that made sure that whenever we completed a task (which can be done directly by hitting the 'Submit' button on the `TabbedForms`) we made sure the call was hung up.  I changed an existing block in a couple ways:
  * First, use `async/await` to ensure that all the work to set the task to wrapping and/or hang up the call necessarily precedes completing the task (it was working fine before but race conditions were possible).
  * Second, require that we wrap up the task before completion.  As far as I can tell, "HangupCall" is only for voice calls and automatically will set to "wrapping", but "WrapupTask" is needed for text conversations
* Added a new block to add a step to the "WrapupTask" work to send one more message to the user.

One current problem with this implementation is that for webchat, the message comes in the counselor's name:
![image](https://user-images.githubusercontent.com/10714292/75406459-5b319880-58c5-11ea-8b18-3c7a65d7a018.png)

This is not good, and probably renders this unlaunchable, but I think it's okay to get this onto staging and fix it before we launch to production.

@murilovmachado please take a look.  Don't spend too much time learning all the context by yourself.  I'm very happy to talk you through it.