### PR TITLE
(WIP) Add workerSid to Contact record in HRM

### DIFF
--- a/plugin-hrm-form/src/components/HrmFormController.js
+++ b/plugin-hrm-form/src/components/HrmFormController.js
@@ -42,7 +42,7 @@ export function transformForm(form) {
 }
 
 // should this be a static method on the class or separate.  Or should it even be here at all?
-export function saveToHrm(task, form, abortFunction, hrmBaseUrl) {
+export function saveToHrm(task, form, abortFunction, hrmBaseUrl, workerSid) {
   // if we got this far, we assume the form is valid and ready to submit
 
   /*
@@ -55,6 +55,7 @@ export function saveToHrm(task, form, abortFunction, hrmBaseUrl) {
   // Add task info
   formToSend.channel = task.channelType;
   formToSend.queueName = task.queueName;
+  formToSend.counselor = workerSid;
   if (task.channelType === 'facebook') {
     formToSend.number = task.defaultFrom.replace('messenger:', '');
   } else if (task.channelType === 'whatsapp') {

--- a/plugin-hrm-form/src/states/ContactState.js
+++ b/plugin-hrm-form/src/states/ContactState.js
@@ -32,11 +32,12 @@ export class Actions {
   static initializeContactState = taskId => ({ type: INITIALIZE_CONTACT_STATE, taskId });
 
   // I'm really not sure if this should live here, but it seems like we need to come through the store
-  static saveContactState = (task, abortFunction, hrmBaseUrl) => ({
+  static saveContactState = (task, abortFunction, hrmBaseUrl, workerSid) => ({
     type: SAVE_CONTACT_STATE,
     task,
     abortFunction,
     hrmBaseUrl,
+    workerSid,
   });
 
   static removeContactState = taskId => ({ type: REMOVE_CONTACT_STATE, taskId });
@@ -150,7 +151,13 @@ export function reduce(state = initialState, action) {
 
     case SAVE_CONTACT_STATE: {
       // TODO(nick): Make this a Promise instead?
-      saveToHrm(action.task, state.tasks[action.task.taskSid], action.abortFunction, action.hrmBaseUrl);
+      saveToHrm(
+        action.task,
+        state.tasks[action.task.taskSid],
+        action.abortFunction,
+        action.hrmBaseUrl,
+        action.workerSid,
+      );
       return state;
     }
 


### PR DESCRIPTION
In order to include the counselor in search, we need to record the counselor in the HRM when we submit a new contact record.  This WIP PR shows a possible way to do that on the Flex side.  I re-organized code in `HrmFormPlugin.js`, but the most relevant lines are 53-65, especially `const workerSid = manager.workerClient.sid;`, grabbing the current worker/counselor's ID to save it.

This raises a few questions:
1. How do we want to connect a worker/counselor with a contact record?  Is the ID the right thing?  Do we want to also store the person's name, even if the name changes later?
2. How would we get the list of names in the select box when we search by counselor?
3. How do we rightly filter search by helpline?

Connecting Twilio-based ID with our own system will continue to require thought.

FYI @murilovmachado 