### PR TITLE
Show recent contacts: Use new GET /contacts API and downgrade Flex to 1.14.1

### DIFF
--- a/plugin-show-recent-contacts/package-lock.json
+++ b/plugin-show-recent-contacts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-show-recent-contacts",
-  "version": "0.2.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1781,9 +1781,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
-      "version": "16.9.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
-      "integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
+      "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -4769,9 +4769,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-      "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+      "integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==",
       "dev": true
     },
     "cyclist": {
@@ -7160,9 +7160,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "dev": true,
       "requires": {
         "react-is": "^16.7.0"
@@ -11133,9 +11133,9 @@
       }
     },
     "popper.js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
       "dev": true
     },
     "portfinder": {
@@ -12220,9 +12220,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.9.0.tgz",
-      "integrity": "sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.1.tgz",
+      "integrity": "sha512-1ZvJOUl8ifkkBxu2ByVM/8GijMIPx+cef7u3yroO3Ogm4DOdZcF5dcrWTIlSHe3Pg/mtlt6/eFjObDfJureZZA==",
       "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -14638,9 +14638,9 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
       "dev": true
     },
     "tiny-warning": {
@@ -14912,9 +14912,9 @@
       }
     },
     "twilio-taskrouter": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.1.tgz",
-      "integrity": "sha512-+gIn5/BsUs088dBb5qvNqgAqh0sGgnzEMdjkURhInmRLyY18GFIgqQpUwthbq4RCEXP2tFduX+g/eH1/fG339w==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.3.tgz",
+      "integrity": "sha512-nUoKYVM6WQjNAhOPRkg9vRzZ7NNNgF//FHO3HIw+59RXWNBwFA7KN2eiE8FYoWW7bPTfpWSKS3GiIGtL0pEjVg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5",

--- a/plugin-show-recent-contacts/package.json
+++ b/plugin-show-recent-contacts/package.json
@@ -17,7 +17,7 @@
     "eject": "flex-plugin eject"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "1.16.1"
+    "@twilio/flex-ui": "1.14.1"
   },
   "dependencies": {
     "@craco/craco": "^5.0.2",

--- a/plugin-show-recent-contacts/src/ShowRecentContactsPlugin.js
+++ b/plugin-show-recent-contacts/src/ShowRecentContactsPlugin.js
@@ -5,7 +5,7 @@ import RecentContactsView from './components/RecentContactsView';
 import RecentContactsSidebarButton from './components/RecentContactsSidebarButton';
 
 const PLUGIN_NAME = 'ShowRecentContactsPlugin';
-const PLUGIN_VERSION = '0.3.0';
+const PLUGIN_VERSION = '0.3.5';
 
 export default class ShowRecentContactsPlugin extends FlexPlugin {
   constructor() {

--- a/plugin-show-recent-contacts/src/components/RecentContactsView.js
+++ b/plugin-show-recent-contacts/src/components/RecentContactsView.js
@@ -122,11 +122,11 @@ export default class RecentContactsView extends React.Component {
                   </tr>
                   <tr>
                     <th>Channel</th>
-                    <td>{this.valueOrNone(contact.FormData.channel)}</td>
+                    <td>{this.valueOrNone(contact.channel || contact.FormData.channel)}</td>
                   </tr>
                   <tr>
                     <th>Number</th>
-                    <td>{this.valueOrNone(contact.FormData.number)}</td>
+                    <td>{this.valueOrNone(contact.number || contact.FormData.number)}</td>
                   </tr>
                   <tr>
                     <th>Call type</th>
@@ -365,8 +365,8 @@ export default class RecentContactsView extends React.Component {
                   <tr>
                     <td>{this.formatDate(element.Date)}</td>
                     <td style={{textDecoration: 'underline', cursor: 'pointer'}} onClick={(e) => this.setState({id: element.id})}>{this.valueOrNone(element.id)}</td>
-                    <td>{this.valueOrNone(element.FormData && element.FormData.channel)}</td>
-                    <td>{this.valueOrNone(element.FormData && element.FormData.number)}</td>
+                    <td>{this.valueOrNone(element.channel || (element.FormData && element.FormData.channel))}</td>
+                    <td>{this.valueOrNone(element.number || (element.FormData && element.FormData.number))}</td>
                     <td>{this.valueOrNone(element.FormData && element.FormData.callType)}</td>
                     <td>{this.nameFor(element.FormData && element.FormData.callerInformation && element.FormData.callerInformation.name)}</td>
                     <td>{this.nameFor(element.FormData && element.FormData.childInformation && element.FormData.childInformation.name)}</td>


### PR DESCRIPTION
Uses new GET API that extracts metadata fields out of the FormData.  Also downgrades Flex to prepare for pre-Version 0.4 roll to production.

Probably best to just wait until staging HRM is deployed and test it against that.