### PR TITLE
Add CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Actions Status](https://github.com/tech-matters/flex-plugins/workflows/Run%20plugin-hrm-form%20CI/badge.svg)](https://github.com/tech-matters/flex-plugins/actions)
 # flex-plugins

--- a/plugin-hrm-form/README.md
+++ b/plugin-hrm-form/README.md
@@ -1,3 +1,4 @@
+[![Actions Status](https://github.com/tech-matters/flex-plugins/workflows/Run%20plugin-hrm-form%20CI/badge.svg)](https://github.com/tech-matters/flex-plugins/actions)
 # Your custom Twilio Flex Plugin
 
 Twilio Flex Plugins allow you to customize the appearance and behavior of [Twilio Flex](https://www.twilio.com/flex). If you want to learn more about the capabilities and how to use the API, check out our [Flex documentation](https://www.twilio.com/docs/flex).


### PR DESCRIPTION
Adds CI Status badge to `flex-plugins` README and to `flex-plugins/plugin-hrm-form` README.

<img width="362" alt="Screen Shot 2020-03-09 at 14 19 33" src="https://user-images.githubusercontent.com/1504544/76240084-62d03600-6211-11ea-8c8e-77ada7e6e7a1.png">
<img width="546" alt="Screen Shot 2020-03-09 at 14 19 44" src="https://user-images.githubusercontent.com/1504544/76240085-6499f980-6211-11ea-87b7-f603ee5b75a3.png">
