### PR TITLE
Fix undefined helpline being sended to serverless endpoint

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -40,7 +40,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     const hrmBaseUrl = manager.serviceConfiguration.attributes.hrm_base_url;
     const serverlessBaseUrl = manager.serviceConfiguration.attributes.serverless_base_url;
     const workerSid = manager.workerClient.sid;
-    const { helpline } = manager.workerClient.attributes || ''; // overrides undefined helpline with ''
+    const { helpline } = manager.workerClient.attributes;
     const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
     const getSsoToken = () => manager.store.getState().flex.session.ssoTokenPayload.token;
 

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -40,7 +40,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     const hrmBaseUrl = manager.serviceConfiguration.attributes.hrm_base_url;
     const serverlessBaseUrl = manager.serviceConfiguration.attributes.serverless_base_url;
     const workerSid = manager.workerClient.sid;
-    const { helpline } = manager.workerClient.attributes;
+    const { helpline } = manager.workerClient.attributes || ''; // overrides undefined helpline with ''
     const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
     const getSsoToken = () => manager.store.getState().flex.session.ssoTokenPayload.token;
 

--- a/plugin-hrm-form/src/services/ServerlessService.js
+++ b/plugin-hrm-form/src/services/ServerlessService.js
@@ -14,7 +14,7 @@ export const populateCounselors = async context => {
   const url = `${serverlessBaseUrl}/populateCounselors`;
   const body = {
     workspaceSID: currentWorkspace,
-    helpline,
+    helpline: helpline || '',
     Token: getSsoToken(),
   };
 


### PR DESCRIPTION
When helpline is undefined, we want it to default to empty string, (in order to work properly with URLSearchParams)