### PR TITLE
Tabs visuals rework

### DIFF
--- a/plugin-hrm-form/src/Styles/HrmStyles.js
+++ b/plugin-hrm-form/src/Styles/HrmStyles.js
@@ -167,17 +167,29 @@ export const BottomButtonBar = styled('div')`
   justify-content: center;
 `;
 
+export const NameFields = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  > div {
+    flex-grow: 1;
+    flex-basis: 0;
+    margin: 0 10px;
+  }
+`;
+
 export const ColumnarBlock = styled('div')`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  flex-basis: 0;
   margin: 0 10px;
 `;
 
 export const TwoColumnLayout = styled('div')`
   display: flex;
   flex-direction: row;
-  justify-content: space-around;
+  justify-content: space-between;
 `;
 
 export const CategoryCheckboxField = styled('div')`
@@ -196,7 +208,7 @@ export const StyledTableCell = styled(TableCell)`
 export const SearchFields = styled('div')`
   display: flex;
   flex-wrap: wrap;
-  div {
+  > div {
     max-width: 160px;
     min-width: 160px;
   }

--- a/plugin-hrm-form/src/Styles/HrmStyles.js
+++ b/plugin-hrm-form/src/Styles/HrmStyles.js
@@ -1,56 +1,25 @@
+import React from 'react';
 import styled, { keyframes } from 'react-emotion';
-import { Input, Select, MenuItem, TableCell } from '@material-ui/core';
+import { Input, Select, MenuItem, TableCell, Tabs, Tab } from '@material-ui/core';
 import { Button, getBackgroundWithHoverCSS } from '@twilio/flex-ui';
 
 export const Container = styled('div')`
   display: flex;
-  padding: 32px 32px 12px;
+  padding: 32px 20px 12px 20px;
   flex-direction: column;
   flex-wrap: wrap;
+  background-color: #ffffff;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  margin: 0 20px;
 `;
 
-/*
- * export const TabContainer = styled('div')`
- *   margin-top: 24px;
- * `;
- */
-
-/*
- * export const ButtonContainer = styled('div')`
- *   display: flex;
- *   margin-top: 24px;
- * `;
- */
-
-/*
- * export const Header1 = styled('h1')`
- *   font-size: 24px;
- *   font-weight: bold;
- *   margin: 8px 0;
- * `;
- * export const Header2 = styled('h2')`
- *   font-size: 20px;
- *   font-weight: bold;
- *   margin: 8px 0;
- * `;
- * export const Header3 = styled('h3')`
- *   font-size: 16px;
- *   font-weight: bold;
- *   margin: 8px 0;
- * `;
- */
 export const ErrorText = styled('p')`
   color: ${props => props.theme.colors.errorColor};
   font-size: 10px;
   line-height: 1.5;
 `;
 
-/*
- * export const Text = styled('p')`
- *   font-size: 14px;
- *   line-height: 1.5;
- * `;
- */
 export const StyledInput = styled(Input)`
   display: flex;
   flex-grow: 0;
@@ -69,7 +38,6 @@ export const TextField = styled('div')`
   display: flex;
   flex-direction: column;
   margin: 8px 0;
-  width: 320px;
 `;
 
 export const StyledLabel = styled('label')`
@@ -178,7 +146,6 @@ export const CheckboxField = styled('div')`
   display: flex;
   flex-direction: row;
   margin: 8px 0;
-  width: 320px;
 `;
 
 export const StyledCheckboxLabel = styled('label')`
@@ -200,15 +167,11 @@ export const BottomButtonBar = styled('div')`
   justify-content: center;
 `;
 
-export const NameFields = styled('div')`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-`;
-
 export const ColumnarBlock = styled('div')`
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
+  margin: 0 10px;
 `;
 
 export const TwoColumnLayout = styled('div')`
@@ -216,15 +179,6 @@ export const TwoColumnLayout = styled('div')`
   flex-direction: row;
   justify-content: space-around;
 `;
-
-/*
- * export const StyledCheckbox = styled(Checkbox)`
- *   width: 28 !important;
- *   height: 28 !important;
- *   border-sizing: border-box !important;
- *   background-color: red !important;
- * `;
- */
 
 export const CategoryCheckboxField = styled('div')`
   display: flex;
@@ -244,6 +198,7 @@ export const SearchFields = styled('div')`
   flex-wrap: wrap;
   div {
     max-width: 160px;
+    min-width: 160px;
   }
 `;
 
@@ -251,4 +206,26 @@ export const StyledSearchButton = styled(StyledNextStepButton)`
   width: 100px;
   margin-bottom: 8px;
   margin-top: auto;
+`;
+
+export const StyledTabs = styled(props => <Tabs {...props} classes={{ indicator: 'indicator' }} />)`
+  && .indicator {
+    background-color: transparent;
+  }
+`;
+
+export const StyledTab = styled(props => <Tab {...props} classes={{ selected: 'selected' }} />)`
+  && {
+    min-width: ${({ searchTab }) => (searchTab ? '50px' : '130px')};
+    width: ${({ searchTab }) => (searchTab ? '50px' : '130px')};
+    background-color: ${({ searchTab }) => (searchTab ? 'transparent' : '#d1d1d5')};
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    margin: 0 5px;
+    line-height: 18px;
+
+    &.selected {
+      background-color: #ffffff;
+    }
+  }
 `;

--- a/plugin-hrm-form/src/Styles/HrmStyles.js
+++ b/plugin-hrm-form/src/Styles/HrmStyles.js
@@ -165,6 +165,9 @@ export const BottomButtonBar = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: center;
+  background-color: #ffffff;
+  margin: 0 20px;
+  padding: 20px 0;
 `;
 
 export const NameFields = styled('div')`

--- a/plugin-hrm-form/src/___tests__/FieldText.test.js
+++ b/plugin-hrm-form/src/___tests__/FieldText.test.js
@@ -48,7 +48,7 @@ test('render required FieldText', () => {
     value: '',
     touched: false,
     error: null,
-    validation: [ValidationType.REQUIRED],
+    validation: ValidationType.REQUIRED,
   };
   const handleBlur = jest.fn();
   const handleChange = jest.fn();
@@ -77,7 +77,7 @@ test('render FieldText with errors', () => {
     value: '',
     touched: true,
     error: 'This field is required',
-    validation: [ValidationType.REQUIRED],
+    validation: ValidationType.REQUIRED,
   };
   const handleBlur = jest.fn();
   const handleChange = jest.fn();

--- a/plugin-hrm-form/src/___tests__/FieldText.test.js
+++ b/plugin-hrm-form/src/___tests__/FieldText.test.js
@@ -48,7 +48,7 @@ test('render required FieldText', () => {
     value: '',
     touched: false,
     error: null,
-    validation: ValidationType.REQUIRED,
+    validation: [ValidationType.REQUIRED],
   };
   const handleBlur = jest.fn();
   const handleChange = jest.fn();
@@ -77,7 +77,7 @@ test('render FieldText with errors', () => {
     value: '',
     touched: true,
     error: 'This field is required',
-    validation: ValidationType.REQUIRED,
+    validation: [ValidationType.REQUIRED],
   };
   const handleBlur = jest.fn();
   const handleChange = jest.fn();

--- a/plugin-hrm-form/src/___tests__/__snapshots__/decorateTab.test.js.snap
+++ b/plugin-hrm-form/src/___tests__/__snapshots__/decorateTab.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`decorateTab when invalid 1`] = `
-<Tab
+<StyledTab
   label={
     <React.Fragment>
-      <span
+      <div
         style={
           Object {
             "verticalAlign": "middle",
@@ -19,7 +19,7 @@ exports[`decorateTab when invalid 1`] = `
             }
           }
         />
-      </span>
+      </div>
        
       My Label
        
@@ -29,7 +29,7 @@ exports[`decorateTab when invalid 1`] = `
 `;
 
 exports[`decorateTab when valid 1`] = `
-<Tab
+<StyledTab
   label="My Label"
 />
 `;

--- a/plugin-hrm-form/src/___tests__/decorateTab.test.js
+++ b/plugin-hrm-form/src/___tests__/decorateTab.test.js
@@ -1,20 +1,10 @@
-import { Tab } from '@material-ui/core';
-import ErrorIcon from '@material-ui/icons/Error';
 import renderer from 'react-test-renderer';
 
 import { formIsValid } from '../states/ValidationRules';
 import decorateTab from '../components/decorateTab';
 
-jest.mock('@material-ui/core', () => {
-  return {
-    Tab: 'Tab',
-  };
-});
-jest.mock('../states/ValidationRules', () => {
-  return {
-    formIsValid: jest.fn(),
-  };
-});
+jest.mock('../Styles/HrmStyles', () => ({ StyledTab: 'StyledTab' }));
+jest.mock('../states/ValidationRules', () => ({ formIsValid: jest.fn() }));
 jest.mock('@material-ui/icons/Error', () => 'ErrorIcon');
 
 test('decorateTab when valid', () => {

--- a/plugin-hrm-form/src/components/CallTypeButtons.js
+++ b/plugin-hrm-form/src/components/CallTypeButtons.js
@@ -21,7 +21,7 @@ const CallTypeButtons = props => {
   ));
 
   return (
-    <Container>
+    <Container style={{ backgroundColor: 'transparent' }}>
       {buttons}
       {props.form &&
       props.form.callType &&

--- a/plugin-hrm-form/src/components/TabbedForms.js
+++ b/plugin-hrm-form/src/components/TabbedForms.js
@@ -613,25 +613,27 @@ class TabbedForms extends React.PureComponent {
           {tabs}
         </StyledTabs>
         {body[this.state.tab]}
-        <BottomButtonBar>
-          {showNextButton && (
-            <StyledNextStepButton
-              roundCorners={true}
-              onClick={() => this.setState(prevState => ({ tab: prevState.tab + 1 }))}
-            >
-              Next
-            </StyledNextStepButton>
-          )}
-          {showSubmitButton && (
-            <StyledNextStepButton
-              roundCorners={true}
-              onClick={() => this.props.handleSubmit(this.props.task)}
-              disabled={!formIsValid(this.props.form)}
-            >
-              Submit
-            </StyledNextStepButton>
-          )}
-        </BottomButtonBar>
+        {(showNextButton || showSubmitButton) && (
+          <BottomButtonBar>
+            {showNextButton && (
+              <StyledNextStepButton
+                roundCorners={true}
+                onClick={() => this.setState(prevState => ({ tab: prevState.tab + 1 }))}
+              >
+                Next
+              </StyledNextStepButton>
+            )}
+            {showSubmitButton && (
+              <StyledNextStepButton
+                roundCorners={true}
+                onClick={() => this.props.handleSubmit(this.props.task)}
+                disabled={!formIsValid(this.props.form)}
+              >
+                Submit
+              </StyledNextStepButton>
+            )}
+          </BottomButtonBar>
+        )}
       </>
     );
   }

--- a/plugin-hrm-form/src/components/TabbedForms.js
+++ b/plugin-hrm-form/src/components/TabbedForms.js
@@ -10,6 +10,7 @@ import {
   ColumnarBlock,
   Container,
   ErrorText,
+  NameFields,
   StyledCheckboxLabel,
   StyledNextStepButton,
   TopNav,
@@ -82,14 +83,23 @@ class TabbedForms extends React.PureComponent {
     if (isCallerType) {
       body.push(
         <Container>
+          <NameFields>
+            <FieldText
+              id="CallerInformation_FirstName"
+              label="First name"
+              field={this.props.form.callerInformation.name.firstName}
+              {...this.defaultEventHandlers(['callerInformation', 'name'], 'firstName')}
+            />
+            <FieldText
+              id="CallerInformation_LastName"
+              label="Last name"
+              field={this.props.form.callerInformation.name.lastName}
+              {...this.defaultEventHandlers(['callerInformation', 'name'], 'lastName')}
+            />
+          </NameFields>
+
           <TwoColumnLayout>
             <ColumnarBlock>
-              <FieldText
-                id="CallerInformation_FirstName"
-                label="First name"
-                field={this.props.form.callerInformation.name.firstName}
-                {...this.defaultEventHandlers(['callerInformation', 'name'], 'firstName')}
-              />
               <FieldSelect
                 field={this.props.form.callerInformation.relationshipToChild}
                 id="CallerInformation_RelationshipToChild"
@@ -147,12 +157,6 @@ class TabbedForms extends React.PureComponent {
 
             <ColumnarBlock>
               <FieldText
-                id="CallerInformation_LastName"
-                label="Last name"
-                field={this.props.form.callerInformation.name.lastName}
-                {...this.defaultEventHandlers(['callerInformation', 'name'], 'lastName')}
-              />
-              <FieldText
                 id="CallerInformation_StreetAddress"
                 label="Street address"
                 field={this.props.form.callerInformation.location.streetAddress}
@@ -202,15 +206,23 @@ class TabbedForms extends React.PureComponent {
     // Child Information
     body.push(
       <Container>
+        <NameFields>
+          <FieldText
+            id="ChildInformation_FirstName"
+            label="First name"
+            field={this.props.form.childInformation.name.firstName}
+            {...this.defaultEventHandlers(['childInformation', 'name'], 'firstName')}
+          />
+          <FieldText
+            id="ChildInformation_LastName"
+            label="Last name"
+            field={this.props.form.childInformation.name.lastName}
+            {...this.defaultEventHandlers(['childInformation', 'name'], 'lastName')}
+          />
+        </NameFields>
+
         <TwoColumnLayout>
           <ColumnarBlock>
-            <FieldText
-              id="ChildInformation_FirstName"
-              label="First name"
-              field={this.props.form.childInformation.name.firstName}
-              {...this.defaultEventHandlers(['childInformation', 'name'], 'firstName')}
-            />
-
             <FieldSelect
               field={this.props.form.childInformation.gender}
               id="ChildInformation_Gender"
@@ -311,12 +323,6 @@ class TabbedForms extends React.PureComponent {
           </ColumnarBlock>
 
           <ColumnarBlock>
-            <FieldText
-              id="ChildInformation_FirstName"
-              label="Last name"
-              field={this.props.form.childInformation.name.lastName}
-              {...this.defaultEventHandlers(['childInformation', 'name'], 'lastName')}
-            />
             <FieldText
               id="ChildInformation_StreetAddress"
               label="Street address"

--- a/plugin-hrm-form/src/components/TabbedForms.js
+++ b/plugin-hrm-form/src/components/TabbedForms.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withTaskContext } from '@twilio/flex-ui';
-import { Checkbox, Tab, Tabs } from '@material-ui/core';
+import { Checkbox } from '@material-ui/core';
+import SearchIcon from '@material-ui/icons/Search';
 
 import {
   BottomButtonBar,
@@ -9,12 +10,13 @@ import {
   ColumnarBlock,
   Container,
   ErrorText,
-  NameFields,
   StyledCheckboxLabel,
   StyledNextStepButton,
   TopNav,
   TwoColumnLayout,
   TransparentButton,
+  StyledTabs,
+  StyledTab,
 } from '../Styles/HrmStyles';
 import callTypes from '../states/DomainConstants';
 import decorateTab from './decorateTab';
@@ -80,24 +82,14 @@ class TabbedForms extends React.PureComponent {
     if (isCallerType) {
       body.push(
         <Container>
-          <NameFields>
-            <FieldText
-              id="CallerInformation_FirstName"
-              label="First name"
-              field={this.props.form.callerInformation.name.firstName}
-              {...this.defaultEventHandlers(['callerInformation', 'name'], 'firstName')}
-            />
-
-            <FieldText
-              id="CallerInformation_LastName"
-              label="Last name"
-              field={this.props.form.callerInformation.name.lastName}
-              {...this.defaultEventHandlers(['callerInformation', 'name'], 'lastName')}
-            />
-          </NameFields>
-
           <TwoColumnLayout>
             <ColumnarBlock>
+              <FieldText
+                id="CallerInformation_FirstName"
+                label="First name"
+                field={this.props.form.callerInformation.name.firstName}
+                {...this.defaultEventHandlers(['callerInformation', 'name'], 'firstName')}
+              />
               <FieldSelect
                 field={this.props.form.callerInformation.relationshipToChild}
                 id="CallerInformation_RelationshipToChild"
@@ -155,6 +147,12 @@ class TabbedForms extends React.PureComponent {
 
             <ColumnarBlock>
               <FieldText
+                id="CallerInformation_LastName"
+                label="Last name"
+                field={this.props.form.callerInformation.name.lastName}
+                {...this.defaultEventHandlers(['callerInformation', 'name'], 'lastName')}
+              />
+              <FieldText
                 id="CallerInformation_StreetAddress"
                 label="Street address"
                 field={this.props.form.callerInformation.location.streetAddress}
@@ -204,24 +202,15 @@ class TabbedForms extends React.PureComponent {
     // Child Information
     body.push(
       <Container>
-        <NameFields>
-          <FieldText
-            id="ChildInformation_FirstName"
-            label="First name"
-            field={this.props.form.childInformation.name.firstName}
-            {...this.defaultEventHandlers(['childInformation', 'name'], 'firstName')}
-          />
-
-          <FieldText
-            id="ChildInformation_FirstName"
-            label="Last name"
-            field={this.props.form.childInformation.name.lastName}
-            {...this.defaultEventHandlers(['childInformation', 'name'], 'lastName')}
-          />
-        </NameFields>
-
         <TwoColumnLayout>
           <ColumnarBlock>
+            <FieldText
+              id="ChildInformation_FirstName"
+              label="First name"
+              field={this.props.form.childInformation.name.firstName}
+              {...this.defaultEventHandlers(['childInformation', 'name'], 'firstName')}
+            />
+
             <FieldSelect
               field={this.props.form.childInformation.gender}
               id="ChildInformation_Gender"
@@ -322,6 +311,12 @@ class TabbedForms extends React.PureComponent {
           </ColumnarBlock>
 
           <ColumnarBlock>
+            <FieldText
+              id="ChildInformation_FirstName"
+              label="Last name"
+              field={this.props.form.childInformation.name.lastName}
+              {...this.defaultEventHandlers(['childInformation', 'name'], 'lastName')}
+            />
             <FieldText
               id="ChildInformation_StreetAddress"
               label="Street address"
@@ -584,13 +579,13 @@ class TabbedForms extends React.PureComponent {
     );
 
     const tabs = [];
-    tabs.push(<Tab key="Search" label="Search" />);
+    tabs.push(<StyledTab searchTab key="Search" icon={<SearchIcon />} />);
     if (isCallerType) {
-      tabs.push(decorateTab('Caller Information', this.props.form.callerInformation));
+      tabs.push(decorateTab('Add Caller Information', this.props.form.callerInformation));
     }
-    tabs.push(decorateTab('Child Information', this.props.form.childInformation));
-    tabs.push(decorateTab('Issue Categorization', this.props.form.caseInformation.categories));
-    tabs.push(<Tab key="Case Information" label="Case Information" />);
+    tabs.push(decorateTab('Add Child Information', this.props.form.childInformation));
+    tabs.push(decorateTab('Categorize Issue', this.props.form.caseInformation.categories));
+    tabs.push(<StyledTab key="Case Information" label="Add Case Summary" />);
 
     const showNextButton = this.state.tab !== 0 && this.state.tab < body.length - 1;
     const showSubmitButton = this.state.tab === body.length - 1;
@@ -602,9 +597,15 @@ class TabbedForms extends React.PureComponent {
             &lt; BACK
           </TransparentButton>
         </TopNav>
-        <Tabs name="tab" variant="scrollable" scrollButtons="auto" value={this.state.tab} onChange={this.tabChange}>
+        <StyledTabs
+          name="tab"
+          variant="scrollable"
+          scrollButtons="auto"
+          value={this.state.tab}
+          onChange={this.tabChange}
+        >
           {tabs}
-        </Tabs>
+        </StyledTabs>
         {body[this.state.tab]}
         <BottomButtonBar>
           {showNextButton && (

--- a/plugin-hrm-form/src/components/decorateTab.js
+++ b/plugin-hrm-form/src/components/decorateTab.js
@@ -1,15 +1,15 @@
 import React from 'react';
-import { Tab } from '@material-ui/core';
 import ErrorIcon from '@material-ui/icons/Error';
 
+import { StyledTab } from '../Styles/HrmStyles';
 import { formIsValid } from '../states/ValidationRules';
 
 const decorateTab = (label, formRoot) => {
   if (formIsValid(formRoot)) {
-    return <Tab key={label} label={label} />;
+    return <StyledTab key={label} label={label} />;
   }
   return (
-    <Tab
+    <StyledTab
       key={label}
       label={
         <>

--- a/plugin-hrm-form/src/components/decorateTab.js
+++ b/plugin-hrm-form/src/components/decorateTab.js
@@ -13,9 +13,9 @@ const decorateTab = (label, formRoot) => {
       key={label}
       label={
         <>
-          <span style={{ verticalAlign: 'middle' }}>
+          <div style={{ verticalAlign: 'middle' }}>
             <ErrorIcon fontSize="inherit" style={{ color: 'red' }} />
-          </span>{' '}
+          </div>{' '}
           {label}{' '}
         </>
       }

--- a/plugin-hrm-form/src/types/index.js
+++ b/plugin-hrm-form/src/types/index.js
@@ -7,7 +7,7 @@ export const taskType = PropTypes.shape({
 export const fieldType = PropTypes.shape({
   value: PropTypes.string,
   error: PropTypes.string,
-  validation: PropTypes.string,
+  validation: PropTypes.arrayOf(PropTypes.string),
   touched: PropTypes.bool,
 });
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-75

This PR:
- Implements the new visuals for the tabs
- Updates `Container` element to match the new visuals.

<img width="665" alt="Screen Shot 2020-03-23 at 20 31 40" src="https://user-images.githubusercontent.com/1504544/77372821-61405b00-6d45-11ea-8b73-5715a259880d.png">
<img width="682" alt="Screen Shot 2020-03-23 at 20 31 49" src="https://user-images.githubusercontent.com/1504544/77372825-656c7880-6d45-11ea-97e9-0e4bc7c0011c.png">
