### PR TITLE
Upgrade Flex to 1.18.0

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -1133,6 +1133,46 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
       "dev": true
     },
+    "@gooddata/gooddata-js": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@gooddata/gooddata-js/-/gooddata-js-11.19.1.tgz",
+      "integrity": "sha512-on99qRdFtCs6QmnYFvlh8pBIR7HeaLVO9EwB7bLctXp5iT7O7aVmVTk//eZL/2fCx/b6bvTwjGZoh0IKvpeuXg==",
+      "dev": true,
+      "requires": {
+        "@gooddata/typings": "^2.18.0",
+        "es6-promise": "^3.0.2",
+        "fetch-cookie": "^0.7.0",
+        "invariant": "^2.2.2",
+        "isomorphic-fetch": "^2.2.1",
+        "json-stable-stringify": "^1.0.1",
+        "lodash": "^4.7.11",
+        "md5": "^2.2.1",
+        "node-fetch": "^1.7.3",
+        "qs": "^6.5.1",
+        "rxjs": "^5.5.6",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "5.5.12",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        }
+      }
+    },
+    "@gooddata/typings": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@gooddata/typings/-/typings-2.22.0.tgz",
+      "integrity": "sha512-AD5Cd1tFu7GJ9Px+jDT7QyTm6ofyeKH5zdmOjrm8YWG6fmwTcCEigLvrekHUSCdGceeAlHXpkqFXQXNjzspEtQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1374,9 +1414,9 @@
       "integrity": "sha512-eIRvJUr8gpt8VcCkfN89ZiBtUH96lG9H8ENYxzH/2R5DC3cFUsbHAy5lOWlypzhUyHYsARTWKry1AMyjnLBZzw=="
     },
     "@material-ui/core": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
-      "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
+      "integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0",
@@ -1462,6 +1502,12 @@
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
           "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
           "dev": true
         }
       }
@@ -1634,83 +1680,82 @@
         "babel-runtime": "^6.26.0"
       }
     },
+    "@twilio/flex-insights-identity-client-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-insights-identity-client-js/-/flex-insights-identity-client-js-2.0.5.tgz",
+      "integrity": "sha512-ODDEK7Rj0t73riyVJKPAda9c00uY8bLdx0Ns8yXXXy9vWL0Jq5CXSxQISQBKlPke0GkrWpiwyFCMimsPfPEOPg==",
+      "dev": true
+    },
+    "@twilio/flex-insights-player": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-insights-player/-/flex-insights-player-2.3.1.tgz",
+      "integrity": "sha512-P+tNK/Wa9/K3ermhbNyvPE/plOgy9WrQACeT7VzHHIyBgF7KYqxHr3NN9Imudh37XLaOIqUA389RKllN6PnEHw==",
+      "dev": true
+    },
     "@twilio/flex-ui": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.14.1.tgz",
-      "integrity": "sha512-iwsBxSwGQrm7MoH2k13o3c2t5DMKQ1ma+zJO+tEZa2c/vGfk423pOTW8Jk10DNVxXxb4doEPD7CTG9ifXr3+eg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.18.0.tgz",
+      "integrity": "sha512-kINS9SZ5w7OyLmJy5sYujSRvX0WQxX/YnebXBqeimN7Nv+yF3+hJdYzh3fE0k5HvOS3awIeJ0MLYLa+iHjeBeQ==",
       "dev": true,
       "requires": {
-        "@material-ui/core": "^3.9.3",
-        "@twilio/frame-ui": "^0.35.2",
-        "@twilio/wfo-identity-client-flex": "^0.9.1",
-        "@types/lodash.merge": "^4.6.6",
+        "@gooddata/gooddata-js": "11.19.1",
+        "@material-ui/core": "3.9.3",
+        "@twilio/flex-insights-identity-client-js": "2.0.5",
+        "@twilio/flex-insights-player": "2.3.1",
+        "@twilio/flex-ui-core": "0.41.1",
         "async-sema": "^3.0.0",
         "axios": "^0.19.0",
+        "core-js": "^3.0.1",
         "emotion": "9.2.6",
         "emotion-theming": "9.2.6",
-        "eventemitter3": "^4.0.0",
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.merge": "^4.6.2",
-        "loglevel": "^1.6.1",
-        "query-string": "^6.1.0",
+        "eventemitter3": "4.0.0",
+        "history": "4.7.2",
+        "hoist-non-react-statics": "3.3.1",
+        "lodash.debounce": "4.0.8",
+        "lodash.isequal": "4.5.0",
+        "lodash.merge": "4.6.2",
+        "loglevel": "1.6.1",
+        "query-string": "6.2.0",
         "react": "^16.5.2",
         "react-dom": "^16.5.2",
         "react-emotion": "9.2.6",
-        "react-flip-move": "^3.0.2",
-        "react-jss": "^8.6.1",
-        "react-redux": "^5.0.6",
-        "react-router": "^4.3.1",
-        "react-router-dom": "^4.2.2",
-        "react-router-redux": "^5.0.0-alpha.9",
-        "redux": "^3.7.1",
-        "redux-logger": "^3.0.6",
+        "react-flip-move": "3.0.3",
+        "react-jss": "8.6.1",
+        "react-redux": "~5.1.0",
+        "react-router": "4.3.1",
+        "react-router-dom": "4.3.1",
+        "react-router-redux": "5.0.0-alpha.9",
+        "redux": "3.7.2",
+        "redux-logger": "3.0.6",
         "redux-promise-middleware": "4.2.1",
-        "reselect": "^4.0.0",
-        "semver": "^5.5.0",
+        "reselect": "4.0.0",
+        "semver": "~5.7.0",
         "twilio-chat": "~3.2",
-        "twilio-client": "~1.9",
+        "twilio-client": "1.9.7",
         "twilio-sync": "^0.11.0",
-        "twilio-taskrouter": "^0.4.1",
+        "twilio-taskrouter": "^0.4.5",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "@twilio/frame-ui": {
-          "version": "0.35.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@material-ui/core": "^3.9.3",
-            "@material-ui/icons": "^2.0.0",
-            "@types/loglevel": "^1.5.3",
-            "emotion": "9.2.6",
-            "emotion-theming": "9.2.6",
-            "handlebars": "^4.0.12",
-            "hex-rgb": "^3.0.0",
-            "hoist-non-react-statics": "^3.3.0",
-            "loglevel": "^1.6.1",
-            "queue": "^6.0.1",
-            "react": "^16.5.2",
-            "react-dom": "^16.5.2",
-            "react-emotion": "9.2.6",
-            "react-redux": "^5.0.6",
-            "redux": "^3.7.1",
-            "redux-logger": "^3.0.6",
-            "redux-promise-middleware": "4.2.1",
-            "semver": "^5.5.0",
-            "twilio-chat": "~3.2",
-            "uuid": "^3.3.2"
-          }
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
+        },
+        "loglevel": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+          "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+          "dev": true
         },
         "query-string": {
-          "version": "6.11.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.1.tgz",
-          "integrity": "sha512-1ZvJOUl8ifkkBxu2ByVM/8GijMIPx+cef7u3yroO3Ogm4DOdZcF5dcrWTIlSHe3Pg/mtlt6/eFjObDfJureZZA==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+          "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
           "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
-            "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
           }
         },
@@ -1722,16 +1767,65 @@
         }
       }
     },
+    "@twilio/flex-ui-core": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.41.1.tgz",
+      "integrity": "sha512-HEYeO07JAXVpk1uxFJdF0ArtHi4MbStzogT4JV50PzaVyHSnfr6wuW+XUyR8zbkA+Jas3OIb9chvYrFzHuZ5+A==",
+      "dev": true,
+      "requires": {
+        "@material-ui/core": "3.9.3",
+        "@material-ui/icons": "2.0.3",
+        "core-js": "^3.0.1",
+        "create-emotion-styled": "^9.2.6",
+        "emotion": "9.2.6",
+        "emotion-theming": "9.2.6",
+        "google-libphonenumber": "3.2.6",
+        "handlebars": "4.1.2",
+        "hex-rgb": "3.0.0",
+        "hoist-non-react-statics": "3.3.0",
+        "lodash.debounce": "4.0.8",
+        "loglevel": "1.6.1",
+        "queue": "6.0.1",
+        "react": "^16.5.2",
+        "react-dom": "^16.5.2",
+        "react-emotion": "9.2.6",
+        "react-hotkeys": "2.0.0",
+        "react-redux": "~5.1.0",
+        "redux": "3.7.2",
+        "redux-logger": "3.0.6",
+        "redux-promise-middleware": "4.2.1",
+        "semver": "~5.7.0",
+        "twilio-chat": "~3.2",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "loglevel": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+          "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+          "dev": true
+        }
+      }
+    },
     "@twilio/voice-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@twilio/voice-errors/-/voice-errors-1.0.1.tgz",
       "integrity": "sha512-iXzCuiOhNMhrr8DVjRRzI14YwGUIBM83kWSWcDktxmXim0Tz9xoCth4QFAQcMkNL2h9DlfXlob6noH+3h2iA4A==",
-      "dev": true
-    },
-    "@twilio/wfo-identity-client-flex": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@twilio/wfo-identity-client-flex/-/wfo-identity-client-flex-0.9.1.tgz",
-      "integrity": "sha512-hpKriFFKJDzH2yJWtD8ZM5Ktyy7uqKRSshllo+IITR6eRqlcXbN3+TEWwDU+4HrvfU+16A8mVCJ7L8pjxxhfPQ==",
       "dev": true
     },
     "@types/babel__core": {
@@ -1842,30 +1936,6 @@
         "indefinite-observable": "^1.0.1"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-      "dev": true
-    },
-    "@types/lodash.merge": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/loglevel": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@types/loglevel/-/loglevel-1.6.3.tgz",
-      "integrity": "sha512-v2YWQQgqtNXAzybOT9qV3CIJqSeoaMUwmBfIMTQdvhsWUybYic/zNGccKH494naWKJ7zUm+VTgFepJfTrbCCJQ==",
-      "dev": true,
-      "requires": {
-        "loglevel": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1893,9 +1963,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
-      "version": "16.9.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
-      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
+      "version": "16.9.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.25.tgz",
+      "integrity": "sha512-Dlj2V72cfYLPNscIG3/SMUOzhzj7GK3bpSrfefwt2YT9GLynvLCCZjbhyF6VsT0q0+aRACRX03TDJGb7cA0cqg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -3603,6 +3673,12 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "cheerio": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
@@ -4279,6 +4355,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -5331,6 +5413,12 @@
         "next-tick": "~1.0.0"
       }
     },
+    "es6-denodeify": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
+      "integrity": "sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8=",
+      "dev": true
+    },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -5340,6 +5428,12 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -6432,6 +6526,16 @@
             "asap": "~2.0.3"
           }
         }
+      }
+    },
+    "fetch-cookie": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.7.3.tgz",
+      "integrity": "sha512-rZPkLnI8x5V+zYAiz8QonAHsTb4BY+iFowFBI1RFn0zrO343AVp9X7/yUj/9wL6Ef/8fLls8b/vGtzUvmyAUGA==",
+      "dev": true,
+      "requires": {
+        "es6-denodeify": "^0.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "figgy-pudding": {
@@ -7617,6 +7721,12 @@
         }
       }
     },
+    "google-libphonenumber": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.6.tgz",
+      "integrity": "sha512-6QCQAaKJlSd/1dUqvdQf7zzfb3uiZHsG8yhCfOdCVRfMuPZ/VDIEB47y5SYwjPQJPs7ebfW5jj6PeobB9JJ4JA==",
+      "dev": true
+    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -7679,9 +7789,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
-      "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -7825,17 +7935,27 @@
       "dev": true
     },
     "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "invariant": "^2.2.1",
         "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "resolve-pathname": "^2.2.0",
+        "value-equal": "^0.4.0",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "hmac-drbg": {
@@ -7849,9 +7969,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
       "dev": true,
       "requires": {
         "react-is": "^16.7.0"
@@ -8161,6 +8281,14 @@
       "dev": true,
       "requires": {
         "symbol-observable": "1.2.0"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        }
       }
     },
     "indent-string": {
@@ -9537,6 +9665,12 @@
         "warning": "^3.0.0"
       },
       "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        },
         "warning": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
@@ -10099,6 +10233,17 @@
         "pump": "^1.0.0",
         "split2": "^1.0.0",
         "through2": "^2.0.0"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "md5.js": {
@@ -13057,10 +13202,19 @@
       }
     },
     "react-flip-move": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz",
-      "integrity": "sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.3.tgz",
+      "integrity": "sha512-gR2jvjUgIXI7ceFWJkr8owX4vKhV0IJoXIf/Dt7gESFe5OKiSz2H6d10mKTW8fN134NDI16J4HgEgq9pKqJd5A==",
       "dev": true
+    },
+    "react-hotkeys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
+      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
     },
     "react-is": {
       "version": "16.12.0",
@@ -13651,6 +13805,12 @@
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
           "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
           "dev": true
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
         }
       }
     },
@@ -13680,6 +13840,14 @@
         "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
         "symbol-observable": "^1.0.3"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        }
       }
     },
     "redux-logger": {
@@ -13978,9 +14146,9 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==",
       "dev": true
     },
     "resolve-url": {
@@ -15021,12 +15189,6 @@
         }
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15429,9 +15591,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
       "dev": true
     },
     "symbol-tree": {
@@ -15603,18 +15765,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-    },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
-      "dev": true
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true
     },
     "tmp": {
       "version": "0.1.0",
@@ -15860,9 +16010,9 @@
       }
     },
     "twilio-taskrouter": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.3.tgz",
-      "integrity": "sha512-nUoKYVM6WQjNAhOPRkg9vRzZ7NNNgF//FHO3HIw+59RXWNBwFA7KN2eiE8FYoWW7bPTfpWSKS3GiIGtL0pEjVg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.5.tgz",
+      "integrity": "sha512-eRVBbqs+FvYdGOMzFV+wXzeH/hTgy5U7i0h3YT4CNRsNzGdpy6xgeNS2h+kPzij7+45xEn3ldzLezpDnVAsqAQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5",
@@ -16372,9 +16522,9 @@
       }
     },
     "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==",
       "dev": true
     },
     "vary": {

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -30,7 +30,7 @@
     "react-test-renderer": "16.5.2"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "1.14.1",
+    "@twilio/flex-ui": "1.18.0",
     "babel-eslint": "^10.0.3",
     "babel-polyfill": "^6.26.0",
     "enzyme": "^3.10.0",

--- a/plugin-show-recent-contacts/package-lock.json
+++ b/plugin-show-recent-contacts/package-lock.json
@@ -1032,6 +1032,46 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
       "dev": true
     },
+    "@gooddata/gooddata-js": {
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@gooddata/gooddata-js/-/gooddata-js-11.19.1.tgz",
+      "integrity": "sha512-on99qRdFtCs6QmnYFvlh8pBIR7HeaLVO9EwB7bLctXp5iT7O7aVmVTk//eZL/2fCx/b6bvTwjGZoh0IKvpeuXg==",
+      "dev": true,
+      "requires": {
+        "@gooddata/typings": "^2.18.0",
+        "es6-promise": "^3.0.2",
+        "fetch-cookie": "^0.7.0",
+        "invariant": "^2.2.2",
+        "isomorphic-fetch": "^2.2.1",
+        "json-stable-stringify": "^1.0.1",
+        "lodash": "^4.7.11",
+        "md5": "^2.2.1",
+        "node-fetch": "^1.7.3",
+        "qs": "^6.5.1",
+        "rxjs": "^5.5.6",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "5.5.12",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          }
+        }
+      }
+    },
+    "@gooddata/typings": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@gooddata/typings/-/typings-2.22.0.tgz",
+      "integrity": "sha512-AD5Cd1tFu7GJ9Px+jDT7QyTm6ofyeKH5zdmOjrm8YWG6fmwTcCEigLvrekHUSCdGceeAlHXpkqFXQXNjzspEtQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.1.tgz",
@@ -1292,9 +1332,9 @@
       "integrity": "sha512-eIRvJUr8gpt8VcCkfN89ZiBtUH96lG9H8ENYxzH/2R5DC3cFUsbHAy5lOWlypzhUyHYsARTWKry1AMyjnLBZzw=="
     },
     "@material-ui/core": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
-      "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
+      "integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0",
@@ -1380,6 +1420,12 @@
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
           "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
           "dev": true
         }
       }
@@ -1552,79 +1598,152 @@
         "babel-runtime": "^6.26.0"
       }
     },
+    "@twilio/flex-insights-identity-client-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-insights-identity-client-js/-/flex-insights-identity-client-js-2.0.5.tgz",
+      "integrity": "sha512-ODDEK7Rj0t73riyVJKPAda9c00uY8bLdx0Ns8yXXXy9vWL0Jq5CXSxQISQBKlPke0GkrWpiwyFCMimsPfPEOPg==",
+      "dev": true
+    },
+    "@twilio/flex-insights-player": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-insights-player/-/flex-insights-player-2.3.1.tgz",
+      "integrity": "sha512-P+tNK/Wa9/K3ermhbNyvPE/plOgy9WrQACeT7VzHHIyBgF7KYqxHr3NN9Imudh37XLaOIqUA389RKllN6PnEHw==",
+      "dev": true
+    },
     "@twilio/flex-ui": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.14.1.tgz",
-      "integrity": "sha512-iwsBxSwGQrm7MoH2k13o3c2t5DMKQ1ma+zJO+tEZa2c/vGfk423pOTW8Jk10DNVxXxb4doEPD7CTG9ifXr3+eg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.18.0.tgz",
+      "integrity": "sha512-kINS9SZ5w7OyLmJy5sYujSRvX0WQxX/YnebXBqeimN7Nv+yF3+hJdYzh3fE0k5HvOS3awIeJ0MLYLa+iHjeBeQ==",
       "dev": true,
       "requires": {
-        "@material-ui/core": "^3.9.3",
-        "@twilio/frame-ui": "^0.35.2",
-        "@twilio/wfo-identity-client-flex": "^0.9.1",
-        "@types/lodash.merge": "^4.6.6",
+        "@gooddata/gooddata-js": "11.19.1",
+        "@material-ui/core": "3.9.3",
+        "@twilio/flex-insights-identity-client-js": "2.0.5",
+        "@twilio/flex-insights-player": "2.3.1",
+        "@twilio/flex-ui-core": "0.41.1",
         "async-sema": "^3.0.0",
         "axios": "^0.19.0",
+        "core-js": "^3.0.1",
         "emotion": "9.2.6",
         "emotion-theming": "9.2.6",
-        "eventemitter3": "^4.0.0",
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "lodash.debounce": "^4.0.8",
-        "lodash.merge": "^4.6.2",
-        "loglevel": "^1.6.1",
-        "query-string": "^6.1.0",
+        "eventemitter3": "4.0.0",
+        "history": "4.7.2",
+        "hoist-non-react-statics": "3.3.1",
+        "lodash.debounce": "4.0.8",
+        "lodash.isequal": "4.5.0",
+        "lodash.merge": "4.6.2",
+        "loglevel": "1.6.1",
+        "query-string": "6.2.0",
         "react": "^16.5.2",
         "react-dom": "^16.5.2",
         "react-emotion": "9.2.6",
-        "react-flip-move": "^3.0.2",
-        "react-jss": "^8.6.1",
-        "react-redux": "^5.0.6",
-        "react-router": "^4.3.1",
-        "react-router-dom": "^4.2.2",
-        "react-router-redux": "^5.0.0-alpha.9",
-        "redux": "^3.7.1",
-        "redux-logger": "^3.0.6",
+        "react-flip-move": "3.0.3",
+        "react-jss": "8.6.1",
+        "react-redux": "~5.1.0",
+        "react-router": "4.3.1",
+        "react-router-dom": "4.3.1",
+        "react-router-redux": "5.0.0-alpha.9",
+        "redux": "3.7.2",
+        "redux-logger": "3.0.6",
         "redux-promise-middleware": "4.2.1",
-        "reselect": "^4.0.0",
-        "semver": "^5.5.0",
+        "reselect": "4.0.0",
+        "semver": "~5.7.0",
         "twilio-chat": "~3.2",
-        "twilio-client": "~1.9",
+        "twilio-client": "1.9.7",
         "twilio-sync": "^0.11.0",
-        "twilio-taskrouter": "^0.4.1",
+        "twilio-taskrouter": "^0.4.5",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "@twilio/frame-ui": {
-          "version": "0.35.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "@material-ui/core": "^3.9.3",
-            "@material-ui/icons": "^2.0.0",
-            "@types/loglevel": "^1.5.3",
-            "emotion": "9.2.6",
-            "emotion-theming": "9.2.6",
-            "handlebars": "^4.0.12",
-            "hex-rgb": "^3.0.0",
-            "hoist-non-react-statics": "^3.3.0",
-            "loglevel": "^1.6.1",
-            "queue": "^6.0.1",
-            "react": "^16.5.2",
-            "react-dom": "^16.5.2",
-            "react-emotion": "9.2.6",
-            "react-redux": "^5.0.6",
-            "redux": "^3.7.1",
-            "redux-logger": "^3.0.6",
-            "redux-promise-middleware": "4.2.1",
-            "semver": "^5.5.0",
-            "twilio-chat": "~3.2",
-            "uuid": "^3.3.2"
-          }
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
         },
         "eventemitter3": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
           "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+          "dev": true
+        },
+        "loglevel": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+          "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+          "dev": true
+        }
+      }
+    },
+    "@twilio/flex-ui-core": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.41.1.tgz",
+      "integrity": "sha512-HEYeO07JAXVpk1uxFJdF0ArtHi4MbStzogT4JV50PzaVyHSnfr6wuW+XUyR8zbkA+Jas3OIb9chvYrFzHuZ5+A==",
+      "dev": true,
+      "requires": {
+        "@material-ui/core": "3.9.3",
+        "@material-ui/icons": "2.0.3",
+        "core-js": "^3.0.1",
+        "create-emotion-styled": "^9.2.6",
+        "emotion": "9.2.6",
+        "emotion-theming": "9.2.6",
+        "google-libphonenumber": "3.2.6",
+        "handlebars": "4.1.2",
+        "hex-rgb": "3.0.0",
+        "hoist-non-react-statics": "3.3.0",
+        "lodash.debounce": "4.0.8",
+        "loglevel": "1.6.1",
+        "queue": "6.0.1",
+        "react": "^16.5.2",
+        "react-dom": "^16.5.2",
+        "react-emotion": "9.2.6",
+        "react-hotkeys": "2.0.0",
+        "react-redux": "~5.1.0",
+        "redux": "3.7.2",
+        "redux-logger": "3.0.6",
+        "redux-promise-middleware": "4.2.1",
+        "semver": "~5.7.0",
+        "twilio-chat": "~3.2",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+          "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+          "dev": true,
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "dev": true,
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "loglevel": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
+          "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -1633,12 +1752,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@twilio/voice-errors/-/voice-errors-1.0.1.tgz",
       "integrity": "sha512-iXzCuiOhNMhrr8DVjRRzI14YwGUIBM83kWSWcDktxmXim0Tz9xoCth4QFAQcMkNL2h9DlfXlob6noH+3h2iA4A==",
-      "dev": true
-    },
-    "@twilio/wfo-identity-client-flex": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@twilio/wfo-identity-client-flex/-/wfo-identity-client-flex-0.9.1.tgz",
-      "integrity": "sha512-hpKriFFKJDzH2yJWtD8ZM5Ktyy7uqKRSshllo+IITR6eRqlcXbN3+TEWwDU+4HrvfU+16A8mVCJ7L8pjxxhfPQ==",
       "dev": true
     },
     "@types/babel__core": {
@@ -1735,30 +1848,6 @@
         "indefinite-observable": "^1.0.1"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-      "dev": true
-    },
-    "@types/lodash.merge": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.6.tgz",
-      "integrity": "sha512-IB90krzMf7YpfgP3u/EvZEdXVvm4e3gJbUvh5ieuI+o+XqiNEt6fCzqNRaiLlPVScLI59RxIGZMQ3+Ko/DJ8vQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/loglevel": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@types/loglevel/-/loglevel-1.6.3.tgz",
-      "integrity": "sha512-v2YWQQgqtNXAzybOT9qV3CIJqSeoaMUwmBfIMTQdvhsWUybYic/zNGccKH494naWKJ7zUm+VTgFepJfTrbCCJQ==",
-      "dev": true,
-      "requires": {
-        "loglevel": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1781,9 +1870,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
-      "version": "16.9.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
-      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
+      "version": "16.9.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.25.tgz",
+      "integrity": "sha512-Dlj2V72cfYLPNscIG3/SMUOzhzj7GK3bpSrfefwt2YT9GLynvLCCZjbhyF6VsT0q0+aRACRX03TDJGb7cA0cqg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -3388,6 +3477,12 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "cheerio": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
@@ -4484,6 +4579,12 @@
         "which": "^1.2.9"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -5467,6 +5568,12 @@
         "next-tick": "^1.0.0"
       }
     },
+    "es6-denodeify": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
+      "integrity": "sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8=",
+      "dev": true
+    },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -5476,6 +5583,12 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.2",
@@ -6389,6 +6502,16 @@
         }
       }
     },
+    "fetch-cookie": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.7.3.tgz",
+      "integrity": "sha512-rZPkLnI8x5V+zYAiz8QonAHsTb4BY+iFowFBI1RFn0zrO343AVp9X7/yUj/9wL6Ef/8fLls8b/vGtzUvmyAUGA==",
+      "dev": true,
+      "requires": {
+        "es6-denodeify": "^0.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -6925,6 +7048,12 @@
         }
       }
     },
+    "google-libphonenumber": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.6.tgz",
+      "integrity": "sha512-6QCQAaKJlSd/1dUqvdQf7zzfb3uiZHsG8yhCfOdCVRfMuPZ/VDIEB47y5SYwjPQJPs7ebfW5jj6PeobB9JJ4JA==",
+      "dev": true
+    },
     "got": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -7136,17 +7265,27 @@
       "dev": true
     },
     "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2",
+        "invariant": "^2.2.1",
         "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "resolve-pathname": "^2.2.0",
+        "value-equal": "^0.4.0",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
       }
     },
     "hmac-drbg": {
@@ -7160,9 +7299,9 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
       "dev": true,
       "requires": {
         "react-is": "^16.7.0"
@@ -7455,6 +7594,14 @@
       "dev": true,
       "requires": {
         "symbol-observable": "1.2.0"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        }
       }
     },
     "indexes-of": {
@@ -9315,6 +9462,12 @@
         "warning": "^3.0.0"
       },
       "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        },
         "warning": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
@@ -9871,6 +10024,25 @@
         "pump": "^1.0.0",
         "split2": "^1.0.0",
         "through2": "^2.0.0"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        }
       }
     },
     "md5.js": {
@@ -12220,13 +12392,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.1.tgz",
-      "integrity": "sha512-1ZvJOUl8ifkkBxu2ByVM/8GijMIPx+cef7u3yroO3Ogm4DOdZcF5dcrWTIlSHe3Pg/mtlt6/eFjObDfJureZZA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
       "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }
     },
@@ -12525,10 +12696,19 @@
       }
     },
     "react-flip-move": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz",
-      "integrity": "sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.3.tgz",
+      "integrity": "sha512-gR2jvjUgIXI7ceFWJkr8owX4vKhV0IJoXIf/Dt7gESFe5OKiSz2H6d10mKTW8fN134NDI16J4HgEgq9pKqJd5A==",
       "dev": true
+    },
+    "react-hotkeys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
+      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
     },
     "react-is": {
       "version": "16.9.0",
@@ -12801,6 +12981,12 @@
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
           "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
           "dev": true
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
         }
       }
     },
@@ -12830,6 +13016,14 @@
         "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
         "symbol-observable": "^1.0.3"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+          "dev": true
+        }
       }
     },
     "redux-logger": {
@@ -13121,9 +13315,9 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg==",
       "dev": true
     },
     "resolve-url": {
@@ -14076,12 +14270,6 @@
         }
       }
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -14462,9 +14650,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
       "dev": true
     },
     "symbol-tree": {
@@ -14636,18 +14824,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-    },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==",
-      "dev": true
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true
     },
     "tmp": {
       "version": "0.1.0",
@@ -14912,9 +15088,9 @@
       }
     },
     "twilio-taskrouter": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.3.tgz",
-      "integrity": "sha512-nUoKYVM6WQjNAhOPRkg9vRzZ7NNNgF//FHO3HIw+59RXWNBwFA7KN2eiE8FYoWW7bPTfpWSKS3GiIGtL0pEjVg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/twilio-taskrouter/-/twilio-taskrouter-0.4.5.tgz",
+      "integrity": "sha512-eRVBbqs+FvYdGOMzFV+wXzeH/hTgy5U7i0h3YT4CNRsNzGdpy6xgeNS2h+kPzij7+45xEn3ldzLezpDnVAsqAQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5",
@@ -15402,9 +15578,9 @@
       }
     },
     "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw==",
       "dev": true
     },
     "vary": {

--- a/plugin-show-recent-contacts/package.json
+++ b/plugin-show-recent-contacts/package.json
@@ -17,7 +17,7 @@
     "eject": "flex-plugin eject"
   },
   "devDependencies": {
-    "@twilio/flex-ui": "1.14.1"
+    "@twilio/flex-ui": "1.18.0"
   },
   "dependencies": {
     "@craco/craco": "^5.0.2",


### PR DESCRIPTION
This updates our `devDependency` on Flex from 1.14.1 to 1.18.0, to match the version now deployed to staging.  See https://www.twilio.com/docs/flex/release-notes/flex-ui-release-notes#v-1180 for information on what was changed since 1.14.1.  This also has resulted in many changes to `package-lock.json`.

I've confirmed locally that `plugin-hrm-form` still works fine.  However, I am having a problem getting `plugin-show-recent-contacts` to run locally with this new configuration.  Given that we're not actively working in it, I'm willing to take the risk on deploying this new version to staging, as I believe the issue is local to my machine.  We are likely to abandon `plugin-show-recent-contacts` as soon as the search feature has been proven, anyway.

@GPaoloni @murilovmachado you are free to merge this at any time, depending on what works best to limit merge conflicts.