### PR TITLE
Do not save form data when non-data callType

### DIFF
--- a/plugin-hrm-form/src/services/ContactService.js
+++ b/plugin-hrm-form/src/services/ContactService.js
@@ -1,6 +1,6 @@
 import secret from '../private/secret';
 import { FieldType, recreateBlankForm } from '../states/ContactFormStateFactory';
-import { isNonDataCallType } from '../states/DomainConstants';
+import { isNonDataCallType } from '../states/ValidationRules';
 
 export async function searchContacts(hrmBaseUrl, searchParams) {
   try {

--- a/plugin-hrm-form/src/services/ContactService.js
+++ b/plugin-hrm-form/src/services/ContactService.js
@@ -1,5 +1,6 @@
 import secret from '../private/secret';
-import { FieldType } from '../states/ContactFormStateFactory';
+import { FieldType, recreateBlankForm } from '../states/ContactFormStateFactory';
+import { isNonDataCallType } from '../states/DomainConstants';
 
 export async function searchContacts(hrmBaseUrl, searchParams) {
   try {
@@ -73,12 +74,24 @@ export function saveToHrm(task, form, abortFunction, hrmBaseUrl, workerSid, help
   const validMetrics = !recreated;
   const conversationDuration = validMetrics ? secondsElapsed : null;
 
+  const callType = form.callType.value;
+
+  let rawForm = form;
+
+  if (isNonDataCallType(callType)) {
+    rawForm = {
+      ...recreateBlankForm(),
+      callType: form.callType,
+      metadata: form.metadata,
+    };
+  }
+
   /*
    * We do a transform from the original and then add things.
    * Not sure if we should drop that all into one function or not.
    * Probably.  It would just require passing the task.
    */
-  const formToSend = transformForm(form);
+  const formToSend = transformForm(rawForm);
 
   const body = {
     form: formToSend,

--- a/plugin-hrm-form/src/states/DomainConstants.js
+++ b/plugin-hrm-form/src/states/DomainConstants.js
@@ -9,4 +9,6 @@ const callTypes = {
   abusive: 'Abusive',
 };
 
+export const isNonDataCallType = callType => ![callTypes.child, callTypes.caller].includes(callType);
+
 export default callTypes;

--- a/plugin-hrm-form/src/states/DomainConstants.js
+++ b/plugin-hrm-form/src/states/DomainConstants.js
@@ -9,6 +9,4 @@ const callTypes = {
   abusive: 'Abusive',
 };
 
-export const isNonDataCallType = callType => ![callTypes.child, callTypes.caller].includes(callType);
-
 export default callTypes;


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-87

When saving a non-data callType, no information filled in the form by the user should be sent. In this case, we're recreating a blank form, keeping just `metadata` and `callType`.