### PR TITLE
Implement tab navigation for the dialogs

### DIFF
--- a/plugin-hrm-form/.eslintrc.json
+++ b/plugin-hrm-form/.eslintrc.json
@@ -11,6 +11,7 @@
     "no-warning-comments": "off",
     "no-confusing-arrow": "off",
     "no-alert": "off",
-    "import/no-extraneous-dependencies": "off"
+    "import/no-extraneous-dependencies": "off",
+    "jsx-a11y/tabindex-no-positive": "off"
   }
 }

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -49,6 +49,7 @@ jest.mock('../styles/search', () => ({
   ResultsHeader: 'ResultsHeader',
   ListContainer: 'ListContainer',
   ScrollableList: 'ScrollableList',
+  CancelButton: 'CancelButton',
 }));
 
 jest.mock('../styles/callTypeButtons', () => ({

--- a/plugin-hrm-form/src/components/CallTypeButtons.jsx
+++ b/plugin-hrm-form/src/components/CallTypeButtons.jsx
@@ -66,15 +66,17 @@ const CallTypeButtons = props => {
       </Container>
       <CloseTaskDialog onClose={() => clearCallType(props)} open={isDialogOpen(form)}>
         <Box marginLeft="auto">
-          <CloseButton onClick={() => clearCallType(props)} />
+          <CloseButton tabIndex={3} onClick={() => clearCallType(props)} />
         </Box>
         <CloseTaskDialogText>Are you sure?</CloseTaskDialogText>
         <Box marginBottom="32px">
           <Row>
-            <ConfirmButton onClick={() => props.handleSubmit(task)}>
+            <ConfirmButton autoFocus tabIndex={1} onClick={() => props.handleSubmit(task)}>
               {isCallTask(task) ? strings.TaskHeaderEndCall : strings.TaskHeaderEndChat}
             </ConfirmButton>
-            <CancelButton onClick={() => clearCallType(props)}>Cancel</CancelButton>
+            <CancelButton tabIndex={2} onClick={() => clearCallType(props)}>
+              Cancel
+            </CancelButton>
           </Row>
         </Box>
       </CloseTaskDialog>

--- a/plugin-hrm-form/src/components/search/SearchResults/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.jsx
@@ -14,6 +14,7 @@ import {
   ResultsHeader,
   ListContainer,
   ScrollableList,
+  CancelButton,
 } from '../../../styles/search';
 import callTypes from '../../../states/DomainConstants';
 
@@ -81,10 +82,12 @@ class SearchResults extends Component {
         <ConfirmContainer>
           <ConfirmText>{this.state.msg}</ConfirmText>
           <Row>
-            <Button variant="text" size="medium" onClick={handleClose}>
+            <CancelButton tabIndex={2} variant="text" size="medium" onClick={handleClose}>
               cancel
-            </Button>
+            </CancelButton>
             <Button
+              autoFocus
+              tabIndex={1}
               variant="contained"
               size="medium"
               onClick={handleConfirm}

--- a/plugin-hrm-form/src/styles/callTypeButtons/index.js
+++ b/plugin-hrm-form/src/styles/callTypeButtons/index.js
@@ -85,6 +85,11 @@ export const ConfirmButton = styled(Button)`
 export const CancelButton = styled(Button)`
   text-transform: uppercase;
   margin-left: 30px;
+
+  &:focus {
+    background-color: rgba(0, 0, 0, 0.2);
+    background-blend-mode: color;
+  }
 `;
 
 export const CloseButton = styled(props => (
@@ -94,5 +99,9 @@ export const CloseButton = styled(props => (
 ))`
   && .label {
     color: ${props => props.theme.colors.defaultButtonColor};
+  }
+
+  &:focus {
+    background-color: rgba(0, 0, 0, 0.08);
   }
 `;

--- a/plugin-hrm-form/src/styles/search/index.js
+++ b/plugin-hrm-form/src/styles/search/index.js
@@ -83,6 +83,12 @@ export const ConfirmText = styled(PopoverText)`
   margin-bottom: 20px;
 `;
 
+export const CancelButton = styled(Button)`
+  &:focus {
+    background-color: rgba(34, 34, 34, 0.08);
+  }
+`;
+
 export const PrevNameText = styled(FontOpenSans)`
   font-size: 12px;
   font-weight: 700;


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-105

This PR implements tab navigation for:
- `End Chat` dialog
- `Connect Contact` dialog

Notes: Initially, I wanted to make the element focused by the tab navigation to also behave like `:hover`,  but it's not possible to set an HTML element state to `:hover` programmatically ([link](https://stackoverflow.com/questions/17226676/how-do-i-simulate-a-mouseover-in-pure-javascript-that-activates-the-css-hover/17226753#17226753)), so I had to explicitly copy the `:hover` css styles into `:focus`.
An alternative is to use [this](https://github.com/TSedlar/pseudo-styler) or [this](https://github.com/CraigCav/react-pseudostyler) GitHub repos. They've implemented a workaround to set an HTML element state to `:hover`, but they're not very popular repos, so it's better not to rely on them.