### PR TITLE
Implement TabPressWrapper

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -13298,6 +13298,11 @@
         }
       }
     },
+    "react-keyboard-event-handler": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/react-keyboard-event-handler/-/react-keyboard-event-handler-1.5.4.tgz",
+      "integrity": "sha512-MSOxU/sQ5q9XWNHhXAJxzh4xVLZjKORGNC2Pzvx3qUo24TQeztGB0tq8oSArwX6vfKSIVijiw8wBmkN5pJOB4w=="
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -27,6 +27,7 @@
     "prop-types": "^15.7.2",
     "react": "16.5.2",
     "react-dom": "16.5.2",
+    "react-keyboard-event-handler": "^1.5.4",
     "react-scripts": "^3.4.0",
     "react-test-renderer": "16.5.2"
   },

--- a/plugin-hrm-form/src/___tests__/CallTypeButtons.test.js
+++ b/plugin-hrm-form/src/___tests__/CallTypeButtons.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 
 import './mockStyled';
-import CallTypeButtons from '../components/CallTypeButtons';
+import CallTypeButtons from '../components/callTypeButtons';
 import { DataCallTypeButton, NonDataCallTypeButton, ConfirmButton, CancelButton } from '../styles/callTypeButtons';
 import LocalizationContext from '../contexts/LocalizationContext';
 import callTypes from '../states/DomainConstants';

--- a/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
+++ b/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import './mockStyled';
+import TabPressWrapper from '../components/TabPressWrapper';
+
+const getFirstElement = component => component.getInstance().firstElementRef.current;
+const getLastElement = component => component.getInstance().lastElementRef.current;
+
+test('<TabPressWrapper> children with tabIndexes: 1 and 2', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="firstElement" type="button" tabIndex={1} />
+      <button id="secondElement" type="button" tabIndex={2} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('firstElement');
+  expect(lastElement.props.id).toEqual('secondElement');
+});
+
+const setActiveElement = element => jest.spyOn(document, 'activeElement', 'get').mockReturnValue(element);
+const event = {
+  preventDefault: jest.fn(),
+  stopPropagation: jest.fn(),
+};
+const pressTab = component => component.getInstance().handleTab('tab', event);
+const pressShiftTab = component => component.getInstance().handleTab('shift+tab', event);
+
+const assertCalledFocusElementWith = (component, element) => {
+  const focusElementMethod = component.getInstance().focusElement;
+  const firstArgument = focusElementMethod.mock.calls[0][0];
+
+  expect(focusElementMethod).toHaveBeenCalled();
+  expect(firstArgument.current).toEqual(element);
+};
+
+test('<TabPressWrapper> lastElement focused and hit "tab"', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="firstElement" type="button" tabIndex={1} />
+      <button id="secondElement" type="button" tabIndex={2} />
+    </TabPressWrapper>,
+  );
+
+  const lastElement = getLastElement(component);
+  setActiveElement(lastElement);
+
+  // Mock TabPressWrapper.focusElement()
+  component.getInstance().focusElement = jest.fn();
+
+  pressTab(component);
+
+  const firstElement = getFirstElement(component);
+  assertCalledFocusElementWith(component, firstElement);
+});
+
+test('<TabPressWrapper> firstElement focused and hit "shift+tab"', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="firstElement" type="button" tabIndex={1} />
+      <button id="secondElement" type="button" tabIndex={2} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  setActiveElement(firstElement);
+
+  // Mock TabPressWrapper.focusElement()
+  component.getInstance().focusElement = jest.fn();
+
+  pressShiftTab(component);
+
+  const lastElement = getLastElement(component);
+  assertCalledFocusElementWith(component, lastElement);
+});

--- a/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
+++ b/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
@@ -7,20 +7,183 @@ import TabPressWrapper from '../components/TabPressWrapper';
 const getFirstElement = component => component.getInstance().firstElementRef.current;
 const getLastElement = component => component.getInstance().lastElementRef.current;
 
-test('<TabPressWrapper> children with tabIndexes: 1 and 2', () => {
+/**
+ * firstElement and lastElement tests
+ */
+
+test('<TabPressWrapper> with no children', () => {
+  const component = renderer.create(<TabPressWrapper />);
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement).toBeNull();
+  expect(lastElement).toBeNull();
+});
+
+test('<TabPressWrapper> with no children with tabIndex', () => {
   const component = renderer.create(
     <TabPressWrapper>
-      <button id="firstElement" type="button" tabIndex={1} />
-      <button id="secondElement" type="button" tabIndex={2} />
+      <button id="noTabIndex1" type="button" />
+      <button id="noTabIndex2" type="button" />
     </TabPressWrapper>,
   );
 
   const firstElement = getFirstElement(component);
   const lastElement = getLastElement(component);
 
-  expect(firstElement.props.id).toEqual('firstElement');
-  expect(lastElement.props.id).toEqual('secondElement');
+  expect(firstElement).toBeNull();
+  expect(lastElement).toBeNull();
 });
+
+test('<TabPressWrapper> children with only one tabIndex', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="tabIndex1" type="button" tabIndex={1} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex1');
+  expect(lastElement).toBeNull();
+});
+
+test('<TabPressWrapper> children with tabIndexes: 1, 2 and 3', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex2" type="button" tabIndex={2} />
+      <button id="tabIndex3" type="button" tabIndex={2} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex1');
+  expect(lastElement.props.id).toEqual('tabIndex3');
+});
+
+test('<TabPressWrapper> not only first level children with tabIndexes: 1, 2 and 3', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <div>
+        <button id="tabIndex1" type="button" tabIndex={1} />
+      </div>
+      <div>
+        <div>
+          <button id="tabIndex2" type="button" tabIndex={2} />
+        </div>
+      </div>
+      <button id="tabIndex3" type="button" tabIndex={3} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex1');
+  expect(lastElement.props.id).toEqual('tabIndex3');
+});
+
+test('<TabPressWrapper> children with tabIndexes: 1 and 3', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex3" type="button" tabIndex={3} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex1');
+  expect(lastElement.props.id).toEqual('tabIndex3');
+});
+
+test('<TabPressWrapper> children with tabIndexes: 5 and 4', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="tabIndex5" type="button" tabIndex={5} />
+      <button id="tabIndex4" type="button" tabIndex={4} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex4');
+  expect(lastElement.props.id).toEqual('tabIndex5');
+});
+
+test('<TabPressWrapper> children with tabIndexes: 1, 2 and 1', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex2" type="button" tabIndex={2} />
+      <button id="tabIndex1Again" type="button" tabIndex={1} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex1');
+  expect(lastElement.props.id).toEqual('tabIndex2');
+});
+
+test('<TabPressWrapper> children with tabIndexes: 1, 2 and 2', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex2" type="button" tabIndex={2} />
+      <button id="tabIndex2Again" type="button" tabIndex={2} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex1');
+  expect(lastElement.props.id).toEqual('tabIndex2Again');
+});
+
+test('<TabPressWrapper> complex children structure', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <div>
+        <button id="tabIndex7" type="button" tabIndex={7} />
+        <div />
+        <button id="tabIndex6" type="button" tabIndex={6} />
+        <button id="tabIndex3" type="button" tabIndex={3} />
+      </div>
+      <div>
+        <button id="tabIndex3Again" type="button" tabIndex={3} />
+        <button id="tabIndex7Again" type="button" tabIndex={7} />
+        <button id="tabIndex6Again" type="button" tabIndex={6} />
+      </div>
+      <div>
+        <div>
+          <button id="tabIndex2" type="button" tabIndex={2} />
+        </div>
+      </div>
+      <button id="tabIndex2Again" type="button" tabIndex={2} />
+      <button id="tabIndex3AgainAgain" type="button" tabIndex={3} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex2');
+  expect(lastElement.props.id).toEqual('tabIndex7Again');
+});
+
+/**
+ * tab and shift+tab tests
+ */
 
 const setActiveElement = element => jest.spyOn(document, 'activeElement', 'get').mockReturnValue(element);
 const event = {
@@ -76,4 +239,40 @@ test('<TabPressWrapper> firstElement focused and hit "shift+tab"', () => {
 
   const lastElement = getLastElement(component);
   assertCalledFocusElementWith(component, lastElement);
+});
+
+test('<TabPressWrapper> single element hit "tab"', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="singleElement" type="button" tabIndex={1} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  setActiveElement(firstElement);
+
+  // Mock TabPressWrapper.focusElement()
+  component.getInstance().focusElement = jest.fn();
+
+  pressTab(component);
+
+  assertCalledFocusElementWith(component, firstElement);
+});
+
+test('<TabPressWrapper> single element hit "shift+tab"', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="singleElement" type="button" tabIndex={2} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  setActiveElement(firstElement);
+
+  // Mock TabPressWrapper.focusElement()
+  component.getInstance().focusElement = jest.fn();
+
+  pressShiftTab(component);
+
+  assertCalledFocusElementWith(component, firstElement);
 });

--- a/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
+++ b/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
@@ -50,6 +50,22 @@ test('<TabPressWrapper> children with only one tabIndex', () => {
   expect(lastElement).toBeNull();
 });
 
+test('<TabPressWrapper> children with tabIndexes: 1, 2 and 3', () => {
+  const component = renderer.create(
+    <TabPressWrapper>
+      <button id="tabIndex1" type="button" tabIndex={1} />
+      <button id="tabIndex2" type="button" tabIndex={2} />
+      <button id="tabIndex3" type="button" tabIndex={3} />
+    </TabPressWrapper>,
+  );
+
+  const firstElement = getFirstElement(component);
+  const lastElement = getLastElement(component);
+
+  expect(firstElement.props.id).toEqual('tabIndex1');
+  expect(lastElement.props.id).toEqual('tabIndex3');
+});
+
 test('<TabPressWrapper> not only first level children with tabIndexes: 1, 2 and 3', () => {
   const component = renderer.create(
     <TabPressWrapper>

--- a/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
+++ b/plugin-hrm-form/src/___tests__/TabPressWrapper.test.js
@@ -50,22 +50,6 @@ test('<TabPressWrapper> children with only one tabIndex', () => {
   expect(lastElement).toBeNull();
 });
 
-test('<TabPressWrapper> children with tabIndexes: 1, 2 and 3', () => {
-  const component = renderer.create(
-    <TabPressWrapper>
-      <button id="tabIndex1" type="button" tabIndex={1} />
-      <button id="tabIndex2" type="button" tabIndex={2} />
-      <button id="tabIndex3" type="button" tabIndex={2} />
-    </TabPressWrapper>,
-  );
-
-  const firstElement = getFirstElement(component);
-  const lastElement = getLastElement(component);
-
-  expect(firstElement.props.id).toEqual('tabIndex1');
-  expect(lastElement.props.id).toEqual('tabIndex3');
-});
-
 test('<TabPressWrapper> not only first level children with tabIndexes: 1, 2 and 3', () => {
   const component = renderer.create(
     <TabPressWrapper>

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -62,4 +62,5 @@ jest.mock('../styles/callTypeButtons', () => ({
   ConfirmButton: 'ConfirmButton',
   CancelButton: 'CancelButton',
   CloseButton: 'CloseButton',
+  NonDataCallTypeDialogContainer: 'NonDataCallTypeDialogContainer',
 }));

--- a/plugin-hrm-form/src/components/HrmForm.jsx
+++ b/plugin-hrm-form/src/components/HrmForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTaskContext } from '@twilio/flex-ui';
 
-import CallTypeButtons from './CallTypeButtons';
+import CallTypeButtons from './callTypeButtons';
 import TabbedForms from './tabbedForms';
 import { isNonDataCallType } from '../states/ValidationRules';
 import { formType } from '../types';

--- a/plugin-hrm-form/src/components/TabPressWrapper.jsx
+++ b/plugin-hrm-form/src/components/TabPressWrapper.jsx
@@ -1,0 +1,135 @@
+/* eslint-disable react/no-find-dom-node */
+/**
+ * Component that handles element navigation with 'tab' or 'shift+tab', so that
+ * it will only navigate between the desired elements.
+ *
+ * Usage: <TabPressWrapper><YourComponent /></TabPressWrapper>
+ *
+ * What it requires?
+ * It requires that every navigable element of <YourComponent> has a unique tabIndex value.
+ *
+ * How does it work?
+ * 1) It detects the first and last navigable elements according to the tabIndexes.
+ * 2) It adds a Ref to these elements, in order to access the HTML native element.
+ * 3) It listens to 'tab' or 'shift+tab' key presses:
+ *    a) If it's on the lastElement and listens to a 'tab', it focus the firstElement
+ *    b) If it's on the firstElement and listens a 'shif+tab', it focus the lastElement
+ *    c) Otherwise, it lets the browser handle it
+ */
+import React, { Component, createRef } from 'react';
+import PropTypes from 'prop-types';
+import KeyboardEventHandler from 'react-keyboard-event-handler';
+import RootRef from '@material-ui/core/RootRef';
+
+import { isNullOrUndefined } from '../utils';
+
+class TabPressWrapper extends Component {
+  static displayName = 'TabPressWrapper';
+
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.firstElementRef = createRef();
+    this.lastElementRef = createRef();
+  }
+
+  state = {
+    childrenWithRef: null,
+  };
+
+  componentDidMount() {
+    const { children } = this.props;
+
+    const maxTabIndex = this.countTabIndexElements(children);
+    const childrenWithRef = this.addRefToFirstAndLastElement(children, maxTabIndex);
+
+    this.setState({ childrenWithRef });
+  }
+
+  handleTab = (key, event) => {
+    const { activeElement } = document;
+    const isFirstElement = activeElement === this.firstElementRef.current;
+    const isLastElement = activeElement === this.lastElementRef.current;
+
+    if (isLastElement && key === 'tab') {
+      this.focusElement(this.firstElementRef, event);
+    } else if (isFirstElement && key === 'shift+tab') {
+      this.focusElement(this.lastElementRef, event);
+    }
+  };
+
+  focusElement = (elementRef, event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    elementRef.current.focus();
+  };
+
+  countTabIndexElements = children => {
+    let childrenCount = 0;
+
+    React.Children.forEach(children, element => {
+      const hasTabIndex = Boolean(element.props && !isNullOrUndefined(element.props.tabIndex));
+      const hasChildren = Boolean(element.props && !isNullOrUndefined(element.props.children));
+
+      if (hasTabIndex) {
+        childrenCount += 1;
+      } else if (hasChildren) {
+        childrenCount += this.countTabIndexElements(element.props.children);
+      }
+    });
+
+    return childrenCount;
+  };
+
+  addRefToFirstAndLastElement = (children, maxTabIndex) =>
+    React.Children.map(children, element => {
+      const hasTabIndex = Boolean(element.props && !isNullOrUndefined(element.props.tabIndex));
+      const hasChildren = Boolean(element.props && !isNullOrUndefined(element.props.children));
+
+      if (hasTabIndex) {
+        const { tabIndex } = element.props;
+        const isFirstElement = tabIndex === 1;
+        const isLastElement = tabIndex === maxTabIndex;
+
+        if (isFirstElement) {
+          return this.addRef(element, this.firstElementRef);
+        }
+
+        if (isLastElement) {
+          return this.addRef(element, this.lastElementRef);
+        }
+
+        return element;
+      } else if (hasChildren) {
+        const updatedChildren = this.addRefToFirstAndLastElement(element.props.children, maxTabIndex);
+        return React.cloneElement(element, {}, updatedChildren);
+      }
+
+      return element;
+    });
+
+  addRef = (node, elementRef) => (
+    <RootRef rootRef={elementRef}>{React.cloneElement(node, { ref: elementRef })}</RootRef>
+  );
+
+  render() {
+    const { childrenWithRef } = this.state;
+
+    return (
+      <KeyboardEventHandler
+        id="KeyboardEventHandler"
+        handleKeys={['tab', 'shift+tab']}
+        onKeyEvent={this.handleTab}
+        handleFocusableElements
+      >
+        {childrenWithRef}
+      </KeyboardEventHandler>
+    );
+  }
+}
+
+export default TabPressWrapper;

--- a/plugin-hrm-form/src/components/TabPressWrapper.jsx
+++ b/plugin-hrm-form/src/components/TabPressWrapper.jsx
@@ -6,12 +6,15 @@
  * Usage: <TabPressWrapper><YourComponent /></TabPressWrapper>
  *
  * What it requires?
- * It requires that every navigable element of <YourComponent> has a unique tabIndex value.
+ * It requires that every navigable element of <YourComponent> has a tabIndex value.
  *
  * How does it work?
  * 1) It detects the first and last navigable elements according to the tabIndexes.
- * 2) It adds a Ref to these elements, in order to access the HTML native element.
- * 3) It listens to 'tab' or 'shift+tab' key presses:
+ * 2) In case of elements with same tabIndex
+ *   a) First element will be the first one found with min tabIndex
+ *   b) Last element will be the last one found with max tabIndex
+ * 3) It adds a Ref to these elements, in order to access the HTML native element.
+ * 4) It listens to 'tab' or 'shift+tab' key presses:
  *    a) If it's on the lastElement and listens to a 'tab', it focus the firstElement
  *    b) If it's on the firstElement and listens a 'shif+tab', it focus the lastElement
  *    c) Otherwise, it lets the browser handle it

--- a/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.jsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.jsx
@@ -3,22 +3,13 @@ import PropTypes from 'prop-types';
 import { withTaskContext } from '@twilio/flex-ui';
 import FaceIcon from '@material-ui/icons/Face';
 
-import { withLocalization } from '../contexts/LocalizationContext';
-import { Box, Row } from '../styles/HrmStyles';
-import {
-  Container,
-  Label,
-  DataCallTypeButton,
-  NonDataCallTypeButton,
-  CloseTaskDialog,
-  CloseTaskDialogText,
-  ConfirmButton,
-  CancelButton,
-  CloseButton,
-} from '../styles/callTypeButtons';
-import callTypes from '../states/DomainConstants';
-import { isNonDataCallType } from '../states/ValidationRules';
-import { formType, taskType, localizationType } from '../types';
+import { withLocalization } from '../../contexts/LocalizationContext';
+import { Box } from '../../styles/HrmStyles';
+import { Container, Label, DataCallTypeButton, NonDataCallTypeButton } from '../../styles/callTypeButtons';
+import callTypes from '../../states/DomainConstants';
+import { isNonDataCallType } from '../../states/ValidationRules';
+import { formType, taskType, localizationType } from '../../types';
+import NonDataCallTypeDialog from './NonDataCallTypeDialog';
 
 const isDialogOpen = form =>
   Boolean(form && form.callType && form.callType.value && isNonDataCallType(form.callType.value));
@@ -64,22 +55,12 @@ const CallTypeButtons = props => {
             ))}
         </Box>
       </Container>
-      <CloseTaskDialog onClose={() => clearCallType(props)} open={isDialogOpen(form)}>
-        <Box marginLeft="auto">
-          <CloseButton tabIndex={3} onClick={() => clearCallType(props)} />
-        </Box>
-        <CloseTaskDialogText>Are you sure?</CloseTaskDialogText>
-        <Box marginBottom="32px">
-          <Row>
-            <ConfirmButton autoFocus tabIndex={1} onClick={() => props.handleSubmit(task)}>
-              {isCallTask(task) ? strings.TaskHeaderEndCall : strings.TaskHeaderEndChat}
-            </ConfirmButton>
-            <CancelButton tabIndex={2} onClick={() => clearCallType(props)}>
-              Cancel
-            </CancelButton>
-          </Row>
-        </Box>
-      </CloseTaskDialog>
+      <NonDataCallTypeDialog
+        isOpen={isDialogOpen(form)}
+        confirmLabel={isCallTask(task) ? strings.TaskHeaderEndCall : strings.TaskHeaderEndChat}
+        handleConfirm={() => props.handleSubmit(task)}
+        handleCancel={() => clearCallType(props)}
+      />
     </>
   );
 };

--- a/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Box, Row } from '../../styles/HrmStyles';
+import {
+  CloseTaskDialog,
+  CloseTaskDialogText,
+  NonDataCallTypeDialogContainer,
+  ConfirmButton,
+  CancelButton,
+  CloseButton,
+} from '../../styles/callTypeButtons';
+import TabPressWrapper from '../TabPressWrapper';
+
+const NonDataCallTypeDialog = ({ isOpen, confirmLabel, handleConfirm, handleCancel }) => (
+  <CloseTaskDialog onClose={handleCancel} open={isOpen}>
+    <TabPressWrapper>
+      <NonDataCallTypeDialogContainer>
+        <Box marginLeft="auto">
+          <CloseButton tabIndex={3} onClick={handleCancel} />
+        </Box>
+        <CloseTaskDialogText>Are you sure?</CloseTaskDialogText>
+        <Box marginBottom="32px">
+          <Row>
+            <ConfirmButton autoFocus tabIndex={1} onClick={handleConfirm}>
+              {confirmLabel}
+            </ConfirmButton>
+            <CancelButton tabIndex={2} onClick={handleCancel}>
+              Cancel
+            </CancelButton>
+          </Row>
+        </Box>
+      </NonDataCallTypeDialogContainer>
+    </TabPressWrapper>
+  </CloseTaskDialog>
+);
+
+NonDataCallTypeDialog.displayName = 'NonDataCallTypeDialog';
+NonDataCallTypeDialog.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  confirmLabel: PropTypes.string.isRequired,
+  handleConfirm: PropTypes.func.isRequired,
+  handleCancel: PropTypes.func.isRequired,
+};
+
+export default NonDataCallTypeDialog;

--- a/plugin-hrm-form/src/components/callTypeButtons/index.js
+++ b/plugin-hrm-form/src/components/callTypeButtons/index.js
@@ -1,0 +1,3 @@
+import CallTypeButtons from './CallTypeButtons';
+
+export default CallTypeButtons;

--- a/plugin-hrm-form/src/components/search/SearchResults/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.jsx
@@ -17,6 +17,7 @@ import {
   CancelButton,
 } from '../../../styles/search';
 import callTypes from '../../../states/DomainConstants';
+import TabPressWrapper from '../../TabPressWrapper';
 
 class SearchResults extends Component {
   static displayName = 'SearchResults';
@@ -79,25 +80,27 @@ class SearchResults extends Component {
           horizontal: 'right',
         }}
       >
-        <ConfirmContainer>
-          <ConfirmText>{this.state.msg}</ConfirmText>
-          <Row>
-            <CancelButton tabIndex={2} variant="text" size="medium" onClick={handleClose}>
-              cancel
-            </CancelButton>
-            <Button
-              autoFocus
-              tabIndex={1}
-              variant="contained"
-              size="medium"
-              onClick={handleConfirm}
-              style={{ backgroundColor: '#000', color: '#fff', marginLeft: 20 }}
-            >
-              <CheckIcon />
-              yes, copy
-            </Button>
-          </Row>
-        </ConfirmContainer>
+        <TabPressWrapper>
+          <ConfirmContainer>
+            <ConfirmText>{this.state.msg}</ConfirmText>
+            <Row>
+              <CancelButton tabIndex={2} variant="text" size="medium" onClick={handleClose}>
+                cancel
+              </CancelButton>
+              <Button
+                autoFocus
+                tabIndex={1}
+                variant="contained"
+                size="medium"
+                onClick={handleConfirm}
+                style={{ backgroundColor: '#000', color: '#fff', marginLeft: 20 }}
+              >
+                <CheckIcon />
+                yes, copy
+              </Button>
+            </Row>
+          </ConfirmContainer>
+        </TabPressWrapper>
       </Popover>
     );
   };

--- a/plugin-hrm-form/src/styles/callTypeButtons/index.js
+++ b/plugin-hrm-form/src/styles/callTypeButtons/index.js
@@ -62,12 +62,15 @@ export const NonDataCallTypeButton = styled(Button)`
 
 export const CloseTaskDialog = styled(props => <Dialog {...props} classes={{ paper: 'paper' }} />)`
   && .paper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 5px;
     width: 350px;
   }
+`;
+
+export const NonDataCallTypeDialogContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 5px;
 `;
 
 export const CloseTaskDialogText = styled('p')`
@@ -80,6 +83,10 @@ export const ConfirmButton = styled(Button)`
   text-transform: uppercase;
   color: ${props => props.theme.colors.declineTextColor};
   ${p => getBackgroundWithHoverCSS(p.theme.colors.declineColor, true, false, p.disabled)};
+
+  &:focus {
+    box-shadow: rgba(0, 0, 0, 0.2) 0px 3px 3px 0px;
+  }
 `;
 
 export const CancelButton = styled(Button)`

--- a/plugin-hrm-form/src/utils/checkers.js
+++ b/plugin-hrm-form/src/utils/checkers.js
@@ -1,0 +1,1 @@
+export const isNullOrUndefined = element => element === null || typeof element === 'undefined';

--- a/plugin-hrm-form/src/utils/index.js
+++ b/plugin-hrm-form/src/utils/index.js
@@ -1,2 +1,3 @@
 export * from './formatters';
 export * from './mappers';
+export * from './checkers';


### PR DESCRIPTION
Implements `TabPressWrapper`, a component that handles `tab` and `shift+tab` key presses, and rotate the focus between the contained elements.

Usage:
```
<TabPressWrapper>
  <YourComponent />
</TabPressWrapper>
```

This PR:
- Implements `TabPressWrapper`
- Implement unit tests
