### PR TITLE
Small strings updates for Version 0.4

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -11,7 +11,7 @@ import HrmTheme from './styles/HrmTheme';
 import { channelTypes } from './states/DomainConstants';
 
 const PLUGIN_NAME = 'HrmFormPlugin';
-const PLUGIN_VERSION = '0.4.0';
+const PLUGIN_VERSION = '0.4.1';
 
 export default class HrmFormPlugin extends FlexPlugin {
   constructor() {
@@ -53,6 +53,8 @@ export default class HrmFormPlugin extends FlexPlugin {
     const getSsoToken = () => manager.store.getState().flex.session.ssoTokenPayload.token;
     const { strings } = manager;
     const { isCallTask } = TaskHelper;
+
+    strings.ChatWelcomeText = 'Conversation started';
 
     // TODO(nick): Eventually remove this log line or set to debug
     console.log(`HRM URL: ${hrmBaseUrl}`);

--- a/plugin-hrm-form/src/components/search/ContactDetails/Details.jsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/Details.jsx
@@ -153,7 +153,7 @@ const Details = ({ contact, handleOpenConnectDialog, handleMockedMessage }) => {
             { description: 'Keep Confidential?', value: keepConfidential },
             { description: 'OK for the case worker to call?', value: okForCaseWorkerToCall },
             { description: 'How did the child hear about us?', value: howDidTheChildHearAboutUs },
-            { description: 'Did you discuss right with the child?', value: didYouDiscussRightsWithTheChild },
+            { description: 'Did you discuss rights with the child?', value: didYouDiscussRightsWithTheChild },
             { description: 'Did the child feel we solved their problem?', value: didTheChildFeelWeSolvedTheirProblem },
             { description: 'Would the child recommend us to a friend?', value: wouldTheChildRecommendUsToAFriend },
           ]}

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -109,7 +109,7 @@ class SearchForm extends Component {
           <Row>
             <FieldText
               id="Search_CustomerPhoneNumber"
-              label="Customer phone"
+              label="Phone"
               field={getField(phoneNumber)}
               {...this.defaultEventHandlers('phoneNumber')}
               onKeyPress={submitOnEnter}


### PR DESCRIPTION
A few small text changes before release:
1. A typo on `ContactDetail`, "right" -> "rights"
![Screen Shot 2020-04-21 at 9 21 08 AM](https://user-images.githubusercontent.com/10714292/79892505-89a88d00-83b7-11ea-90b5-dd3ff1dcabaf.png)
2. Drop the term "Customer" from the search form:
![Screen Shot 2020-04-21 at 9 20 39 AM](https://user-images.githubusercontent.com/10714292/79892554-9b8a3000-83b7-11ea-9fa3-aec6aa62a4ed.png)
3. Drop the term "Customer" from the chat window message, "Conversation started with customer":
![Screen Shot 2020-04-21 at 9 20 21 AM](https://user-images.githubusercontent.com/10714292/79892632-b066c380-83b7-11ea-8f26-6a571e888771.png)

Helplines don't generally talk about the people who call in as customers, so we'll drop the term for now.

My biggest question on review is if I should make the `strings` change in another place.  `HrmFormPlugin#init` is getting quite big.

*Deployment*
* I've already deployed this to production so we can get screenshots for instructions
* After review I'll merge to master, then merge down to staging, then deploy staging.
