### PR TITLE
Implement accessibility test for NonDataCallTypeDialog

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -2816,6 +2816,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
+    "axe-core": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
+      "integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==",
+      "dev": true
+    },
     "axios": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
@@ -8975,6 +8981,105 @@
             "prompts": "^2.0.1",
             "realpath-native": "^1.1.0",
             "yargs": "^13.3.0"
+          }
+        }
+      }
+    },
+    "jest-axe": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-3.4.0.tgz",
+      "integrity": "sha512-iKAq/cBxvyizSkpSY+CTndsXy2v5IWAkYXqanPF6bGaGXJ3fEtzEWQRVeZ0SHCEbsjnvDaOly5nwiiDOz0suDw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.5.1",
+        "chalk": "^3.0.0",
+        "jest-matcher-utils": "^25.1.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.4.0.tgz",
+          "integrity": "sha512-XBeaWNzw2PPnGW5aXvZt3+VO60M+34RY3XDsCK5tW7kyj3RK0XClRutCfjqcBuaR2aBQTbluEDME9b5MB9UAPw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.4",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
+          "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.4.0.tgz",
+          "integrity": "sha512-kklLbJVXW0y8UKOWOdYhI6TH5MG6QAxrWiBMgQaPIuhj3dNFGirKCd+/xfplBXICQ7fI+3QcqHm9p9lWu1N6ug==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.4.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.4.0.tgz",
+          "integrity": "sha512-yPMdtj7YDgXhnGbc66bowk8AkQ0YwClbbwk3Kzhn5GVDrciiCr27U4NJRbrqXbTdtxjImONITg2LiRIw650k5A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "jest-diff": "^25.4.0",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.4.0"
+          }
+        },
+        "pretty-format": {
+          "version": "25.4.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.4.0.tgz",
+          "integrity": "sha512-PI/2dpGjXK5HyXexLPZU/jw5T9Q6S1YVXxxVxco+LIqzUFHXIbKZKdUVt7GcX7QUCr31+3fzhi4gN4/wUYPVxQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.4.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
           }
         }
       }

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -41,6 +41,7 @@
     "eslint": "^6.8.0",
     "eslint-config-twilio-react": "^1.21.0",
     "fromentries": "^1.2.0",
+    "jest-axe": "^3.4.0",
     "redux-mock-store": "^1.5.4"
   },
   "browserslist": {

--- a/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.js
+++ b/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import './mockStyled';
-import CallTypeButtons from '../components/callTypeButtons';
-import { DataCallTypeButton, NonDataCallTypeButton, ConfirmButton, CancelButton } from '../styles/callTypeButtons';
-import LocalizationContext from '../contexts/LocalizationContext';
-import callTypes from '../states/DomainConstants';
+import '../mockStyled';
+import CallTypeButtons from '../../components/callTypeButtons';
+import { DataCallTypeButton, NonDataCallTypeButton, ConfirmButton, CancelButton } from '../../styles/callTypeButtons';
+import LocalizationContext from '../../contexts/LocalizationContext';
+import callTypes from '../../states/DomainConstants';
 
 const task = {
   taskSid: 'task-sid',

--- a/plugin-hrm-form/src/___tests__/callTypeButtons/NonDataCallTypeDialog.test.js
+++ b/plugin-hrm-form/src/___tests__/callTypeButtons/NonDataCallTypeDialog.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { configureAxe, toHaveNoViolations } from 'jest-axe';
+import { mount } from 'enzyme';
+import { StorelessThemeProvider as MaterialStorelessThemeProvider } from '@twilio/flex-ui';
+
+import HrmTheme from '../../styles/HrmTheme';
+import NonDataCallTypeDialog from '../../components/callTypeButtons/NonDataCallTypeDialog';
+
+expect.extend(toHaveNoViolations);
+
+test('a11y', async () => {
+  const themeConf = {
+    colorTheme: HrmTheme,
+  };
+
+  const wrapper = mount(
+    <MaterialStorelessThemeProvider themeConf={themeConf}>
+      <NonDataCallTypeDialog
+        isOpen={true}
+        confirmLabel="End Chat"
+        handleConfirm={() => null}
+        handleCancel={() => null}
+      />
+    </MaterialStorelessThemeProvider>,
+  );
+
+  const rules = {
+    tabindex: { enabled: false },
+  };
+
+  const axe = configureAxe({ rules });
+  const results = await axe(wrapper.getDOMNode());
+
+  expect(results).toHaveNoViolations();
+});

--- a/plugin-hrm-form/src/___tests__/callTypeButtons/NonDataCallTypeDialog.test.js
+++ b/plugin-hrm-form/src/___tests__/callTypeButtons/NonDataCallTypeDialog.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { configureAxe, toHaveNoViolations } from 'jest-axe';
 import { mount } from 'enzyme';
-import { StorelessThemeProvider as MaterialStorelessThemeProvider } from '@twilio/flex-ui';
+import { StorelessThemeProvider } from '@twilio/flex-ui';
 
 import HrmTheme from '../../styles/HrmTheme';
 import NonDataCallTypeDialog from '../../components/callTypeButtons/NonDataCallTypeDialog';
@@ -14,14 +14,14 @@ test('a11y', async () => {
   };
 
   const wrapper = mount(
-    <MaterialStorelessThemeProvider themeConf={themeConf}>
+    <StorelessThemeProvider themeConf={themeConf}>
       <NonDataCallTypeDialog
         isOpen={true}
         confirmLabel="End Chat"
         handleConfirm={() => null}
         handleCancel={() => null}
       />
-    </MaterialStorelessThemeProvider>,
+    </StorelessThemeProvider>,
   );
 
   const rules = {

--- a/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
@@ -17,7 +17,7 @@ const NonDataCallTypeDialog = ({ isOpen, confirmLabel, handleConfirm, handleCanc
     <TabPressWrapper>
       <NonDataCallTypeDialogContainer>
         <Box marginLeft="auto">
-          <CloseButton tabIndex={3} onClick={handleCancel} />
+          <CloseButton tabIndex={3} aria-label="Close" onClick={handleCancel} />
         </Box>
         <CloseTaskDialogText>Are you sure?</CloseTaskDialogText>
         <Box marginBottom="32px">


### PR DESCRIPTION
This PR:
- Fix Accessibility issue of button without description on `NonDataCallTypeDialog`
- Creates an accessibility unit test for `NonDataCallTypeDialog`

Details:
1. `jest-axe` expects a DOM element as a parameter, so I had to use `enzyme` instead of `react-test-renderer` for this kind of test.
2. Notice that using Material's `StorelessThemeProvider` with our `HrmTheme` I didn't need to mock the `styled components`. I believe we can use the same approach in the other unit tests. Mocking `styled components` is currently a pain point in our development process.