### PR TITLE
Which queues does the counselor see?

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -66,7 +66,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     }
 
     flex.MainContainer.Content.add(
-      <QueuesStatusWriter insightsClient={manager.insightsClient} key="queue-status-writer" />,
+      <QueuesStatusWriter insightsClient={manager.insightsClient} key="queue-status-writer" helpline={helpline} />,
       {
         sortOrder: -1,
         align: 'start',
@@ -88,7 +88,6 @@ export default class HrmFormPlugin extends FlexPlugin {
           smsColor,
           whatsappColor,
         }}
-        helpline={helpline}
       />,
       {
         sortOrder: -1,

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -88,6 +88,7 @@ export default class HrmFormPlugin extends FlexPlugin {
           smsColor,
           whatsappColor,
         }}
+        helpline={helpline}
       />,
       {
         sortOrder: -1,

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
@@ -59,7 +59,7 @@ test('Test <QueuesStatus> with initial state', () => {
   expect(() => component.findByType(ErrorText)).not.toThrow();
 });
 
-test('Test <QueuesStatus> after update (with helpline)', () => {
+test('Test <QueuesStatus> after update', () => {
   const secondsAgo = new Date();
   const oneMinuteAgo = new Date(secondsAgo.getTime() - 60 * 1000);
   const twoMinutesAgo = new Date(oneMinuteAgo.getTime() - 60 * 1000);
@@ -74,68 +74,11 @@ test('Test <QueuesStatus> after update (with helpline)', () => {
     },
   };
 
-  const ownProps1 = { ...ownProps, helpline: 'Q1' };
-  const ownProps2 = { ...ownProps, helpline: 'Q2' };
-  const ownProps3 = { ...ownProps, helpline: 'Q3' };
-  const ownProps4 = { ...ownProps, helpline: 'Q4' };
-
   const queuesStatusState = {
     queuesStatus: {
       Q1: { facebook: 1, sms: 2, voice: 3, web: 4, whatsapp: 5, longestWaitingDate: secondsAgo.toISOString() },
       Q2: { facebook: 5, sms: 4, voice: 3, web: 2, whatsapp: 1, longestWaitingDate: oneMinuteAgo.toISOString() },
       Q3: { facebook: 2, sms: 2, voice: 2, web: 2, whatsapp: 2, longestWaitingDate: twoMinutesAgo.toISOString() },
-      Q4: { facebook: 0, sms: 0, voice: 0, web: 0, whatsapp: 0, longestWaitingDate: null },
-      Admin: { facebook: 9, sms: 9, voice: 9, web: 9, whatsapp: 9, longestWaitingDate: null },
-    },
-    error: null,
-    loading: true,
-  };
-  const initialState = createState(queuesStatusState);
-  const store = mockStore(initialState);
-
-  const [component1, component2, component3, component4] = [ownProps1, ownProps2, ownProps3, ownProps4].map(
-    props =>
-      renderer.create(
-        <StorelessThemeProvider themeConf={themeConf}>
-          <Provider store={store}>
-            <QueuesStatus {...props} />
-          </Provider>
-        </StorelessThemeProvider>,
-      ).root,
-  );
-
-  [component1, component2, component3, component4].forEach(component => {
-    expect(() => component.findAllByType(QueueCard)).not.toThrow();
-    expect(component.findAllByType(QueueCard)).toHaveLength(1);
-  });
-
-  const WaitTimeValue1 = component1.findByType(WaitTimeValue).props;
-  const WaitTimeValue2 = component2.findByType(WaitTimeValue).props;
-  const WaitTimeValue3 = component3.findByType(WaitTimeValue).props;
-  const WaitTimeValue4 = component4.findByType(WaitTimeValue).props;
-  expect(WaitTimeValue1.children).toBe('less than a minute');
-  expect(WaitTimeValue2.children).toBe('1 minute');
-  expect(WaitTimeValue3.children).toBe('2 minutes');
-  expect(WaitTimeValue4.children).toBe('none');
-});
-
-test('Test <QueuesStatus> with non existing helpline shows Admin', () => {
-  const ownProps = {
-    colors: {
-      voiceColor: { Accepted: '#000000' },
-      webColor: { Accepted: '#000000' },
-      facebookColor: { Accepted: '#000000' },
-      smsColor: { Accepted: '#000000' },
-      whatsappColor: { Accepted: '#000000' },
-    },
-    helpline: 'Non Existing',
-  };
-
-  const queuesStatusState = {
-    queuesStatus: {
-      Q1: { facebook: 1, sms: 2, voice: 3, web: 4, whatsapp: 5, longestWaitingDate: null },
-      Q2: { facebook: 5, sms: 4, voice: 3, web: 2, whatsapp: 1, longestWaitingDate: null },
-      Q3: { facebook: 2, sms: 2, voice: 2, web: 2, whatsapp: 2, longestWaitingDate: null },
       Q4: { facebook: 0, sms: 0, voice: 0, web: 0, whatsapp: 0, longestWaitingDate: null },
       Admin: { facebook: 9, sms: 9, voice: 9, web: 9, whatsapp: 9, longestWaitingDate: null },
     },
@@ -154,74 +97,21 @@ test('Test <QueuesStatus> with non existing helpline shows Admin', () => {
   ).root;
 
   expect(() => component.findAllByType(QueueCard)).not.toThrow();
-  const QueueCards = component.findAllByType(QueueCard);
-  expect(QueueCards).toHaveLength(1);
-  expect(QueueCards[0].props.facebook).toBe(9);
-  expect(QueueCards[0].props.sms).toBe(9);
-  expect(QueueCards[0].props.voice).toBe(9);
-  expect(QueueCards[0].props.web).toBe(9);
-  expect(QueueCards[0].props.whatsapp).toBe(9);
-  const WaitTimeValue1 = component.findByType(WaitTimeValue).props;
-  expect(WaitTimeValue1.children).toBe('none');
-});
+  const QueuesCards = component.findAllByType(QueueCard);
+  expect(QueuesCards).toHaveLength(5);
 
-test('Test <QueuesStatus> without helpline', () => {
-  const ownProps = {
-    colors: {
-      voiceColor: { Accepted: '#000000' },
-      webColor: { Accepted: '#000000' },
-      facebookColor: { Accepted: '#000000' },
-      smsColor: { Accepted: '#000000' },
-      whatsappColor: { Accepted: '#000000' },
-    },
-  };
-
-  const ownProps1 = { ...ownProps, helpline: '' };
-  const ownProps2 = { ...ownProps };
-
-  const queuesStatusState = {
-    queuesStatus: {
-      Q1: { facebook: 1, sms: 2, voice: 3, web: 4, whatsapp: 5, longestWaitingDate: null },
-      Q2: { facebook: 5, sms: 4, voice: 3, web: 2, whatsapp: 1, longestWaitingDate: null },
-      Q3: { facebook: 2, sms: 2, voice: 2, web: 2, whatsapp: 2, longestWaitingDate: null },
-      Q4: { facebook: 0, sms: 0, voice: 0, web: 0, whatsapp: 0, longestWaitingDate: null },
-      Admin: { facebook: 9, sms: 9, voice: 9, web: 9, whatsapp: 9, longestWaitingDate: null },
-    },
-    error: null,
-    loading: true,
-  };
-  const initialState = createState(queuesStatusState);
-  const store = mockStore(initialState);
-
-  const [component1, component2] = [ownProps1, ownProps2].map(
-    props =>
-      renderer.create(
-        <StorelessThemeProvider themeConf={themeConf}>
-          <Provider store={store}>
-            <QueuesStatus {...props} />
-          </Provider>
-        </StorelessThemeProvider>,
-      ).root,
-  );
-
-  [component1, component2].forEach(component => {
-    expect(() => component.findAllByType(QueueCard)).not.toThrow();
-    const QueueCards = component.findAllByType(QueueCard);
-    expect(QueueCards).toHaveLength(1);
-    expect(QueueCards[0].props.facebook).toBe(9);
-    expect(QueueCards[0].props.sms).toBe(9);
-    expect(QueueCards[0].props.voice).toBe(9);
-    expect(QueueCards[0].props.web).toBe(9);
-    expect(QueueCards[0].props.whatsapp).toBe(9);
-    const WaitTimeValue1 = component.findByType(WaitTimeValue).props;
-    expect(WaitTimeValue1.children).toBe('none');
-  });
+  const WaitTimeValue1 = QueuesCards[0].findByType(WaitTimeValue).props;
+  const WaitTimeValue2 = QueuesCards[1].findByType(WaitTimeValue).props;
+  const WaitTimeValue3 = QueuesCards[2].findByType(WaitTimeValue).props;
+  const WaitTimeValue4 = QueuesCards[3].findByType(WaitTimeValue).props;
+  expect(WaitTimeValue1.children).toBe('less than a minute');
+  expect(WaitTimeValue2.children).toBe('1 minute');
+  expect(WaitTimeValue3.children).toBe('2 minutes');
+  expect(WaitTimeValue4.children).toBe('none');
 });
 
 test('Test <QueuesStatus> after error', () => {
   const secondsAgo = new Date();
-  const oneMinuteAgo = new Date(secondsAgo.getTime() - 60 * 1000);
-  const twoMinutesAgo = new Date(oneMinuteAgo.getTime() - 60 * 1000);
 
   const ownProps = {
     colors: {
@@ -231,7 +121,6 @@ test('Test <QueuesStatus> after error', () => {
       smsColor: { Accepted: '#000000' },
       whatsappColor: { Accepted: '#000000' },
     },
-    helpline: '',
   };
   const queuesStatusState = {
     queuesStatus: {
@@ -251,7 +140,8 @@ test('Test <QueuesStatus> after error', () => {
       </Provider>
     </StorelessThemeProvider>,
   ).root;
-  expect(() => component.findByType(QueueCard)).not.toThrow();
+
+  expect(() => component.findAllByType(QueueCard)).not.toThrow();
   expect(() => component.findByType(ErrorText)).not.toThrow();
   const ErrorProps = component.findByType(ErrorText).props;
   expect(ErrorProps.children).toBe(queuesStatusState.error);

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
@@ -119,6 +119,44 @@ test('Test <QueuesStatus> after update (with helpline)', () => {
   expect(WaitTimeValue4.children).toBe('none');
 });
 
+test('Test <QueuesStatus> with non existing helpline', () => {
+  const ownProps = {
+    colors: {
+      voiceColor: { Accepted: '#000000' },
+      webColor: { Accepted: '#000000' },
+      facebookColor: { Accepted: '#000000' },
+      smsColor: { Accepted: '#000000' },
+      whatsappColor: { Accepted: '#000000' },
+    },
+    helpline: 'Non Existing',
+  };
+
+  const queuesStatusState = {
+    queuesStatus: {
+      Q1: { facebook: 1, sms: 2, voice: 3, web: 4, whatsapp: 5, longestWaitingDate: null },
+      Q2: { facebook: 5, sms: 4, voice: 3, web: 2, whatsapp: 1, longestWaitingDate: null },
+      Q3: { facebook: 2, sms: 2, voice: 2, web: 2, whatsapp: 2, longestWaitingDate: null },
+      Q4: { facebook: 0, sms: 0, voice: 0, web: 0, whatsapp: 0, longestWaitingDate: null },
+      Admin: { facebook: 9, sms: 9, voice: 9, web: 9, whatsapp: 9, longestWaitingDate: null },
+    },
+    error: null,
+    loading: true,
+  };
+  const initialState = createState(queuesStatusState);
+  const store = mockStore(initialState);
+
+  const component = renderer.create(
+    <StorelessThemeProvider themeConf={themeConf}>
+      <Provider store={store}>
+        <QueuesStatus {...ownProps} />
+      </Provider>
+    </StorelessThemeProvider>,
+  ).root;
+
+  expect(() => component.findByType(QueueCard)).toThrow();
+  expect(() => component.findByType(ErrorText)).toThrow();
+});
+
 test('Test <QueuesStatus> without helpline', () => {
   const ownProps = {
     colors: {

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
@@ -215,7 +215,7 @@ test('Test <QueuesStatus> without helpline', () => {
     expect(QueueCards[0].props.whatsapp).toBe(9);
     const WaitTimeValue1 = component.findByType(WaitTimeValue).props;
     expect(WaitTimeValue1.children).toBe('none');
-  })
+  });
 });
 
 test('Test <QueuesStatus> after error', () => {

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
@@ -174,8 +174,10 @@ test('Test <QueuesStatus> without helpline', () => {
       smsColor: { Accepted: '#000000' },
       whatsappColor: { Accepted: '#000000' },
     },
-    helpline: '',
   };
+
+  const ownProps1 = { ...ownProps, helpline: '' };
+  const ownProps2 = { ...ownProps };
 
   const queuesStatusState = {
     queuesStatus: {
@@ -191,24 +193,29 @@ test('Test <QueuesStatus> without helpline', () => {
   const initialState = createState(queuesStatusState);
   const store = mockStore(initialState);
 
-  const component = renderer.create(
-    <StorelessThemeProvider themeConf={themeConf}>
-      <Provider store={store}>
-        <QueuesStatus {...ownProps} />
-      </Provider>
-    </StorelessThemeProvider>,
-  ).root;
+  const [component1, component2] = [ownProps1, ownProps2].map(
+    props =>
+      renderer.create(
+        <StorelessThemeProvider themeConf={themeConf}>
+          <Provider store={store}>
+            <QueuesStatus {...props} />
+          </Provider>
+        </StorelessThemeProvider>,
+      ).root,
+  );
 
-  expect(() => component.findAllByType(QueueCard)).not.toThrow();
-  const QueueCards = component.findAllByType(QueueCard);
-  expect(QueueCards).toHaveLength(1);
-  expect(QueueCards[0].props.facebook).toBe(9);
-  expect(QueueCards[0].props.sms).toBe(9);
-  expect(QueueCards[0].props.voice).toBe(9);
-  expect(QueueCards[0].props.web).toBe(9);
-  expect(QueueCards[0].props.whatsapp).toBe(9);
-  const WaitTimeValue1 = component.findByType(WaitTimeValue).props;
-  expect(WaitTimeValue1.children).toBe('none');
+  [component1, component2].forEach(component => {
+    expect(() => component.findAllByType(QueueCard)).not.toThrow();
+    const QueueCards = component.findAllByType(QueueCard);
+    expect(QueueCards).toHaveLength(1);
+    expect(QueueCards[0].props.facebook).toBe(9);
+    expect(QueueCards[0].props.sms).toBe(9);
+    expect(QueueCards[0].props.voice).toBe(9);
+    expect(QueueCards[0].props.web).toBe(9);
+    expect(QueueCards[0].props.whatsapp).toBe(9);
+    const WaitTimeValue1 = component.findByType(WaitTimeValue).props;
+    expect(WaitTimeValue1.children).toBe('none');
+  })
 });
 
 test('Test <QueuesStatus> after error', () => {

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatus.test.js
@@ -119,7 +119,7 @@ test('Test <QueuesStatus> after update (with helpline)', () => {
   expect(WaitTimeValue4.children).toBe('none');
 });
 
-test('Test <QueuesStatus> with non existing helpline', () => {
+test('Test <QueuesStatus> with non existing helpline shows Admin', () => {
   const ownProps = {
     colors: {
       voiceColor: { Accepted: '#000000' },
@@ -153,8 +153,16 @@ test('Test <QueuesStatus> with non existing helpline', () => {
     </StorelessThemeProvider>,
   ).root;
 
-  expect(() => component.findByType(QueueCard)).toThrow();
-  expect(() => component.findByType(ErrorText)).toThrow();
+  expect(() => component.findAllByType(QueueCard)).not.toThrow();
+  const QueueCards = component.findAllByType(QueueCard);
+  expect(QueueCards).toHaveLength(1);
+  expect(QueueCards[0].props.facebook).toBe(9);
+  expect(QueueCards[0].props.sms).toBe(9);
+  expect(QueueCards[0].props.voice).toBe(9);
+  expect(QueueCards[0].props.web).toBe(9);
+  expect(QueueCards[0].props.whatsapp).toBe(9);
+  const WaitTimeValue1 = component.findByType(WaitTimeValue).props;
+  expect(WaitTimeValue1.children).toBe('none');
 });
 
 test('Test <QueuesStatus> without helpline', () => {

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
@@ -1,0 +1,232 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { QueuesStatusWriter } from '../../../components/queuesStatus/QueuesStatusWriter';
+import { channelTypes } from '../../../states/DomainConstants';
+import { newQueueEntry, initializeQueuesStatus, getNewQueuesStatus } from '../../../components/queuesStatus/helpers';
+
+console.log = jest.fn();
+console.error = jest.fn();
+
+const queues = { Q1: { queue_name: 'Q1' }, Admin: { queue_name: 'Admin' } };
+
+const secondsAgo = new Date();
+const oneMinuteAgo = new Date(secondsAgo.getTime() - 60 * 1000);
+const twoMinutesAgo = new Date(oneMinuteAgo.getTime() - 60 * 1000);
+
+const tasks = {
+  T1: {
+    status: 'pending',
+    date_created: oneMinuteAgo,
+    channel_type: channelTypes.voice,
+    queue_name: 'Admin',
+    attributes: { channelType: undefined },
+  },
+  T2: {
+    status: 'pending',
+    date_created: twoMinutesAgo,
+    queue_name: 'Q1',
+    attributes: { channelType: channelTypes.web },
+  },
+  T3: {
+    status: 'pending',
+    date_created: twoMinutesAgo,
+    queue_name: 'Admin',
+    attributes: { channelType: channelTypes.facebook },
+  },
+};
+
+const newTasks = {
+  T4: {
+    status: 'pending',
+    date_created: secondsAgo,
+    queue_name: 'Q1',
+    attributes: { channelType: channelTypes.whatsapp },
+  },
+  T5: {
+    status: 'pending',
+    date_created: secondsAgo,
+    queue_name: 'Admin',
+    attributes: { channelType: channelTypes.sms },
+  },
+};
+
+const clearQueuesStatus = initializeQueuesStatus(Object.keys(queues));
+const queuesStatus = getNewQueuesStatus(clearQueuesStatus, tasks);
+const newQueuesStatus = getNewQueuesStatus(clearQueuesStatus, { ...tasks, ...newTasks });
+
+test('Test <QueuesStatusWriter> should suscribe to Admin queue only', () => {
+  const events = {};
+
+  const innerTasks = {};
+  innerTasks.T1 = tasks.T1;
+  innerTasks.T2 = tasks.T2;
+  innerTasks.T3 = tasks.T3;
+
+  const queuesQuery = { getItems: () => queues, close: () => undefined };
+  const tasksQuery = {
+    getItems: () => innerTasks,
+    on: jest.fn((event, cb) => {
+      events[event] = cb;
+    }),
+  };
+
+  const spy = jest.spyOn(QueuesStatusWriter.prototype, 'updateQueuesState');
+
+  const ownProps = {
+    insightsClient: {
+      liveQuery: jest.fn((query, _) => {
+        if (query === 'tr-queue') {
+          return new Promise(resolve => resolve(queuesQuery));
+        }
+        if (query === 'tr-task') {
+          return new Promise(resolve => resolve(tasksQuery));
+        }
+
+        return undefined;
+      }),
+    },
+  };
+
+  const queuesStatusState = {
+    queuesStatus: null,
+    error: 'Not initialized',
+    loading: true,
+  };
+  const queuesStatusUpdate = jest.fn();
+  const queuesStatusFailure = jest.fn();
+  const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
+
+  const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
+
+  return Promise.resolve(mounted)
+    .then(() => undefined)
+    .then(() => {
+      expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(tasksQuery, { Admin: newQueueEntry });
+      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: queuesStatus.Admin });
+      expect(queuesStatusFailure).not.toHaveBeenCalled();
+
+      spy.mockClear();
+      queuesStatusUpdate.mockClear();
+
+      // simulate new state
+      innerTasks.T4 = newTasks.T4;
+      innerTasks.T5 = newTasks.T5;
+
+      // simulate events
+      events.itemUpdated({ value: newTasks.T4 });
+      expect(queuesStatusUpdate).not.toHaveBeenCalled();
+
+      events.itemUpdated({ value: newTasks.T5 });
+      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: newQueuesStatus.Admin });
+    });
+});
+
+test('Test <QueuesStatusWriter> should suscribe to Q1 queue only', () => {
+  const events = {};
+
+  const innerTasks = {};
+  innerTasks.T1 = tasks.T1;
+  innerTasks.T2 = tasks.T2;
+  innerTasks.T3 = tasks.T3;
+
+  const queuesQuery = { getItems: () => queues, close: () => undefined };
+  const tasksQuery = {
+    getItems: () => innerTasks,
+    on: jest.fn((event, cb) => {
+      events[event] = cb;
+    }),
+  };
+
+  const spy = jest.spyOn(QueuesStatusWriter.prototype, 'updateQueuesState');
+
+  const ownProps = {
+    insightsClient: {
+      liveQuery: jest.fn((query, _) => {
+        if (query === 'tr-queue') {
+          return new Promise(resolve => resolve(queuesQuery));
+        }
+        if (query === 'tr-task') {
+          return new Promise(resolve => resolve(tasksQuery));
+        }
+
+        return undefined;
+      }),
+    },
+    helpline: 'Q1',
+  };
+
+  const queuesStatusState = {
+    queuesStatus: null,
+    error: 'Not initialized',
+    loading: true,
+  };
+  const queuesStatusUpdate = jest.fn();
+  const queuesStatusFailure = jest.fn();
+  const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
+
+  const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
+
+  return Promise.resolve(mounted)
+    .then(() => undefined)
+    .then(() => {
+      expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith(tasksQuery, { Q1: newQueueEntry });
+      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: queuesStatus.Q1 });
+      expect(queuesStatusFailure).not.toHaveBeenCalled();
+
+      spy.mockClear();
+      queuesStatusUpdate.mockClear();
+
+      // simulate new state
+      innerTasks.T4 = newTasks.T4;
+      innerTasks.T5 = newTasks.T5;
+
+      // simulate events
+      events.itemUpdated({ value: newTasks.T5 });
+      expect(queuesStatusUpdate).not.toHaveBeenCalled();
+
+      events.itemUpdated({ value: newTasks.T4 });
+      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: newQueuesStatus.Q1 });
+    });
+});
+
+test('Test <QueuesStatusWriter> should fail', () => {
+  const ownProps = {
+    insightsClient: {
+      liveQuery: jest.fn((query, _) => {
+        if (query === 'tr-queue') {
+          return new Promise((resolve, reject) => reject(new Error('Some error')));
+        }
+        if (query === 'tr-task') {
+          return new Promise((resolve, reject) => reject(new Error('Some error')));
+        }
+
+        return undefined;
+      }),
+    },
+  };
+
+  const queuesStatusState = {
+    queuesStatus: null,
+    error: 'Not initialized',
+    loading: true,
+  };
+  const queuesStatusUpdate = jest.fn();
+  const queuesStatusFailure = jest.fn();
+  const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
+
+  const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
+
+  return (
+    Promise.resolve(mounted)
+      // .then(() => undefined) fails on the 1st await so we need only 1 then clause
+      .then(() => {
+        expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(1);
+        expect(queuesStatusFailure).toHaveBeenCalledWith("Error, couldn't subscribe to live updates");
+        expect(queuesStatusUpdate).not.toHaveBeenCalled();
+      })
+  );
+});

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
@@ -118,6 +118,8 @@ describe('QueuesStatusWriter should subscribe to Admin queue only', () => {
   });
 
   test('Test events', () => {
+    expect(mounted.state().trackedTasks).toStrictEqual({ T1: true, T3: true });
+
     // simulate new state (adding tasks)
     innerTasks.T4 = newTasks.T4;
     innerTasks.T5 = newTasks.T5;
@@ -128,6 +130,7 @@ describe('QueuesStatusWriter should subscribe to Admin queue only', () => {
 
     events.itemUpdated({ key: 'T5', value: newTasks.T5 });
     expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: newQueuesStatus.Admin });
+    expect(mounted.state().trackedTasks).toStrictEqual({ T1: true, T3: true, T5: true });
 
     spy.mockClear();
     queuesStatusUpdate.mockClear();
@@ -142,6 +145,7 @@ describe('QueuesStatusWriter should subscribe to Admin queue only', () => {
 
     events.itemRemoved({ key: 'T1' });
     expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: afterDeleteQueuesStatus.Admin });
+    expect(mounted.state().trackedTasks).toStrictEqual({ T3: true, T5: true });
   });
 
   test('Test unmount', () => {
@@ -212,6 +216,8 @@ describe('QueuesStatusWriter should subscribe to Q1 queue only', () => {
   });
 
   test('Test events', () => {
+    expect(mounted.state().trackedTasks).toStrictEqual({ T2: true });
+
     // simulate new state
     innerTasks.T4 = newTasks.T4;
     innerTasks.T5 = newTasks.T5;
@@ -220,8 +226,9 @@ describe('QueuesStatusWriter should subscribe to Q1 queue only', () => {
     events.itemUpdated({ value: newTasks.T5 });
     expect(queuesStatusUpdate).not.toHaveBeenCalled();
 
-    events.itemUpdated({ value: newTasks.T4 });
+    events.itemUpdated({ key: 'T4', value: newTasks.T4 });
     expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: newQueuesStatus.Q1 });
+    expect(mounted.state().trackedTasks).toStrictEqual({ T2: true, T4: true });
 
     spy.mockClear();
     queuesStatusUpdate.mockClear();
@@ -236,6 +243,7 @@ describe('QueuesStatusWriter should subscribe to Q1 queue only', () => {
 
     events.itemRemoved({ key: 'T2' });
     expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: afterDeleteQueuesStatus.Q1 });
+    expect(mounted.state().trackedTasks).toStrictEqual({ T4: true });
   });
 
   test('Test unmount', () => {

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
@@ -57,7 +57,7 @@ const queuesStatus = getNewQueuesStatus(clearQueuesStatus, tasks);
 const newQueuesStatus = getNewQueuesStatus(clearQueuesStatus, { ...tasks, ...newTasks });
 const afterDeleteQueuesStatus = getNewQueuesStatus(clearQueuesStatus, { T3: tasks.T3, ...newTasks });
 
-test('Test <QueuesStatusWriter> should suscribe to Admin queue only', () => {
+describe('QueuesStatusWriter should subscribe to Admin queue only', () => {
   const events = {};
 
   const innerTasks = {};
@@ -80,10 +80,10 @@ test('Test <QueuesStatusWriter> should suscribe to Admin queue only', () => {
     insightsClient: {
       liveQuery: jest.fn((query, _) => {
         if (query === 'tr-queue') {
-          return new Promise(resolve => resolve(queuesQuery));
+          return Promise.resolve(queuesQuery);
         }
         if (query === 'tr-task') {
-          return new Promise(resolve => resolve(tasksQuery));
+          return Promise.resolve(tasksQuery);
         }
 
         return undefined;
@@ -100,51 +100,57 @@ test('Test <QueuesStatusWriter> should suscribe to Admin queue only', () => {
   const queuesStatusFailure = jest.fn();
   const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
 
-  const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
+  let mounted;
+  test('Test mount', async () => {
+    mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
 
-  return Promise.resolve(mounted)
-    .then(() => undefined)
-    .then(() => {
-      expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(2);
-      expect(spy).toHaveBeenCalledWith(tasksQuery.getItems(), { Admin: newQueueEntry });
-      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: queuesStatus.Admin });
-      expect(queuesStatusFailure).not.toHaveBeenCalled();
-      expect(mounted.state('tasksQuery')).not.toBeNull();
+    await Promise.resolve(); // resolves queuesQuery
+    await Promise.resolve(); // resolves tasksQuery
 
-      spy.mockClear();
-      queuesStatusUpdate.mockClear();
+    expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith(tasksQuery.getItems(), { Admin: newQueueEntry });
+    expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: queuesStatus.Admin });
+    expect(queuesStatusFailure).not.toHaveBeenCalled();
+    expect(mounted.state('tasksQuery')).not.toBeNull();
 
-      // simulate new state (adding tasks)
-      innerTasks.T4 = newTasks.T4;
-      innerTasks.T5 = newTasks.T5;
+    spy.mockClear();
+    queuesStatusUpdate.mockClear();
+  });
 
-      // simulate update events
-      events.itemUpdated({ key: 'T4', value: newTasks.T4 });
-      expect(queuesStatusUpdate).not.toHaveBeenCalled();
+  test('Test events', () => {
+    // simulate new state (adding tasks)
+    innerTasks.T4 = newTasks.T4;
+    innerTasks.T5 = newTasks.T5;
 
-      events.itemUpdated({ key: 'T5', value: newTasks.T5 });
-      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: newQueuesStatus.Admin });
+    // simulate update events
+    events.itemUpdated({ key: 'T4', value: newTasks.T4 });
+    expect(queuesStatusUpdate).not.toHaveBeenCalled();
 
-      spy.mockClear();
-      queuesStatusUpdate.mockClear();
+    events.itemUpdated({ key: 'T5', value: newTasks.T5 });
+    expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: newQueuesStatus.Admin });
 
-      // simulate new state (removing tasks)
-      delete innerTasks.T1;
-      delete innerTasks.T2;
+    spy.mockClear();
+    queuesStatusUpdate.mockClear();
 
-      // simulate removed events
-      events.itemRemoved({ key: 'T2' });
-      expect(queuesStatusUpdate).not.toHaveBeenCalled();
+    // simulate new state (removing tasks)
+    delete innerTasks.T1;
+    delete innerTasks.T2;
 
-      events.itemRemoved({ key: 'T1' });
-      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: afterDeleteQueuesStatus.Admin });
+    // simulate removed events
+    events.itemRemoved({ key: 'T2' });
+    expect(queuesStatusUpdate).not.toHaveBeenCalled();
 
-      mounted.unmount();
-      expect(tasksQuery.close).toBeCalled();
-    });
+    events.itemRemoved({ key: 'T1' });
+    expect(queuesStatusUpdate).toHaveBeenCalledWith({ Admin: afterDeleteQueuesStatus.Admin });
+  });
+
+  test('Test unmount', () => {
+    mounted.unmount();
+    expect(tasksQuery.close).toBeCalled();
+  });
 });
 
-test('Test <QueuesStatusWriter> should suscribe to Q1 queue only', () => {
+describe('QueuesStatusWriter should subscribe to Q1 queue only', () => {
   const events = {};
 
   const innerTasks = {};
@@ -167,10 +173,10 @@ test('Test <QueuesStatusWriter> should suscribe to Q1 queue only', () => {
     insightsClient: {
       liveQuery: jest.fn((query, _) => {
         if (query === 'tr-queue') {
-          return new Promise(resolve => resolve(queuesQuery));
+          return Promise.resolve(queuesQuery);
         }
         if (query === 'tr-task') {
-          return new Promise(resolve => resolve(tasksQuery));
+          return Promise.resolve(tasksQuery);
         }
 
         return undefined;
@@ -188,85 +194,127 @@ test('Test <QueuesStatusWriter> should suscribe to Q1 queue only', () => {
   const queuesStatusFailure = jest.fn();
   const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
 
-  const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
+  let mounted;
+  test('Test mount', async () => {
+    mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
 
-  return Promise.resolve(mounted)
-    .then(() => undefined)
-    .then(() => {
-      expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(2);
-      expect(spy).toHaveBeenCalledWith(tasksQuery.getItems(), { Q1: newQueueEntry });
-      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: queuesStatus.Q1 });
-      expect(queuesStatusFailure).not.toHaveBeenCalled();
-      expect(mounted.state('tasksQuery')).not.toBeNull();
+    await Promise.resolve(); // resolves queuesQuery
+    await Promise.resolve(); // resolves tasksQuery    .then(() => undefined)
 
-      spy.mockClear();
-      queuesStatusUpdate.mockClear();
+    expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledWith(tasksQuery.getItems(), { Q1: newQueueEntry });
+    expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: queuesStatus.Q1 });
+    expect(queuesStatusFailure).not.toHaveBeenCalled();
+    expect(mounted.state('tasksQuery')).not.toBeNull();
 
-      // simulate new state
-      innerTasks.T4 = newTasks.T4;
-      innerTasks.T5 = newTasks.T5;
+    spy.mockClear();
+    queuesStatusUpdate.mockClear();
+  });
 
-      // simulate events
-      events.itemUpdated({ value: newTasks.T5 });
-      expect(queuesStatusUpdate).not.toHaveBeenCalled();
+  test('Test events', () => {
+    // simulate new state
+    innerTasks.T4 = newTasks.T4;
+    innerTasks.T5 = newTasks.T5;
 
-      events.itemUpdated({ value: newTasks.T4 });
-      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: newQueuesStatus.Q1 });
+    // simulate events
+    events.itemUpdated({ value: newTasks.T5 });
+    expect(queuesStatusUpdate).not.toHaveBeenCalled();
 
-      spy.mockClear();
-      queuesStatusUpdate.mockClear();
+    events.itemUpdated({ value: newTasks.T4 });
+    expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: newQueuesStatus.Q1 });
 
-      // simulate new state (removing tasks)
-      delete innerTasks.T1;
-      delete innerTasks.T2;
+    spy.mockClear();
+    queuesStatusUpdate.mockClear();
 
-      // simulate removed events
-      events.itemRemoved({ key: 'T1' });
-      expect(queuesStatusUpdate).not.toHaveBeenCalled();
+    // simulate new state (removing tasks)
+    delete innerTasks.T1;
+    delete innerTasks.T2;
 
-      events.itemRemoved({ key: 'T2' });
-      expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: afterDeleteQueuesStatus.Q1 });
+    // simulate removed events
+    events.itemRemoved({ key: 'T1' });
+    expect(queuesStatusUpdate).not.toHaveBeenCalled();
 
-      mounted.unmount();
-      expect(tasksQuery.close).toBeCalled();
-    });
+    events.itemRemoved({ key: 'T2' });
+    expect(queuesStatusUpdate).toHaveBeenCalledWith({ Q1: afterDeleteQueuesStatus.Q1 });
+  });
+
+  test('Test unmount', () => {
+    mounted.unmount();
+    expect(tasksQuery.close).toBeCalled();
+  });
 });
 
-test('Test <QueuesStatusWriter> should fail', () => {
-  const ownProps = {
-    insightsClient: {
-      liveQuery: jest.fn((query, _) => {
-        if (query === 'tr-queue') {
-          return new Promise((resolve, reject) => reject(new Error('Some error')));
-        }
-        if (query === 'tr-task') {
-          return new Promise((resolve, reject) => reject(new Error('Some error')));
-        }
+describe('QueuesStatusWriter should fail trying to subscribe', () => {
+  test('Test fail on queuesQuery', async () => {
+    const ownProps = {
+      insightsClient: {
+        liveQuery: jest.fn((query, _) => {
+          if (query === 'tr-queue') {
+            return Promise.reject(new Error('Some error'));
+          }
+          if (query === 'tr-task') {
+            return Promise.reject(new Error('Some error'));
+          }
 
-        return undefined;
-      }),
-    },
-  };
+          return undefined;
+        }),
+      },
+    };
 
-  const queuesStatusState = {
-    queuesStatus: null,
-    error: 'Not initialized',
-    loading: true,
-  };
-  const queuesStatusUpdate = jest.fn();
-  const queuesStatusFailure = jest.fn();
-  const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
+    const queuesStatusState = {
+      queuesStatus: null,
+      error: 'Not initialized',
+      loading: true,
+    };
+    const queuesStatusUpdate = jest.fn();
+    const queuesStatusFailure = jest.fn();
+    const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
 
-  const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
+    const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
 
-  return (
-    Promise.resolve(mounted)
-      // .then(() => undefined) fails on the 1st await so we need only 1 then clause
-      .then(() => {
-        expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(1);
-        expect(queuesStatusFailure).toHaveBeenCalledWith("Error, couldn't subscribe to live updates");
-        expect(queuesStatusUpdate).not.toHaveBeenCalled();
-        expect(mounted.state('tasksQuery')).toBeNull();
-      })
-  );
+    await Promise.resolve(); // resolves queuesQuery
+
+    expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(1);
+    expect(queuesStatusFailure).toHaveBeenCalledWith("Error, couldn't subscribe to live updates");
+    expect(queuesStatusUpdate).not.toHaveBeenCalled();
+    expect(mounted.state('tasksQuery')).toBeNull();
+  });
+
+  test('Test fail on tasksQuery', async () => {
+    const queuesQuery = { getItems: () => queues, close: jest.fn() };
+
+    const ownProps = {
+      insightsClient: {
+        liveQuery: jest.fn((query, _) => {
+          if (query === 'tr-queue') {
+            return Promise.resolve(queuesQuery);
+          }
+          if (query === 'tr-task') {
+            return Promise.reject(new Error('Some error'));
+          }
+
+          return undefined;
+        }),
+      },
+    };
+
+    const queuesStatusState = {
+      queuesStatus: null,
+      error: 'Not initialized',
+      loading: true,
+    };
+    const queuesStatusUpdate = jest.fn();
+    const queuesStatusFailure = jest.fn();
+    const reduxProps = { queuesStatusState, queuesStatusUpdate, queuesStatusFailure };
+
+    const mounted = mount(<QueuesStatusWriter {...ownProps} {...reduxProps} />);
+
+    await Promise.resolve(); // resolves queuesQuery
+    await Promise.resolve(); // resolves tasksQuery
+
+    expect(ownProps.insightsClient.liveQuery).toHaveBeenCalledTimes(2);
+    expect(queuesStatusFailure).toHaveBeenCalledWith("Error, couldn't subscribe to live updates");
+    expect(queuesStatusUpdate).not.toHaveBeenCalled();
+    expect(mounted.state('tasksQuery')).toBeNull();
+  });
 });

--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/helpers.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/helpers.test.js
@@ -17,14 +17,10 @@ test('Test newQueueEntry', () => {
 const queuesNames = ['Queue One', 'Queue Two', 'Queue Nine Nine'];
 let cleanQueuesStatus;
 test('Test initializeQueuesStatus', () => {
-  const queues = {
-    Q1: { queue_name: queuesNames[0] },
-    Q2: { queue_name: queuesNames[1] },
-    Q99: { queue_name: queuesNames[2] },
-  };
+  const counselorQueues = [...queuesNames];
+  const result = initializeQueuesStatus(counselorQueues);
 
-  const result = initializeQueuesStatus(queues);
-
+  expect(Object.keys(result)).toHaveLength(3);
   Object.keys(result).forEach(key => {
     expect(result[key]).toStrictEqual(newQueueEntry);
     expect(queuesNames.some(item => item === key)).toBeTruthy();

--- a/plugin-hrm-form/src/components/queuesStatus/QueueCard.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/QueueCard.jsx
@@ -93,8 +93,8 @@ class QueuesCard extends React.PureComponent {
 
     return (
       <>
-        <Box paddingLeft="10px" paddingTop="10px" tabIndex={0}>
-          <HiddenText>Contacts waiting. Queue name:</HiddenText>
+        <Box paddingLeft="10px" paddingTop="10px">
+          <HiddenText aria-label="Queue name:" />
           <QueueName>{qName}</QueueName>
           <Box marginTop="7px" marginBottom="14px">
             <Row>

--- a/plugin-hrm-form/src/components/queuesStatus/QueueCard.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/QueueCard.jsx
@@ -94,7 +94,7 @@ class QueuesCard extends React.PureComponent {
     return (
       <>
         <Box paddingLeft="10px" paddingTop="10px" tabIndex={0}>
-          <HiddenText>Queue name:</HiddenText>
+          <HiddenText>Contacts waiting. Queue name:</HiddenText>
           <QueueName>{qName}</QueueName>
           <Box marginTop="7px" marginBottom="14px">
             <Row>

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.js
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.js
@@ -25,8 +25,8 @@ const isNotWaiting = status => status !== 'pending' && status !== 'reserved';
 const suscribedToQueue = (queue, queues) => Boolean(queues[queue]);
 
 /**
- * Checks if a task is waiting and if counselor is suscribed to task queue (using information from cleanQueuesStatus)
  * Adds each waiting tasks to the appropiate queue and channel, recording which is the oldest
+ * If counselor is not suscribed to a queue, acc[queue] will be undefined
  * @returns {{ [qName: string]: typeof newQueueEntry }}
  */
 export const addPendingTasks = (acc, task) => {

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.js
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.js
@@ -14,21 +14,23 @@ export const newQueueEntry = {
 };
 
 /**
- * @param {{ [s: string]: { queue_name: string }; }} queues
- * @returns {{ [queue_name: string]: typeof newQueueEntry }}
+ * @param {string[]} queues
+ * @returns {{ [qName: string]: typeof newQueueEntry }}
  */
 export const initializeQueuesStatus = queues =>
-  Object.values(queues)
-    // eslint-disable-next-line no-nested-ternary
-    .sort((a, b) => (a.queue_name < b.queue_name ? -1 : a.queue_name > b.queue_name ? 1 : 0))
-    .reduce((acc, q) => ({ ...acc, [q.queue_name]: newQueueEntry }), {});
+  // eslint-disable-next-line no-nested-ternary
+  queues.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).reduce((acc, qName) => ({ ...acc, [qName]: newQueueEntry }), {});
+
+const isNotWaiting = status => status !== 'pending' && status !== 'reserved';
+const suscribedToQueue = (queue, queues) => Boolean(queues[queue]);
 
 /**
- * Adds each pending tasks to the appropiate queue and channel, recording which is the oldest
- * @returns {{ [queue_name: string]: typeof newQueueEntry }}
+ * Checks if a task is waiting and if counselor is suscribed to task queue (using information from cleanQueuesStatus)
+ * Adds each waiting tasks to the appropiate queue and channel, recording which is the oldest
+ * @returns {{ [qName: string]: typeof newQueueEntry }}
  */
 export const addPendingTasks = (acc, task) => {
-  if (task.status !== 'pending' && task.status !== 'reserved') return acc;
+  if (isNotWaiting(task.status) || !suscribedToQueue(task.queue_name, acc)) return acc;
 
   const created = task.date_created;
   const channel = task.channel_type === 'voice' ? 'voice' : task.attributes.channelType;
@@ -47,7 +49,7 @@ export const addPendingTasks = (acc, task) => {
 };
 
 /**
- * @returns {{ [queue_name: string]: typeof newQueueEntry }}
+ * @returns {{ [qName: string]: typeof newQueueEntry }}
  */
 export const getNewQueuesStatus = (cleanQueuesStatus, tasks) => {
   const newQueuesStatus = Object.values(tasks).reduce(addPendingTasks, cleanQueuesStatus);

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.js
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.js
@@ -22,15 +22,15 @@ export const initializeQueuesStatus = queues =>
   queues.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).reduce((acc, qName) => ({ ...acc, [qName]: newQueueEntry }), {});
 
 const isNotWaiting = status => status !== 'pending' && status !== 'reserved';
-const suscribedToQueue = (queue, queues) => Boolean(queues[queue]);
+const subscribedToQueue = (queue, queues) => Boolean(queues[queue]);
 
 /**
  * Adds each waiting tasks to the appropiate queue and channel, recording which is the oldest
- * If counselor is not suscribed to a queue, acc[queue] will be undefined
+ * If counselor is not subscribed to a queue, acc[queue] will be undefined
  * @returns {{ [qName: string]: typeof newQueueEntry }}
  */
 export const addPendingTasks = (acc, task) => {
-  if (isNotWaiting(task.status) || !suscribedToQueue(task.queue_name, acc)) return acc;
+  if (isNotWaiting(task.status) || !subscribedToQueue(task.queue_name, acc)) return acc;
 
   const created = task.date_created;
   const channel = task.channel_type === 'voice' ? 'voice' : task.attributes.channelType;

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.js
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.js
@@ -21,7 +21,7 @@ export const initializeQueuesStatus = queues =>
   // eslint-disable-next-line no-nested-ternary
   queues.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).reduce((acc, qName) => ({ ...acc, [qName]: newQueueEntry }), {});
 
-const isNotWaiting = status => status !== 'pending' && status !== 'reserved';
+export const isWaiting = status => status === 'pending' || status === 'reserved';
 const subscribedToQueue = (queue, queues) => Boolean(queues[queue]);
 
 /**
@@ -30,7 +30,7 @@ const subscribedToQueue = (queue, queues) => Boolean(queues[queue]);
  * @returns {{ [qName: string]: typeof newQueueEntry }}
  */
 export const addPendingTasks = (acc, task) => {
-  if (isNotWaiting(task.status) || !subscribedToQueue(task.queue_name, acc)) return acc;
+  if (!isWaiting(task.status) || !subscribedToQueue(task.queue_name, acc)) return acc;
 
   const created = task.date_created;
   const channel = task.channel_type === 'voice' ? 'voice' : task.attributes.channelType;

--- a/plugin-hrm-form/src/components/queuesStatus/index.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/index.jsx
@@ -21,10 +21,8 @@ const QueuesStatus = ({ colors, helpline, queuesStatusState }) => {
       <QueuesContainer>
         {error && <ErrorText>{error}</ErrorText>}
         {queuesStatus &&
-          (helpline ? (
-            queuesStatus[helpline] && (
-              <QueueCard key={`${helpline}-queue`} qName={helpline} colors={colors} {...queuesStatus[helpline]} />
-            )
+          (helpline && queuesStatus[helpline] ? (
+            <QueueCard key={`${helpline}-queue`} qName={helpline} colors={colors} {...queuesStatus[helpline]} />
           ) : (
             <QueueCard key="Admin-queue" qName="Admin" colors={colors} {...queuesStatus.Admin} />
           ))}

--- a/plugin-hrm-form/src/components/queuesStatus/index.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/index.jsx
@@ -8,7 +8,7 @@ import { Container, HeaderContainer, QueuesContainer } from '../../styles/queues
 import { Box, ErrorText } from '../../styles/HrmStyles';
 import { TLHPaddingLeft } from '../../styles/GlobalOverrides';
 
-const QueuesStatus = ({ colors, helpline, queuesStatusState }) => {
+const QueuesStatus = ({ colors, queuesStatusState }) => {
   const { queuesStatus, error } = queuesStatusState;
 
   return (
@@ -21,10 +21,8 @@ const QueuesStatus = ({ colors, helpline, queuesStatusState }) => {
       <QueuesContainer>
         {error && <ErrorText>{error}</ErrorText>}
         {queuesStatus &&
-          (helpline && queuesStatus[helpline] ? (
-            <QueueCard key={`${helpline}-queue`} qName={helpline} colors={colors} {...queuesStatus[helpline]} />
-          ) : (
-            <QueueCard key="Admin-queue" qName="Admin" colors={colors} {...queuesStatus.Admin} />
+          Object.entries(queuesStatus).map(([qName, qStatus]) => (
+            <QueueCard key={qName} qName={qName} colors={colors} {...qStatus} />
           ))}
       </QueuesContainer>
     </Container>
@@ -41,7 +39,6 @@ QueuesStatus.propTypes = {
     smsColor: PropTypes.shape({ Accepted: PropTypes.string }),
     whatsappColor: PropTypes.shape({ Accepted: PropTypes.string }),
   }).isRequired,
-  helpline: PropTypes.string,
   queuesStatusState: PropTypes.shape({
     queuesStatus: PropTypes.shape({
       Admin: PropTypes.shape({}),
@@ -49,10 +46,6 @@ QueuesStatus.propTypes = {
     error: PropTypes.string,
     loading: PropTypes.bool,
   }).isRequired,
-};
-
-QueuesStatus.defaultProps = {
-  helpline: undefined,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/plugin-hrm-form/src/components/queuesStatus/index.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/index.jsx
@@ -10,7 +10,6 @@ import { TLHPaddingLeft } from '../../styles/GlobalOverrides';
 
 const QueuesStatus = ({ colors, helpline, queuesStatusState }) => {
   const { queuesStatus, error } = queuesStatusState;
-  const hasHelpline = helpline && queuesStatus[helpline];
 
   return (
     <Container role="complementary" tabIndex={0}>
@@ -22,8 +21,10 @@ const QueuesStatus = ({ colors, helpline, queuesStatusState }) => {
       <QueuesContainer>
         {error && <ErrorText>{error}</ErrorText>}
         {queuesStatus &&
-          (hasHelpline ? (
-            <QueueCard key={`${helpline}-queue`} qName={helpline} colors={colors} {...queuesStatus[helpline]} />
+          (helpline ? (
+            queuesStatus[helpline] && (
+              <QueueCard key={`${helpline}-queue`} qName={helpline} colors={colors} {...queuesStatus[helpline]} />
+            )
           ) : (
             <QueueCard key="Admin-queue" qName="Admin" colors={colors} {...queuesStatus.Admin} />
           ))}

--- a/plugin-hrm-form/src/components/queuesStatus/index.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/index.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CircularProgress, Collapse } from '@material-ui/core';
-import { ArrowDropDownTwoTone, ArrowDropUpTwoTone } from '@material-ui/icons';
 import { connect } from 'react-redux';
 
 import { namespace, queuesStatusBase } from '../../states';
@@ -10,68 +8,53 @@ import { Container, HeaderContainer, QueuesContainer } from '../../styles/queues
 import { Box, ErrorText } from '../../styles/HrmStyles';
 import { TLHPaddingLeft } from '../../styles/GlobalOverrides';
 
-class QueuesStatus extends React.Component {
-  static displayName = 'QueuesStatus';
+const QueuesStatus = ({ colors, helpline, queuesStatusState }) => {
+  const { queuesStatus, error } = queuesStatusState;
+  const hasHelpline = helpline && queuesStatus[helpline];
 
-  static propTypes = {
-    colors: PropTypes.shape({
-      voiceColor: PropTypes.shape({ Accepted: PropTypes.string }),
-      webColor: PropTypes.shape({ Accepted: PropTypes.string }),
-      facebookColor: PropTypes.shape({ Accepted: PropTypes.string }),
-      smsColor: PropTypes.shape({ Accepted: PropTypes.string }),
-      whatsappColor: PropTypes.shape({ Accepted: PropTypes.string }),
-    }).isRequired,
-    queuesStatusState: PropTypes.shape({
-      queuesStatus: PropTypes.shape({}),
-      error: PropTypes.string,
-      loading: PropTypes.bool,
-    }).isRequired,
-  };
+  return (
+    <Container role="complementary">
+      <HeaderContainer>
+        <Box marginTop="12px" marginRight="5px" marginBottom="12px" marginLeft={TLHPaddingLeft}>
+          Contacts waiting
+        </Box>
+      </HeaderContainer>
+      <QueuesContainer>
+        {error && <ErrorText>{error}</ErrorText>}
+        {queuesStatus &&
+          (hasHelpline ? (
+            <QueueCard key={`${helpline}-queue`} qName={helpline} colors={colors} {...queuesStatus[helpline]} />
+          ) : (
+            <QueueCard key="Admin-queue" qName="Admin" colors={colors} {...queuesStatus.Admin} />
+          ))}
+      </QueuesContainer>
+    </Container>
+  );
+};
 
-  state = {
-    expanded: true,
-  };
+QueuesStatus.displayName = 'QueuesStatus';
 
-  handleExpandClick = () => this.setState(prev => ({ expanded: !prev.expanded }));
+QueuesStatus.propTypes = {
+  colors: PropTypes.shape({
+    voiceColor: PropTypes.shape({ Accepted: PropTypes.string }),
+    webColor: PropTypes.shape({ Accepted: PropTypes.string }),
+    facebookColor: PropTypes.shape({ Accepted: PropTypes.string }),
+    smsColor: PropTypes.shape({ Accepted: PropTypes.string }),
+    whatsappColor: PropTypes.shape({ Accepted: PropTypes.string }),
+  }).isRequired,
+  helpline: PropTypes.string,
+  queuesStatusState: PropTypes.shape({
+    queuesStatus: PropTypes.shape({
+      Admin: PropTypes.shape({}),
+    }),
+    error: PropTypes.string,
+    loading: PropTypes.bool,
+  }).isRequired,
+};
 
-  renderHeaderIcon = () => {
-    if (this.props.queuesStatusState.loading) return <CircularProgress size={12} color="inherit" />;
-
-    return this.state.expanded ? (
-      <ArrowDropUpTwoTone style={{ padding: 0, fontSize: 18 }} />
-    ) : (
-      <ArrowDropDownTwoTone style={{ padding: 0, fontSize: 18 }} />
-    );
-  };
-
-  render() {
-    const { queuesStatus, error } = this.props.queuesStatusState;
-    const { expanded } = this.state;
-    return (
-      <Container role="complementary">
-        <HeaderContainer
-          onClick={this.handleExpandClick}
-          role="button"
-          aria-label={`Contacts waiting ${this.state.expanded ? 'press to collapse' : 'press to expand'}`}
-        >
-          <Box marginTop="12px" marginRight="5px" marginBottom="12px" marginLeft={TLHPaddingLeft}>
-            Contacts waiting
-          </Box>
-          {this.renderHeaderIcon()}
-        </HeaderContainer>
-        <Collapse in={expanded} timeout="auto" unmountOnExit>
-          <QueuesContainer>
-            {error && <ErrorText>{error}</ErrorText>}
-            {queuesStatus &&
-              Object.entries(queuesStatus).map(([qName, qStatus]) => (
-                <QueueCard key={qName} qName={qName} colors={this.props.colors} {...qStatus} />
-              ))}
-          </QueuesContainer>
-        </Collapse>
-      </Container>
-    );
-  }
-}
+QueuesStatus.defaultProps = {
+  helpline: undefined,
+};
 
 const mapStateToProps = (state, ownProps) => {
   const queuesStatusState = state[namespace][queuesStatusBase];

--- a/plugin-hrm-form/src/components/queuesStatus/index.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/index.jsx
@@ -13,7 +13,7 @@ const QueuesStatus = ({ colors, helpline, queuesStatusState }) => {
   const hasHelpline = helpline && queuesStatus[helpline];
 
   return (
-    <Container role="complementary">
+    <Container role="complementary" tabIndex={0}>
       <HeaderContainer>
         <Box marginTop="12px" marginRight="5px" marginBottom="12px" marginLeft={TLHPaddingLeft}>
           Contacts waiting

--- a/plugin-hrm-form/src/styles/HrmStyles.js
+++ b/plugin-hrm-form/src/styles/HrmStyles.js
@@ -250,14 +250,6 @@ export const Row = styled('div')`
   align-items: center;
 `;
 
-/*
- * export const ButtonRow = styled('button')`
- *   display: flex;
- *   flex-direction: row;
- *   align-items: center;
- * `;
- */
-
 export const FontOpenSans = styled('p')`
   color: #000000;
   font-family: Open Sans;

--- a/plugin-hrm-form/src/styles/HrmStyles.js
+++ b/plugin-hrm-form/src/styles/HrmStyles.js
@@ -250,11 +250,13 @@ export const Row = styled('div')`
   align-items: center;
 `;
 
-export const ButtonRow = styled('button')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
+/*
+ * export const ButtonRow = styled('button')`
+ *   display: flex;
+ *   flex-direction: row;
+ *   align-items: center;
+ * `;
+ */
 
 export const FontOpenSans = styled('p')`
   color: #000000;

--- a/plugin-hrm-form/src/styles/queuesStatus/index.js
+++ b/plugin-hrm-form/src/styles/queuesStatus/index.js
@@ -1,6 +1,6 @@
 import styled from 'react-emotion';
 
-import { FontOpenSans, ButtonRow } from '../HrmStyles';
+import { FontOpenSans, Row } from '../HrmStyles';
 
 export const Container = styled('div')`
   width: 100%;
@@ -12,7 +12,7 @@ export const Container = styled('div')`
   border-color: ${props => props.theme.colors.base4};
 `;
 
-export const HeaderContainer = styled(ButtonRow)`
+export const HeaderContainer = styled(Row)`
   width: 100%;
   justify-items: flex-start;
   background-color: ${props => props.theme.colors.base2};


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-98

This PR changes the queues that each counselor see in queue viz widget.

If counselor has a helpline, shows the queue that matches that helpline (Desing in this case)
![Screenshot from 2020-05-06 16-53-59](https://user-images.githubusercontent.com/15805319/81224578-4efd4200-8fbe-11ea-9c60-31e1876b5703.png)

If counselor has empty or no helpline, or if counselor has a helpline, but there is no queue with that name,counselor see the Admin queue
![Screenshot from 2020-05-06 16-56-30](https://user-images.githubusercontent.com/15805319/81224593-56245000-8fbe-11ea-80d4-95f2c8aa3c49.png)

By changing the [counselorQueues](https://github.com/tech-matters/flex-plugins/blob/a0696c25689068f944b19745ad3ac2f8a3c8eb9c/plugin-hrm-form/src/components/queuesStatus/QueuesStatusWriter.jsx#L39) to an array of more than one queue, the counselor can subscribe to multiple queues (even when not eligible for task assignment in that queue)
![Screenshot from 2020-05-07 11-12-18](https://user-images.githubusercontent.com/15805319/81305556-d9908080-9054-11ea-9f74-169e6eaa07ad.png)
