### PR TITLE
Await original action before continuing; remove sleep

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -18,10 +18,6 @@ import { changeLanguage } from './states/ConfigurationState';
 const PLUGIN_NAME = 'HrmFormPlugin';
 const PLUGIN_VERSION = '0.4.2';
 
-function timeout(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 export default class HrmFormPlugin extends FlexPlugin {
   constructor() {
     super(PLUGIN_NAME);
@@ -74,7 +70,6 @@ export default class HrmFormPlugin extends FlexPlugin {
           await flex.Actions.invokeAction('WrapupTask', { sid, task });
         }
       }
-      await timeout(500);
       flex.Actions.invokeAction('CompleteTask', { sid, task });
     };
 
@@ -174,7 +169,7 @@ export default class HrmFormPlugin extends FlexPlugin {
      */
     const fromActionFunction = fun => async (payload, original) => {
       await fun(payload);
-      original(payload);
+      await original(payload);
     };
 
     const hangupCall = fromActionFunction(saveEndMillis);


### PR DESCRIPTION
This is an update to https://github.com/tech-matters/flex-plugins/pull/93 in which we prevented a ChatOrchestration race condition by adding a half-second sleep.  This removes the sleep, but adds an `await` to the `WrapupTask` action before continuing on to the `CompleteTask` action.  After numerous tries, I can't reproduce the error we saw yesterday while this is in place.

When we have neither the `await` nor the sleep, we get logs like this (filtered for "ChatOrchestrator"):
![Screen Shot 2020-05-22 at 9 28 09 AM](https://user-images.githubusercontent.com/10714292/82691572-fd39f600-9c12-11ea-843c-79a8b1fcdb93.png)
Notice that there are two logs of `ChatOrchestrator DeactivateChatChannel for WR...` before there is a log for `ChatOrchestrator DeactivateChatChannel for WR... done`, followed by an error.  I believe that Flex makes the `DeactivateChatChannel` call as part of handling both the `WrapupTask` and `CompleteTask` actions, and because we did not have an `await` in place, both calls were made before the first finished.  The first then finished while the second was in progress, which changes state unexpectedly, causing an error.

With either the `await` or the sleep, we get logs like this:
![Screen Shot 2020-05-22 at 9 31 14 AM](https://user-images.githubusercontent.com/10714292/82691748-3ecaa100-9c13-11ea-9f37-aafe23870f16.png)

Notice here that there is one log of `ChatOrchestrator DeactivateChatChannel for WR...` followed by one log of `ChatOrchestrator DeactivateChatChannel for WR... done`, which is later followed by `ChatOrchestrator DeactivateChatChannel channel not found for WR...`.  When we `await` the completion of the `WrapupTask` action before calling `CompleteTask`, we ensure that the first `DeactivateChatChannel` call completes before the second one is attempted.  The second one recognizes that the channel is no longer present and quietly returns.

@murilovmachado @GPaoloni I suggest that we keep production as it is, and see how this performs on staging for awhile.
