### PR TITLE
Changes to Gender and Age on Insights

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/CallerInformationTab.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/CallerInformationTab.jsx
@@ -5,6 +5,7 @@ import { callerInformationType } from '../../types';
 import FieldText from '../FieldText';
 import FieldSelect from '../FieldSelect';
 import { ColumnarBlock, Container, NameFields, TwoColumnLayout } from '../../styles/HrmStyles';
+import { genderOptions, ageOptions } from './SelectOptions';
 
 const CallerInformationTab = ({ callerInformation, defaultEventHandlers }) => (
   <Container>
@@ -39,7 +40,7 @@ const CallerInformationTab = ({ callerInformation, defaultEventHandlers }) => (
           id="CallerInformation_Gender"
           name="gender"
           label="Gender"
-          options={['Male', 'Female', 'Other', 'Unknown']}
+          options={genderOptions}
           {...defaultEventHandlers(['callerInformation'], 'gender')}
         />
 
@@ -48,7 +49,7 @@ const CallerInformationTab = ({ callerInformation, defaultEventHandlers }) => (
           id="CallerInformation_Age"
           name="age"
           label="Age"
-          options={['0-3', '4-6', '7-9', '10-12', '13-15', '16-17', '18-25', '>25']}
+          options={ageOptions}
           {...defaultEventHandlers(['callerInformation'], 'age')}
         />
 

--- a/plugin-hrm-form/src/components/tabbedForms/ChildInformationTab.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ChildInformationTab.jsx
@@ -13,6 +13,7 @@ import {
   CheckboxField,
   StyledCheckboxLabel,
 } from '../../styles/HrmStyles';
+import { genderOptions, ageOptions } from './SelectOptions';
 
 const ChildInformationTab = ({ childInformation, handleCheckboxClick, defaultEventHandlers }) => (
   <Container>
@@ -38,7 +39,7 @@ const ChildInformationTab = ({ childInformation, handleCheckboxClick, defaultEve
           id="ChildInformation_Gender"
           name="gender"
           label="Gender"
-          options={['Male', 'Female', 'Other', 'Unknown']}
+          options={genderOptions}
           {...defaultEventHandlers(['childInformation'], 'gender')}
         />
 
@@ -47,7 +48,7 @@ const ChildInformationTab = ({ childInformation, handleCheckboxClick, defaultEve
           id="ChildInformation_Age"
           name="age"
           label="Age"
-          options={['0-3', '4-6', '7-9', '10-12', '13-15', '16-17', '18-25', '>25']}
+          options={ageOptions}
           {...defaultEventHandlers(['childInformation'], 'age')}
         />
 

--- a/plugin-hrm-form/src/components/tabbedForms/SelectOptions.js
+++ b/plugin-hrm-form/src/components/tabbedForms/SelectOptions.js
@@ -1,0 +1,2 @@
+export const genderOptions = ['Boy', 'Girl', 'Non-binary', 'Unknown'];
+export const ageOptions = ['0-3', '4-6', '7-9', '10-12', '13-15', '16-17', '18-25', '>25', 'Unknown'];

--- a/plugin-hrm-form/src/services/ServerlessService.js
+++ b/plugin-hrm-form/src/services/ServerlessService.js
@@ -54,7 +54,7 @@ export const saveInsightsData = async (configuration, task, taskSID) => {
     const { childInformation } = task;
     customers = {
       gender: childInformation.gender.value,
-      year_of_birth: childInformation.age.value,
+      customer_attribute_1: childInformation.age.value,
     };
   }
 


### PR DESCRIPTION
This PR:
- Updates Select Gender Options
- Updates Select Age Options
- Saves `age` as `Customer Attribute 1` (instead of `Year of Birth`) 