### PR TITLE
Implement thematic design changes

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -235,8 +235,6 @@ export default class HrmFormPlugin extends FlexPlugin {
     }
 
     flex.MainHeader.Content.remove('logo');
-    flex.MainHeader.Content.remove('mute-button');
-    flex.MainHeader.Content.remove('user-controls');
   }
 
   /**

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -125,6 +125,8 @@ const setUpComponents = setupObject => {
   Flex.TaskCanvasHeader.Content.remove('actions', {
     if: props => props.task && props.task.status === 'wrapping',
   });
+
+  Flex.MainHeader.Content.remove('logo');
 };
 
 const setUpActions = setupObject => {
@@ -233,8 +235,6 @@ export default class HrmFormPlugin extends FlexPlugin {
     if (hrmBaseUrl === undefined) {
       console.error('HRM base URL not defined, you must provide this to save program data');
     }
-
-    flex.MainHeader.Content.remove('logo');
   }
 
   /**

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -233,6 +233,10 @@ export default class HrmFormPlugin extends FlexPlugin {
     if (hrmBaseUrl === undefined) {
       console.error('HRM base URL not defined, you must provide this to save program data');
     }
+
+    flex.MainHeader.Content.remove('logo');
+    flex.MainHeader.Content.remove('mute-button');
+    flex.MainHeader.Content.remove('user-controls');
   }
 
   /**

--- a/plugin-hrm-form/src/styles/GlobalOverrides.js
+++ b/plugin-hrm-form/src/styles/GlobalOverrides.js
@@ -8,6 +8,26 @@ injectGlobal`
   div.Twilio-ModalPopupWithEntryControl {
     padding-top: 7px;
     padding-bottom: 7px;
-    border-width: 0px 0px 1px 0px;
+  }
+  div.Twilio-SideNav-Container {
+    margin-right: 5px;
+  } 
+  div.Twilio-MainHeader {
+    margin-bottom: 5px;
+  }
+  button.Twilio-TaskListFilter-TaskFilterButton {
+    margin-right: 10px;
+  }
+  button.Twilio-TaskListFilter-TaskFilterButton > div.Twilio-Icon-Filter {
+    margin-left: auto;
+  }
+  button.Twilio-TaskListFilter-TaskFilterButton > div.Twilio-Icon-FilterUp {
+    margin-left: auto;
+  }
+  button.Twilio-TaskCanvasHeader-EndButton {
+    border-radius: 5px;
+  }
+  button.Twilio-MessageInput-SendButton {
+    background: rgba(216, 27, 96, 0.8);
   }
 `;

--- a/plugin-hrm-form/src/styles/HrmTheme.js
+++ b/plugin-hrm-form/src/styles/HrmTheme.js
@@ -1,14 +1,68 @@
+const colors = {
+  base1: '#ffffff',
+  base2: '#f6f6f6',
+  buttonTextColor: '#ffffff',
+  disabledColor: '#d8d8d8',
+  defaultButtonColor: '#000000',
+  inputBackgroundColor: 'rgba(236, 237, 241, 0.37)',
+  hyperlinkColor: '#1874e1',
+  hyperlinkHoverBackgroundColor: 'rgba(24, 116, 225, 0.08)',
+};
+
+const overrides = {
+  MainHeader: {
+    Container: {
+      background: colors.base2,
+      borderColor: colors.base2,
+    },
+    Button: {
+      color: colors.lightTextColor,
+      lightHover: true,
+    },
+  },
+  SideNav: {
+    Container: {
+      background: colors.base2,
+      borderColor: colors.base2,
+    },
+    Button: {
+      background: colors.base2,
+    },
+  },
+  TaskList: {
+    Filter: {
+      Container: {
+        background: colors.base2,
+        borderColor: colors.base2,
+      },
+    },
+    Item: {
+      Container: {
+        borderColor: colors.base2,
+        background: colors.base2,
+      },
+      SelectedContainer: {
+        background: colors.base1,
+      },
+    },
+  },
+  AgentDesktopView: {
+    ContentSplitter: {
+      background: colors.base1,
+      borderColor: colors.base1,
+    },
+  },
+  CRMContainer: {
+    Container: {
+      borderColor: colors.base2,
+    },
+  },
+};
+
 const HrmTheme = {
   baseName: 'HrmTheme',
-  colors: {
-    base2: '#f6f6f6',
-    buttonTextColor: '#ffffff',
-    disabledColor: '#d8d8d8',
-    defaultButtonColor: '#000000',
-    inputBackgroundColor: 'rgba(236, 237, 241, 0.37)',
-    hyperlinkColor: '#1874e1',
-    hyperlinkHoverBackgroundColor: 'rgba(24, 116, 225, 0.08)',
-  },
+  colors,
+  overrides,
 };
 
 export default HrmTheme;

--- a/plugin-hrm-form/src/styles/queuesStatus/index.js
+++ b/plugin-hrm-form/src/styles/queuesStatus/index.js
@@ -5,21 +5,15 @@ import { FontOpenSans, Row } from '../HrmStyles';
 export const Container = styled('div')`
   width: 100%;
   background-color: #ffffff;
-  padding-top: 5px;
   padding-bottom: 14px;
   border-style: solid;
-  border-width: 0px 0px 1px 0px;
-  border-color: ${props => props.theme.colors.base4};
 `;
 
 export const HeaderContainer = styled(Row)`
   width: 100%;
   justify-items: flex-start;
   background-color: ${props => props.theme.colors.base2};
-  border-radius: 2px;
-  border-style: solid;
-  border-width: 1px 0px 1px 0px;
-  border-color: ${props => props.theme.colors.base4};
+  border-width: 0px;
   text-transform: uppercase;
   color: #192b33;
   font-size: 10px;

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -1,4 +1,5 @@
 {  
+  "TaskHeaderEndChat": "End Chat",
   "TranslateButtonAriaLabel": "Change language",
 
   "CallType-child": "Child calling about self",

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -1,4 +1,5 @@
-{  
+{
+  "ChatWelcomeText": "Conversation started",
   "TaskHeaderEndChat": "End Chat",
   "TranslateButtonAriaLabel": "Change language",
 


### PR DESCRIPTION
This is WIP as I plan to wait for #99 before rebasing this and submitting it as a full PR for review.

These are @GPaoloni's original changes with two more things after feedback from product/design:
- Only removing the Twilio logo from the top nav, and not the mute button or user controls
- Adding back in the "Conversation started" string for the chat welcome text, which went missing somehow.

The view with a task now looks like this:
![image](https://user-images.githubusercontent.com/10714292/83211326-ae5bf700-a111-11ea-8c9f-822044b038d5.png)

The view without a task looks a bit weird now, with 'No selected tasks' floating in the middle with no divider to show that it's part of a panel.  I intend to remove the `NoTaskView` component altogether, but I want to do it in a subsequent PR, so that it's easier to revert if we want to put it back to show a more interesting empty state.
