### PR TITLE
Round corners and title case for end conversation button

### DIFF
--- a/plugin-hrm-form/src/styles/GlobalOverrides.js
+++ b/plugin-hrm-form/src/styles/GlobalOverrides.js
@@ -25,7 +25,9 @@ injectGlobal`
     margin-left: auto;
   }
   button.Twilio-TaskCanvasHeader-EndButton {
-    border-radius: 5px;
+    border-radius: 14px;
+    font-size: 13px;
+    letter-spacing: 0px;
   }
   button.Twilio-MessageInput-SendButton {
     background: rgba(216, 27, 96, 0.8);

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -1,5 +1,6 @@
 {
   "ChatWelcomeText": "Conversation started",
+  "TaskHeaderEndCall": "Hang Up",
   "TaskHeaderEndChat": "End Chat",
   "TranslateButtonAriaLabel": "Change language",
 


### PR DESCRIPTION
Changed per design feedback.  We'll want to make most buttons look like this -- for example, the buttons at the bottom right of the forms when we add case management.  If we should put this in a different part of the code in order to make it more generalized, fine by me.

Buttons look like this now:
![image (2)](https://user-images.githubusercontent.com/10714292/83694760-95d65b80-a5ad-11ea-896d-1983b277c78a.png)
![image (3)](https://user-images.githubusercontent.com/10714292/83694775-a1298700-a5ad-11ea-8a61-75356247bd8b.png)
