### PR TITLE
Add support for feature flags

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -235,8 +235,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     };
     manager.updateConfig(managerConfiguration);
 
-    // TODO(nick): Eventually remove this log line or set to debug
-    // fail hard here?  is that possible?
+    // TODO(nick): Eventually remove this log line or set to debug.  Should we fail hard here?
     const { hrmBaseUrl } = config;
     console.log(`HRM URL: ${hrmBaseUrl}`);
     if (hrmBaseUrl === undefined) {

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -28,7 +28,6 @@ export const getConfig = () => {
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
   const { configuredLanguage } = manager.serviceConfiguration.attributes;
-  // TODO: should we fail hard if this isn't present?  Or is the default empty object fine?
   const featureFlags = manager.serviceConfiguration.attributes.feature_flags || {};
 
   return {


### PR DESCRIPTION
This adds support for feature flags that can be toggled in service configuration.  I've updated the configuration object on our staging account to include a `feature_flags` entry:

```
GET https://flex-api.twilio.com/v1/Configuration returns:

{
    "attributes": {
      "feature_flags": {
          "enable_save_insights": true
      },
    ...
  },
  ...
}
```

This allows us to do a couple things:
1. Deploy code to production that is still not ready to be seen, by wrapping `if (featureFlags.flag_we_set) { }` around the partially completed code.
2. Allows us to deploy code to production and _then_ actually enable the feature with a POST request to the configuration.  And we can disable the feature with another POST request.

Note that if the flag is missing, it will default to not being enabled.  This is a safer approach.

Some questions on my mind:
1. Should we 'fail hard' (that is, crash Flex intentionally) if certain configuration entries are missing?  That may prevent us from deploying something that is completely broken.  I'm also not sure if it's possible.
2. I couldn't figure out how to change the service configuration (different from the UI configuration) in `appConfig.js`.  It would be nice to be able to do this.

What do you think of this approach?