### PR TITLE
[WIP] Blocking transfer buttons

### DIFF
--- a/plugin-hrm-form/src/styles/GlobalOverrides.js
+++ b/plugin-hrm-form/src/styles/GlobalOverrides.js
@@ -32,4 +32,12 @@ injectGlobal`
   button.Twilio-MessageInput-SendButton {
     background: rgba(216, 27, 96, 0.8);
   }
+
+  div.Twilio-WorkerDirectory-ButtonContainer > button.Twilio-IconButton[title=Consult] {
+    display: none;
+  }
+
+  button.Twilio-CallCanvas-HangupButton[title=Leave] {
+    display: none;
+  }
 `;


### PR DESCRIPTION
@GPaoloni I did a little experimentation with implementing Joan's requests.  If this is helpful to you, that's great.  But if it is not helpful, you can ignore it.

I used the global overrides to hide the warm transfer button from the WorkerDirectory with a `display: none` conditional on the title.  This hides the warm transfer button for both voice and chat, however.  I don't know how to make it conditional on `isChatTask()`.  I did notice that a component higher up has an `isWarmTransferEnabled` prop:

![Screen Shot 2020-06-13 at 11 23 44 AM](https://user-images.githubusercontent.com/10714292/84576642-31648a80-ad6b-11ea-90d0-290ac140f592.png)

I am not sure how that gets changed, though it starts out from the [Flex Admin Pre-release feature config](https://flex.twilio.com/admin/features).  It would be really nice if we could inject `false` into that prop conditional on it being a chat task, but I don't see a way to do that.

Another thing I did was to hide the 'Leave call' button, which we wanted to do for the first counselor.  I don't know how to make it conditional on whether you are sending or receiving the transfer, though we could possibly hide it for both and just use the Accept/Reject Transfer buttons.

Again, if this is not helpful it is totally okay to ignore this.  I just wanted to spend a little time understanding this better.