### PR TITLE
Change incoming transfer message + lock form on warm transfer

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -32,6 +32,7 @@ export const getConfig = () => {
   const { helpline, counselorLanguage, helplineLanguage } = manager.workerClient.attributes;
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
+  const counselorName = manager.workerClient.attributes.full_name;
   const { configuredLanguage } = manager.serviceConfiguration.attributes;
   const featureFlags = manager.serviceConfiguration.attributes.feature_flags || {};
   const { strings } = manager;
@@ -47,6 +48,7 @@ export const getConfig = () => {
     configuredLanguage,
     identity,
     token,
+    counselorName,
     featureFlags,
     sharedStateClient,
     strings,
@@ -129,7 +131,10 @@ const setUpComponents = setupObject => {
   Components.setUpQueuesStatusWriter(setupObject);
   Components.setUpQueuesStatus();
   Components.setUpCustomCRMContainer();
-  if (featureFlags.enable_transfers) Components.setUpTransferComponents();
+  if (featureFlags.enable_transfers) {
+    Components.setUpTransferComponents();
+    Components.setUpIncomingTransferMessage();
+  }
 
   if (!Boolean(helpline)) Components.setUpDeveloperComponents(setupObject); // utilities for developers only
 

--- a/plugin-hrm-form/src/___tests__/mockGetConfig.js
+++ b/plugin-hrm-form/src/___tests__/mockGetConfig.js
@@ -11,6 +11,7 @@ jest.mock('../HrmFormPlugin', () => ({
       configuredLanguage: '',
       identity: '',
       token: '',
+      counselorName: '',
     };
   },
 }));

--- a/plugin-hrm-form/src/___tests__/utils/transfer.test.js
+++ b/plugin-hrm-form/src/___tests__/utils/transfer.test.js
@@ -285,16 +285,19 @@ describe('Kick, close and helpers', () => {
       { sid: 'reservation1', taskSid: 'task1', taskChannelSid: 'channel1', workerSid: 'worker1' },
     );
 
+    const counselorName = 'full name';
+
     const coldExpected = {
       originalTask: 'task1',
       originalReservation: 'reservation1',
       originalCounselor: 'worker1',
+      originalCounselorName: counselorName,
       transferStatus: transferStatuses.accepted,
       formDocument: 'some string',
       mode: transferModes.cold,
     };
 
-    await TransferHelpers.setTransferMeta(coldTask, transferModes.cold, 'some string');
+    await TransferHelpers.setTransferMeta(coldTask, transferModes.cold, 'some string', counselorName);
     expect(coldTask.attributes.transferMeta).toStrictEqual(coldExpected);
 
     const warmTask = createTask(
@@ -306,12 +309,13 @@ describe('Kick, close and helpers', () => {
       originalTask: 'task1',
       originalReservation: 'reservation1',
       originalCounselor: 'worker1',
+      originalCounselorName: counselorName,
       transferStatus: transferStatuses.transferring,
       formDocument: 'some string',
       mode: transferModes.warm,
     };
 
-    await TransferHelpers.setTransferMeta(warmTask, transferModes.warm, 'some string');
+    await TransferHelpers.setTransferMeta(warmTask, transferModes.warm, 'some string', counselorName);
     expect(warmTask.attributes.transferMeta).toStrictEqual(warmExpected);
   });
 });

--- a/plugin-hrm-form/src/components/FormNotEditable.jsx
+++ b/plugin-hrm-form/src/components/FormNotEditable.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Template } from '@twilio/flex-ui';
 import { AppBar, Toolbar, Typography } from '@material-ui/core';
 import { InfoTwoTone } from '@material-ui/icons';
 
@@ -10,7 +11,7 @@ const FormNotEditable = () => (
       <Row>
         <InfoTwoTone style={{ fontSize: 26, marginRight: 10 }} />
         <Typography variant="subtitle1" style={{ color: '#ffffff' }}>
-          Task is being transferred. In the final version, this form will not be editable.
+          <Template code="Transfer-FormNotEditable" />
         </Typography>
       </Row>
     </Toolbar>

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
@@ -21,13 +21,15 @@ import CallerInformationTab from './CallerInformationTab';
 import ChildInformationTab from './ChildInformationTab';
 import IssueCategorizationTab from './IssueCategorizationTab';
 import CaseInformationTab from './CaseInformationTab';
+import { hasTaskControl } from '../../utils/transfer';
 
 const TabbedForms = props => {
   const { task, form } = props;
   const taskId = task.taskSid;
 
-  const curriedHandleChange = (parents, name) => e =>
-    props.handleChange(taskId, parents, name, e.target.value || e.currentTarget.value);
+  const curriedHandleChange = (parents, name) => e => {
+    if (hasTaskControl(task)) props.handleChange(taskId, parents, name, e.target.value || e.currentTarget.value);
+  };
 
   const curriedHandleFocus = (parents, name) => () => props.handleFocus(taskId, parents, name);
 
@@ -48,10 +50,20 @@ const TabbedForms = props => {
     props.changeTab(tab, taskId);
   };
 
-  const handleCheckboxClick = (parents, name, value) => props.handleChange(taskId, parents, name, value);
+  const handleCheckboxClick = (parents, name, value) => {
+    if (hasTaskControl(task)) props.handleChange(taskId, parents, name, value);
+  };
+
+  const handleCategoryToggle = (taskSID, category, subcategory, newValue) => {
+    if (hasTaskControl(task)) props.handleCategoryToggle(taskSID, category, subcategory, newValue);
+  };
 
   const handleTabsChange = (event, tab) => {
     props.changeTab(tab, taskId);
+  };
+
+  const handleSubmit = () => {
+    if (hasTaskControl(task)) props.handleSubmit(task);
   };
 
   const { tab } = form.metadata;
@@ -80,7 +92,7 @@ const TabbedForms = props => {
     />,
   );
 
-  body.push(<IssueCategorizationTab form={form} taskId={taskId} handleCategoryToggle={props.handleCategoryToggle} />);
+  body.push(<IssueCategorizationTab form={form} taskId={taskId} handleCategoryToggle={handleCategoryToggle} />);
 
   body.push(
     <CaseInformationTab
@@ -128,11 +140,7 @@ const TabbedForms = props => {
             </StyledNextStepButton>
           )}
           {showSubmitButton && (
-            <StyledNextStepButton
-              roundCorners={true}
-              onClick={() => props.handleSubmit(task)}
-              disabled={!formIsValid(form)}
-            >
+            <StyledNextStepButton roundCorners={true} onClick={handleSubmit} disabled={!formIsValid(form)}>
               Submit
             </StyledNextStepButton>
           )}

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -23,5 +23,6 @@
   "Transfer-TaskLineChatLineReserved": "Request from",
   "Transfer-TaskLineChatMessengerReserved": "Request from",
   "Transfer-TaskLineChatSmsReserved": "Request from",
-  "Transfer-TaskLineChatWhatsAppReserved": "Request from"
+  "Transfer-TaskLineChatWhatsAppReserved": "Request from",
+  "Transfer-FormNotEditable": "Form locked until transfer is completed."
 }

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -18,5 +18,10 @@
 
   "Transfer-TransferButton": "Transfer",
   "Transfer-AcceptTransferButton": "Accept Transfer",
-  "Transfer-RejectTransferButton": "Reject Transfer"
+  "Transfer-RejectTransferButton": "Reject Transfer",
+  "Transfer-TaskLineChatReserved": "Request from",
+  "Transfer-TaskLineChatLineReserved": "Request from",
+  "Transfer-TaskLineChatMessengerReserved": "Request from",
+  "Transfer-TaskLineChatSmsReserved": "Request from",
+  "Transfer-TaskLineChatWhatsAppReserved": "Request from"
 }

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -65,6 +65,8 @@ export const restoreFormIfTransfer = async payload => {
 export const customTransferTask = setupObject => async (payload, original) => {
   console.log('TRANSFER PAYLOAD', payload);
 
+  const { identity, workerSid, counselorName } = setupObject;
+
   // save current form state as sync document (if there is a form)
   const form = getStateContactForms(payload.task.taskSid);
   const documentName = await saveFormSharedState(form, payload.task);
@@ -72,7 +74,7 @@ export const customTransferTask = setupObject => async (payload, original) => {
   const mode = payload.options.mode || DEFAULT_TRANSFER_MODE;
 
   // set metadata for the transfer
-  await TransferHelpers.setTransferMeta(payload.task, mode, documentName);
+  await TransferHelpers.setTransferMeta(payload.task, mode, documentName, counselorName);
 
   if (TaskHelper.isCallTask(payload.task)) {
     if (TransferHelpers.isColdTransfer(payload.task) && !TransferHelpers.hasTaskControl(payload.task)) {
@@ -82,7 +84,6 @@ export const customTransferTask = setupObject => async (payload, original) => {
     return original(payload);
   }
 
-  const { identity, workerSid } = setupObject;
   const memberToKick = mode === transferModes.cold ? TransferHelpers.getMemberToKick(payload.task, identity) : '';
 
   const body = {

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -191,6 +191,11 @@ export const removeActionsIfTransferring = () => {
   });
 };
 
+/**
+ * @param {string} str
+ */
+const uppercaseFirst = str => str[0].toUpperCase() + str.slice(1);
+
 export const setUpIncomingTransferMessage = () => {
   // here we use manager instead of setupObject, so manager.strings will always have the latest version of strings
   const manager = Flex.Manager.getInstance();
@@ -204,25 +209,25 @@ export const setUpIncomingTransferMessage = () => {
   Flex.DefaultTaskChannels.Chat.templates.TaskListItem.secondLine = task =>
     TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
       ? `${manager.strings['Transfer-Chat']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChat[task.status[0].toUpperCase() + task.status.slice(1)];
+      : dafaultChat[uppercaseFirst(task.status)];
 
   Flex.DefaultTaskChannels.ChatLine.templates.TaskListItem.secondLine = task =>
     TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
       ? `${manager.strings['Transfer-ChatLine']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatLine[task.status[0].toUpperCase() + task.status.slice(1)];
+      : dafaultChatLine[uppercaseFirst(task.status)];
 
   Flex.DefaultTaskChannels.ChatMessenger.templates.TaskListItem.secondLine = task =>
     TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
       ? `${manager.strings['Transfer-ChatMessenger']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatMessenger[task.status[0].toUpperCase() + task.status.slice(1)];
+      : dafaultChatMessenger[uppercaseFirst(task.status)];
 
   Flex.DefaultTaskChannels.ChatSms.templates.TaskListItem.secondLine = task =>
     TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
       ? `${manager.strings['Transfer-ChatSms']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatSms[task.status[0].toUpperCase() + task.status.slice(1)];
+      : dafaultChatSms[uppercaseFirst(task.status)];
 
   Flex.DefaultTaskChannels.ChatWhatsApp.templates.TaskListItem.secondLine = task =>
     TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
       ? `${manager.strings['Transfer-TaskLineChatWhatsAppReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatWhatsApp[task.status[0].toUpperCase() + task.status.slice(1)];
+      : dafaultChatWhatsApp[uppercaseFirst(task.status)];
 };

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -36,7 +36,6 @@ export const setUpQueuesStatusWriter = setupObject => {
  * Add a widget at the beginnig of the TaskListContainer, which shows the pending tasks in each channel (consumes from QueuesStatusWriter)
  */
 export const setUpQueuesStatus = () => {
-  // this is coming as a function so we need to disable TS, as it won't type otherwise
   const voiceColor = { Accepted: Flex.DefaultTaskChannels.Call.colors.main() };
   const webColor = Flex.DefaultTaskChannels.Chat.colors.main;
   const facebookColor = Flex.DefaultTaskChannels.ChatMessenger.colors.main;
@@ -190,4 +189,40 @@ export const removeActionsIfTransferring = () => {
   Flex.ParticipantCanvas.Content.remove('actions', {
     if: props => hasNoControlAndIsWarm(props.task) && props.participant.participantType === 'worker',
   });
+};
+
+export const setUpIncomingTransferMessage = () => {
+  // here we use manager instead of setupObject, so manager.strings will always have the latest version of strings
+  const manager = Flex.Manager.getInstance();
+
+  const dafaultChat = Flex.DefaultTaskChannels.Chat.templates.TaskListItem.secondLine;
+  const dafaultChatLine = Flex.DefaultTaskChannels.ChatLine.templates.TaskListItem.secondLine;
+  const dafaultChatMessenger = Flex.DefaultTaskChannels.ChatMessenger.templates.TaskListItem.secondLine;
+  const dafaultChatSms = Flex.DefaultTaskChannels.ChatSms.templates.TaskListItem.secondLine;
+  const dafaultChatWhatsApp = Flex.DefaultTaskChannels.ChatWhatsApp.templates.TaskListItem.secondLine;
+
+  Flex.DefaultTaskChannels.Chat.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-Chat']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChat[task.status[0].toUpperCase() + task.status.slice(1)];
+
+  Flex.DefaultTaskChannels.ChatLine.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-ChatLine']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatLine[task.status[0].toUpperCase() + task.status.slice(1)];
+
+  Flex.DefaultTaskChannels.ChatMessenger.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-ChatMessenger']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatMessenger[task.status[0].toUpperCase() + task.status.slice(1)];
+
+  Flex.DefaultTaskChannels.ChatSms.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-ChatSms']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatSms[task.status[0].toUpperCase() + task.status.slice(1)];
+
+  Flex.DefaultTaskChannels.ChatWhatsApp.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-TaskLineChatWhatsAppReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatWhatsApp[task.status[0].toUpperCase() + task.status.slice(1)];
 };

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -149,11 +149,6 @@ export const setUpDeveloperComponents = setupObject => {
 };
 
 /**
- * @param {string} str
- */
-const uppercaseFirst = str => str[0].toUpperCase() + str.slice(1);
-
-/**
  *
  * @param {import('@twilio/flex-ui').ITask} task
  */
@@ -169,7 +164,7 @@ const setSecondLine = chatChannel => {
   const { channel, string } = chatChannel;
   const defaultStrings = Flex.DefaultTaskChannels[channel].templates.TaskListItem.secondLine;
 
-  Flex.DefaultTaskChannels[channel].templates.TaskListItem.secondLine = task => {
+  Flex.DefaultTaskChannels[channel].templates.TaskListItem.secondLine = (task, componentType) => {
     if (isIncomingTransfer(task) && task.attributes.transferTargetType === 'queue') {
       const { originalCounselorName } = task.attributes.transferMeta;
       return `${manager.strings[string]} ${originalCounselorName} (${task.queueName})`;
@@ -180,7 +175,7 @@ const setSecondLine = chatChannel => {
       return `${manager.strings[string]} ${originalCounselorName} (direct)`;
     }
 
-    return defaultStrings[uppercaseFirst(task.status)];
+    return Flex.TaskChannelHelper.getTemplateForStatus(task, defaultStrings, componentType);
   };
 };
 

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -149,6 +149,47 @@ export const setUpDeveloperComponents = setupObject => {
 };
 
 /**
+ * @param {string} str
+ */
+const uppercaseFirst = str => str[0].toUpperCase() + str.slice(1);
+
+export const setUpIncomingTransferMessage = () => {
+  // here we use manager instead of setupObject, so manager.strings will always have the latest version of strings
+  const manager = Flex.Manager.getInstance();
+
+  const dafaultChat = Flex.DefaultTaskChannels.Chat.templates.TaskListItem.secondLine;
+  const dafaultChatLine = Flex.DefaultTaskChannels.ChatLine.templates.TaskListItem.secondLine;
+  const dafaultChatMessenger = Flex.DefaultTaskChannels.ChatMessenger.templates.TaskListItem.secondLine;
+  const dafaultChatSms = Flex.DefaultTaskChannels.ChatSms.templates.TaskListItem.secondLine;
+  const dafaultChatWhatsApp = Flex.DefaultTaskChannels.ChatWhatsApp.templates.TaskListItem.secondLine;
+
+  Flex.DefaultTaskChannels.Chat.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-TaskLineChatReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChat[uppercaseFirst(task.status)];
+
+  Flex.DefaultTaskChannels.ChatLine.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-TaskLineChatLineReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatLine[uppercaseFirst(task.status)];
+
+  Flex.DefaultTaskChannels.ChatMessenger.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-TaskLineChatMessengerReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatMessenger[uppercaseFirst(task.status)];
+
+  Flex.DefaultTaskChannels.ChatSms.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-TaskLineChatSmsReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatSms[uppercaseFirst(task.status)];
+
+  Flex.DefaultTaskChannels.ChatWhatsApp.templates.TaskListItem.secondLine = task =>
+    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
+      ? `${manager.strings['Transfer-TaskLineChatWhatsAppReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
+      : dafaultChatWhatsApp[uppercaseFirst(task.status)];
+};
+
+/**
  * Removes the actions buttons from TaskCanvasHeaders if the task is wrapping
  */
 export const removeActionsIfWrapping = () => {
@@ -189,45 +230,4 @@ export const removeActionsIfTransferring = () => {
   Flex.ParticipantCanvas.Content.remove('actions', {
     if: props => hasNoControlAndIsWarm(props.task) && props.participant.participantType === 'worker',
   });
-};
-
-/**
- * @param {string} str
- */
-const uppercaseFirst = str => str[0].toUpperCase() + str.slice(1);
-
-export const setUpIncomingTransferMessage = () => {
-  // here we use manager instead of setupObject, so manager.strings will always have the latest version of strings
-  const manager = Flex.Manager.getInstance();
-
-  const dafaultChat = Flex.DefaultTaskChannels.Chat.templates.TaskListItem.secondLine;
-  const dafaultChatLine = Flex.DefaultTaskChannels.ChatLine.templates.TaskListItem.secondLine;
-  const dafaultChatMessenger = Flex.DefaultTaskChannels.ChatMessenger.templates.TaskListItem.secondLine;
-  const dafaultChatSms = Flex.DefaultTaskChannels.ChatSms.templates.TaskListItem.secondLine;
-  const dafaultChatWhatsApp = Flex.DefaultTaskChannels.ChatWhatsApp.templates.TaskListItem.secondLine;
-
-  Flex.DefaultTaskChannels.Chat.templates.TaskListItem.secondLine = task =>
-    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
-      ? `${manager.strings['Transfer-Chat']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChat[uppercaseFirst(task.status)];
-
-  Flex.DefaultTaskChannels.ChatLine.templates.TaskListItem.secondLine = task =>
-    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
-      ? `${manager.strings['Transfer-ChatLine']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatLine[uppercaseFirst(task.status)];
-
-  Flex.DefaultTaskChannels.ChatMessenger.templates.TaskListItem.secondLine = task =>
-    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
-      ? `${manager.strings['Transfer-ChatMessenger']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatMessenger[uppercaseFirst(task.status)];
-
-  Flex.DefaultTaskChannels.ChatSms.templates.TaskListItem.secondLine = task =>
-    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
-      ? `${manager.strings['Transfer-ChatSms']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatSms[uppercaseFirst(task.status)];
-
-  Flex.DefaultTaskChannels.ChatWhatsApp.templates.TaskListItem.secondLine = task =>
-    TransferHelpers.hasTransferStarted(task) && task.status === 'pending'
-      ? `${manager.strings['Transfer-TaskLineChatWhatsAppReserved']} ${task.attributes.transferMeta.originalCounselorName} (${task.queueName})`
-      : dafaultChatWhatsApp[uppercaseFirst(task.status)];
 };

--- a/plugin-hrm-form/src/utils/transfer.js
+++ b/plugin-hrm-form/src/utils/transfer.js
@@ -107,8 +107,9 @@ export const setTransferRejected = updateTransferStatus(transferStatuses.rejecte
  * @param {ITask} task
  * @param {string} mode
  * @param {string} documentName name to retrieve the form or null if there were no form to save
+ * @param {string} counselorName
  */
-export const setTransferMeta = async (task, mode, documentName) => {
+export const setTransferMeta = async (task, mode, documentName, counselorName) => {
   // Set transfer metadata
   const updatedAttributes = {
     ...task.attributes,
@@ -116,6 +117,7 @@ export const setTransferMeta = async (task, mode, documentName) => {
       originalTask: task.taskSid,
       originalReservation: task.sid,
       originalCounselor: task.workerSid,
+      originalCounselorName: counselorName,
       transferStatus: mode === transferModes.warm ? transferStatuses.transferring : transferStatuses.accepted,
       formDocument: documentName,
       mode,


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-159

- Change the messaging for a new incoming task to say that it’s a transfer from another counselor (same as call transfers)
- Lock the form during warm transfer to be read-only for everyone