### PR TITLE
Use Close Contact when conversation ended

### DIFF
--- a/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.jsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTaskContext, Template } from '@twilio/flex-ui';
+import { withTaskContext, TaskHelper, Template } from '@twilio/flex-ui';
 import FaceIcon from '@material-ui/icons/Face';
 
 import { withLocalization } from '../../contexts/LocalizationContext';
@@ -89,6 +89,7 @@ const CallTypeButtons = props => {
       <NonDataCallTypeDialog
         isOpen={isDialogOpen(form)}
         isCallTask={isCallTask(task)}
+        isInWrapupMode={TaskHelper.isInWrapupMode(task)}
         handleConfirm={handleConfirmNonDataCallType}
         handleCancel={() => clearCallType(props)}
       />

--- a/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/NonDataCallTypeDialog.jsx
@@ -13,7 +13,7 @@ import {
 } from '../../styles/callTypeButtons';
 import TabPressWrapper from '../TabPressWrapper';
 
-const NonDataCallTypeDialog = ({ isOpen, isCallTask, handleConfirm, handleCancel }) => (
+const NonDataCallTypeDialog = ({ isOpen, isCallTask, isInWrapupMode, handleConfirm, handleCancel }) => (
   <CloseTaskDialog onClose={handleCancel} open={isOpen}>
     <TabPressWrapper>
       <NonDataCallTypeDialogContainer>
@@ -24,8 +24,11 @@ const NonDataCallTypeDialog = ({ isOpen, isCallTask, handleConfirm, handleCancel
         <Box marginBottom="32px">
           <Row>
             <ConfirmButton autoFocus tabIndex={1} onClick={handleConfirm}>
-              {/* eslint-disable-next-line react/jsx-max-depth */}
-              <Template code={isCallTask ? 'TaskHeaderEndCall' : 'TaskHeaderEndChat'} />
+              {/* eslint-disable react/jsx-max-depth,no-nested-ternary */}
+              <Template
+                code={isInWrapupMode ? 'CallType-CloseContact' : isCallTask ? 'TaskHeaderEndCall' : 'TaskHeaderEndChat'}
+              />
+              {/* eslint-enable react/jsx-max-depth,no-nested-ternary */}
             </ConfirmButton>
             <CancelButton tabIndex={2} onClick={handleCancel}>
               Cancel
@@ -41,6 +44,7 @@ NonDataCallTypeDialog.displayName = 'NonDataCallTypeDialog';
 NonDataCallTypeDialog.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   isCallTask: PropTypes.bool.isRequired,
+  isInWrapupMode: PropTypes.bool.isRequired,
   handleConfirm: PropTypes.func.isRequired,
   handleCancel: PropTypes.func.isRequired,
 };

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -13,6 +13,8 @@
   "CallType-wrongnumber": "Wrong Number",
   "CallType-abusive": "Abusive",
 
+  "CallType-CloseContact": "Close Contact",
+
   "SharedStateSaveFormError": "The information stored in the form couldn't be saved. Task will be transferred anyway.",
   "SharedStateLoadFormError": "The information stored in the form by previous counselor couldn't be retrieved. Starting current task with clear contact form.",
 


### PR DESCRIPTION
Joan mentioned that it's weird that our non-data call type confirmation dialog says "Hang Up" or "End Chat" even when we have already hung up or ended the chat.  This PR changes the messaging to "Close Contact" if we are already in the 'wrapping' state.

When the conversation is still open, it looks like it did before:
![Screen Shot 2020-06-26 at 5 33 21 PM](https://user-images.githubusercontent.com/10714292/85910468-ea977b80-b7d3-11ea-9633-97f58cb04b9d.png)
![Screen Shot 2020-06-26 at 5 34 19 PM](https://user-images.githubusercontent.com/10714292/85910471-ed926c00-b7d3-11ea-85f7-839531aed6cd.png)

But when the conversation has been ended, we show 'close contact':
![Screen Shot 2020-06-26 at 5 33 37 PM](https://user-images.githubusercontent.com/10714292/85910482-fa16c480-b7d3-11ea-8370-7aaca0f41bc9.png)
![Screen Shot 2020-06-26 at 5 34 35 PM](https://user-images.githubusercontent.com/10714292/85910485-fdaa4b80-b7d3-11ea-8278-493fa0262d2e.png)
