### PR TITLE
[WIP] Store all three categories concatenated in insights and do not store individual categories

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -98,10 +98,8 @@ test('saveInsightsData for data callType', async () => {
     taskSid: 'task-sid',
     conversations: {
       content: 'content',
-      conversation_attribute_1: 'Unspecified/Other - Missing children;Bullying',
+      conversation_attribute_1: 'Unspecified/Other - Missing children;Bullying;Addictive behaviours',
       conversation_attribute_2: 'Child calling about self',
-      conversation_attribute_3: 'Unspecified/Other - Missing children',
-      conversation_attribute_4: 'Bullying',
     },
     customers: {
       name: 'John Doe',

--- a/plugin-hrm-form/src/services/InsightsService.js
+++ b/plugin-hrm-form/src/services/InsightsService.js
@@ -19,7 +19,8 @@ function getSubcategories(task) {
     });
   });
 
-  return result.splice(0, 2);
+  // grab all three categories -- does this do that?  this comment can be removed
+  return result.splice(0, 3);
 }
 
 function buildConversationsObject(task) {
@@ -33,8 +34,6 @@ function buildConversationsObject(task) {
   return {
     conversation_attribute_1: subcategories.join(';'),
     conversation_attribute_2: callType,
-    conversation_attribute_3: subcategories[0],
-    conversation_attribute_4: subcategories[1],
   };
 }
 

--- a/plugin-hrm-form/src/services/InsightsService.js
+++ b/plugin-hrm-form/src/services/InsightsService.js
@@ -19,7 +19,6 @@ function getSubcategories(task) {
     });
   });
 
-  // grab all three categories -- does this do that?  this comment can be removed
   return result.splice(0, 3);
 }
 


### PR DESCRIPTION
@murilovmachado it was easier to code a bad version of this than try to describe it.  Joan and I agreed to drop the individual category custom fields and concatenate all three subcategories together.  Can you take this from here?  Edit if needed, check in, deploy to staging.  Today or tomorrow, message Joan and I when ready.  We'll wait to go to prod when we have channels.