### PR TITLE
Enable chat capabilities

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -186,6 +186,16 @@ const setUpActions = setupObject => {
   Flex.Actions.addListener('afterCompleteTask', ActionFunctions.removeContactForm);
 };
 
+/**
+ * @param  {...string} taskChannels
+ */
+const enableChatCapabilities = (...taskChannels) => {
+  const customChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel('custom-chat-channel', task =>
+    taskChannels.includes(task.taskChannelUniqueName),
+  );
+  Flex.TaskChannels.register(customChatChannel);
+};
+
 export default class HrmFormPlugin extends FlexPlugin {
   constructor() {
     super(PLUGIN_NAME);
@@ -215,6 +225,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     if (config.featureFlags.enable_transfers) setUpTransfers(setupObject);
     setUpComponents(setupObject);
     setUpActions(setupObject);
+    enableChatCapabilities('whatsapp', 'web');
 
     const managerConfiguration = {
       colorTheme: HrmTheme,

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -186,14 +186,35 @@ const setUpActions = setupObject => {
   Flex.Actions.addListener('afterCompleteTask', ActionFunctions.removeContactForm);
 };
 
-/**
- * @param  {...string} taskChannels
- */
-const enableChatCapabilities = (...taskChannels) => {
-  const customChatChannel = Flex.DefaultTaskChannels.createChatTaskChannel('custom-chat-channel', task =>
-    taskChannels.includes(task.taskChannelUniqueName),
-  );
-  Flex.TaskChannels.register(customChatChannel);
+const enableChatCapabilities = () => {
+  const customWhatsappChannel = {
+    ...Flex.DefaultTaskChannels.ChatWhatsApp,
+    name: 'custom-whatsapp-channel',
+    isApplicable: task => task.taskChannelUniqueName === 'whatsapp',
+  };
+
+  const customFacebookChannel = {
+    ...Flex.DefaultTaskChannels.ChatMessenger,
+    name: 'custom-facebook-channel',
+    isApplicable: task => task.taskChannelUniqueName === 'facebook',
+  };
+
+  const customWebChannel = {
+    ...Flex.DefaultTaskChannels.Chat,
+    name: 'custom-web-channel',
+    isApplicable: task => task.taskChannelUniqueName === 'web',
+  };
+
+  const customSmsChannel = {
+    ...Flex.DefaultTaskChannels.ChatSms,
+    name: 'custom-sms-channel',
+    isApplicable: task => task.taskChannelUniqueName === 'sms',
+  };
+
+  Flex.TaskChannels.register(customWhatsappChannel);
+  Flex.TaskChannels.register(customFacebookChannel);
+  Flex.TaskChannels.register(customWebChannel);
+  Flex.TaskChannels.register(customSmsChannel);
 };
 
 export default class HrmFormPlugin extends FlexPlugin {
@@ -225,7 +246,7 @@ export default class HrmFormPlugin extends FlexPlugin {
     if (config.featureFlags.enable_transfers) setUpTransfers(setupObject);
     setUpComponents(setupObject);
     setUpActions(setupObject);
-    enableChatCapabilities('whatsapp', 'web');
+    enableChatCapabilities();
 
     const managerConfiguration = {
       colorTheme: HrmTheme,


### PR DESCRIPTION
In order for the new `TaskChannels` to work properly, we need to add Chat Capabilities to them. And this is done by creating a `ChatTaskChannel`.

After this PR is merged, we need to go on https://www.twilio.com/console/flex/messaging and link `whatsapp`, `web`, `facebook` and `sms` to the `ChannelSelector Flow`.

~Didn't include `facebook` and `sms` yet, because I'm not sure how to trigger them.~
It worked for `whatsapp`, `web`, `facebook` and `sms`.

<img width="324" alt="Screen Shot 2020-07-13 at 19 51 34" src="https://user-images.githubusercontent.com/1504544/87361329-5a329800-c542-11ea-87c7-cd7249f230b0.png">
<img width="1140" alt="Screen Shot 2020-07-13 at 19 51 56" src="https://user-images.githubusercontent.com/1504544/87361334-5bfc5b80-c542-11ea-96c4-52484deedf0a.png">
