### PR TITLE
Move Insights reported customer attributes to conversation attributes

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -28,7 +28,6 @@ test('saveInsightsData for non-data callType', async () => {
       content: 'content',
       conversation_attribute_2: 'Abusive',
     },
-    customers: {},
   };
 
   expect(twilioTask.setAttributes).toHaveBeenCalledWith(expectedNewAttributes);
@@ -100,11 +99,11 @@ test('saveInsightsData for data callType', async () => {
       content: 'content',
       conversation_attribute_1: 'Unspecified/Other - Missing children;Bullying;Addictive behaviours',
       conversation_attribute_2: 'Child calling about self',
+      conversation_attribute_3: 'Boy',
+      conversation_attribute_4: '13-15'
     },
     customers: {
       name: 'John Doe',
-      customer_attribute_1: '13-15',
-      gender: 'Boy',
     },
   };
 

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -100,7 +100,7 @@ test('saveInsightsData for data callType', async () => {
       conversation_attribute_1: 'Unspecified/Other - Missing children;Bullying;Addictive behaviours',
       conversation_attribute_2: 'Child calling about self',
       conversation_attribute_3: 'Boy',
-      conversation_attribute_4: '13-15'
+      conversation_attribute_4: '13-15',
     },
     customers: {
       name: 'John Doe',

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -39,9 +39,6 @@ test('saveInsightsData for data callType', async () => {
     conversations: {
       content: 'content',
     },
-    customers: {
-      name: 'John Doe',
-    },
   };
 
   const twilioTask = {
@@ -101,9 +98,6 @@ test('saveInsightsData for data callType', async () => {
       conversation_attribute_2: 'Child calling about self',
       conversation_attribute_3: 'Boy',
       conversation_attribute_4: '13-15',
-    },
-    customers: {
-      name: 'John Doe',
     },
   };
 

--- a/plugin-hrm-form/src/components/tabbedForms/SelectOptions.js
+++ b/plugin-hrm-form/src/components/tabbedForms/SelectOptions.js
@@ -1,2 +1,2 @@
 export const genderOptions = ['Boy', 'Girl', 'Non-binary', 'Unknown'];
-export const ageOptions = ['0-3', '4-6', '7-9', '10-12', '13-15', '16-17', '18-25', '>25', 'Unknown'];
+export const ageOptions = ['0-03', '04-06', '07-09', '10-12', '13-15', '16-17', '18-25', '>25', 'Unknown'];

--- a/plugin-hrm-form/src/services/InsightsService.js
+++ b/plugin-hrm-form/src/services/InsightsService.js
@@ -29,45 +29,30 @@ function buildConversationsObject(task) {
   if (!hasCustomerData) return { conversation_attribute_2: callType };
 
   const subcategories = getSubcategories(task);
+  const { childInformation } = task;
 
   return {
     conversation_attribute_1: subcategories.join(';'),
     conversation_attribute_2: callType,
+    conversation_attribute_3: childInformation.gender.value,
+    conversation_attribute_4: childInformation.age.value,
   };
 }
 
-function buildCustomersObject(task) {
-  const callType = task.callType.value;
-  const hasCustomerData = !isNonDataCallType(callType);
-
-  if (!hasCustomerData) return {};
-
-  const { childInformation } = task;
-  return {
-    gender: childInformation.gender.value,
-    customer_attribute_1: childInformation.age.value,
-  };
-}
-
-function mergeAttributes(previousAttributes, { conversations, customers }) {
+function mergeAttributes(previousAttributes, { conversations }) {
   return {
     ...previousAttributes,
     conversations: {
       ...previousAttributes.conversations,
       ...conversations,
     },
-    customers: {
-      ...previousAttributes.customers,
-      ...customers,
-    },
   };
 }
 
 export async function saveInsightsData(twilioTask, task) {
   const conversations = buildConversationsObject(task);
-  const customers = buildCustomersObject(task);
   const previousAttributes = twilioTask.attributes;
-  const newAttributes = mergeAttributes(previousAttributes, { conversations, customers });
+  const newAttributes = mergeAttributes(previousAttributes, { conversations });
 
   await twilioTask.setAttributes(newAttributes);
 }


### PR DESCRIPTION
Now that we've learned that Insights "define customer based on their phone number so.. the same number means the same customer and customer_attribute_x will get overwritten over and over", we'll need to move age and gender to the conversation.  Sadly, this leaves only two free conversation attributes left, though we don't currently see another option.

Another request we have is to put leading zeroes on the select options for age so that they sort alphabetically in the drop-downs in Insights.  While I would prefer to have another layer of abstraction so that we do not couple all this together, this is probably okay for now.

Please think through if there are any other implications to these changes that I don't realize.  When everyone confirms it's good we'll move it to production.