### PR TITLE
Use 'Contact' instead of 'Case' or 'Call' where appropriate

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/CaseInformationTab.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/CaseInformationTab.jsx
@@ -13,7 +13,7 @@ const CaseInformationTab = ({ caseInformation, handleCheckboxClick, defaultEvent
       <ColumnarBlock>
         <FieldText
           id="CaseInformation_CallSummary"
-          label="Call summary"
+          label="Contact summary"
           field={caseInformation.callSummary}
           rows={10}
           {...defaultEventHandlers(['caseInformation'], 'callSummary')}

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -82,10 +82,10 @@
 
   "Categories-Title": "Categorize this contact",
   
-  "TabbedForms-AddCallerInfoTab": "Add Caller Information",
-  "TabbedForms-AddChildInfoTab": "Add Child Information",
-  "TabbedForms-CategoriesTab": "Categorize Issue",
-  "TabbedForms-AddCaseInfoTab": "Add Case Summary",
+  "TabbedForms-AddCallerInfoTab": "Caller Information",
+  "TabbedForms-AddChildInfoTab": "Child Information",
+  "TabbedForms-CategoriesTab": "Categories",
+  "TabbedForms-AddCaseInfoTab": "Summary",
 
   "NotImplemented": "Not implemented yet!",
   "Error-Backend": "Error from backend system.",


### PR DESCRIPTION
In our contact forms, we have been using the terms 'Case' and 'Call' in situations where 'Contact' is more appropriate.  With the introduction of case management, this can confuse the user.  This PR changes the "Call Summary" to "Contact Summary", and changes "Add Case Summary" to "Summary".  The change to "Add Contact Summary" made the tab three lines, so in discussion with our Product team we decided to remove the verbs on the tabs, shortening the names:

![image](https://user-images.githubusercontent.com/10714292/90532041-619a2200-e13c-11ea-980f-48eb6c6698f5.png)

In the code we still have labels like `caseInformation` which can now be confusing.  I've created [Jira issue CHI-205](https://bugs.benetech.org/browse/CHI-205) for later to consider whether we want to change those.  That change would ripple through the system, though, so it's not a job for now, and we may just want to live with it for awhile.

I think I just need @GPaoloni to review this, but @murilovmachado please do read this over when you have a chance.