### PR TITLE
Improved error message

### DIFF
--- a/deploy-scripts/copyFlow.js
+++ b/deploy-scripts/copyFlow.js
@@ -36,7 +36,10 @@ function recReplaceIds(flow, oldIdDict, newIdDict) {
 
               if (idName == null) {
                 throw new Error(
-                  `ERROR: The id ${val} is not present in the fromId file.`
+                  `The flow being copied refers to a value ${val}, ` +
+                    "but no key with such a value is present in the fromIds file. " +
+                    "Please add a key-value pair for this value to fromIds, and an analogous one " +
+                    "to the toIds file, with the value to be used in the new flow."
                 );
               } else {
                 val = newIdDict[idName];


### PR DESCRIPTION
Improved error message for copyFlow script, in the case where a key is missing in the input files.