### PR TITLE
Fix the copyBot script

### DIFF
--- a/deploy-scripts/copyBot.js
+++ b/deploy-scripts/copyBot.js
@@ -86,6 +86,9 @@ async function copyAssitant(oldIdsFile, newIdsFile) {
   await setUpTasks(fromBot.tasks, toBot.tasks, fromIds, toIds);
 
   await setUpFieldTypes(fromBot.fieldTypes, toBot.fieldTypes);
+
+  const defaults = (await bot.defaults().get().fetch()).data;
+  await toBot.defaults().update({ defaults });
 }
 
 // eslint-disable-next-line import/order

--- a/deploy-scripts/copyBot.js
+++ b/deploy-scripts/copyBot.js
@@ -1,17 +1,21 @@
 const fs = require("fs").promises;
+const { replaceIncidence } = require("./helpers");
 
-async function setUpTasks(clientFn, newClientFn) {
+async function setUpTasks(clientFn, newClientFn, fromIds, toIds) {
   const taskList = await clientFn.list();
   await Promise.all(
     taskList.map(async (task) => {
       // The task actions need to be gotten separately
-      const actions = clientFn(task.sid).taskActions().fetch();
+      const taskActions = await clientFn(task.sid).taskActions().fetch();
+      const actions = JSON.parse(
+        replaceIncidence(fromIds, toIds, JSON.stringify(taskActions.data))
+      );
 
       // Create a copy of this task
       const newTask = await newClientFn.create({
         friendlyName: task.friendlyName,
         uniqueName: task.uniqueName,
-        actions: actions.data,
+        actions,
       });
 
       // Now that we have our Task, add in all the samples
@@ -54,39 +58,37 @@ async function setUpFieldTypes(clientFn, newClientFn) {
 
 async function copyAssitant(oldIdsFile, newIdsFile) {
   const file = await fs.readFile(oldIdsFile, "utf8");
-  const ids = JSON.parse(file);
-  const accountSid = ids.AccountSid;
-  const authToken = ids.AuthToken;
+  const fromIds = JSON.parse(file);
+  const accountSid = fromIds.AccountSid;
+  const authToken = fromIds.AuthToken;
   // eslint-disable-next-line global-require
   const client = require("twilio")(accountSid, authToken);
 
   const newFile = await fs.readFile(newIdsFile, "utf8");
-  const newIds = JSON.parse(newFile);
-  const newSid = newIds.AccountSid;
-  const newAuthToken = newIds.AuthToken;
+  const toIds = JSON.parse(newFile);
+
+  const newSid = toIds.AccountSid;
+  const newAuthToken = toIds.AuthToken;
   // eslint-disable-next-line global-require
   const newClient = require("twilio")(newSid, newAuthToken);
 
-  const botId = ids.Bot_To_Copy;
+  const botId = fromIds.Bot_To_Copy;
+  const fromBot = client.autopilot.assistants(botId);
+  const bot = await fromBot.fetch();
 
-  const bot = await client.autopilot.assistants(botId).fetch();
   const newBot = await newClient.autopilot.assistants.create({
     friendlyName: bot.friendlyName,
     uniqueName: bot.uniqueName, // IF YOU GET AN ERROR THAT IT ALREADY EXISTS, JUST PUT ANOTHER STRING IN HERE
   });
   const newBotId = newBot.sid;
+  const toBot = newClient.autopilot.assistants(newBotId);
 
-  await setUpTasks(
-    client.autopilot.assistants(botId).tasks,
-    newClient.autopilot.assistants(newBotId).tasks
-  );
+  await setUpTasks(fromBot.tasks, toBot.tasks, fromIds, toIds);
 
-  await setUpFieldTypes(
-    client.autopilot.assistants(botId).fieldTypes,
-    newClient.autopilot.assistants(newBotId).fieldTypes
-  );
+  await setUpFieldTypes(fromBot.fieldTypes, toBot.fieldTypes);
 }
 
+// eslint-disable-next-line import/order
 const { argv } = require("yargs")
   .usage("npm run copyBot -- --fromIds {file} --toIds {file}")
   .alias("f", "fromIds")

--- a/deploy-scripts/helpers.js
+++ b/deploy-scripts/helpers.js
@@ -1,0 +1,28 @@
+/**
+ * Given fromIds and toIds files with accounts information, and a string, will replace each incidence of the values
+ * present in fromIds in the string, for the analogus ones in toIds.
+ * @param {{ [key: string]: string }} fromIds Key-value pairs of the account to copy from (account info, services, workspaces, etc)
+ * @param {{ [key: string]: string }} toIds Key-value pairs of the account to copy to (account info, services, workspaces, etc)
+ * @param {string} string The string to replace each incidence of the values in fromIds for it's analogus in toIds
+ *
+ * @example
+ * const fromIds = { k1: 'from value' };
+ * const toIds = { k1: 'to value' };
+ * const s = 'This is a string with > from values <';
+ * const result = replaceIncidence(fromIds, toIds, s);
+ * console.log(result); // 'This is a string with > to values <'
+ */
+const replaceIncidence = (fromIds, toIds, string) => {
+  const from = Object.keys(fromIds);
+
+  const result = from.reduce(
+    (prev, key) => prev.replace(fromIds[key], toIds[key]),
+    string
+  );
+
+  return result;
+};
+
+module.exports = {
+  replaceIncidence,
+};


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-234

Modified `copyBot` script to make it fully working. Once the bot is copied from one account to the other, just go to the bot in the Twilio console and click on "build models" to start using it. In order to make testing easier, you can use the flow that is currently inactive in prod ("Channel Selector Flow", the copied version.. sorry but the name can't be modified so we have two flows with that name), referencing the newly created bot in the autopilot flow box.
![Screenshot from 2020-09-11 18-04-11](https://user-images.githubusercontent.com/15805319/92972792-411e6880-f459-11ea-9318-8e2dd13810cf.png)
![Screenshot from 2020-09-11 18-04-23](https://user-images.githubusercontent.com/15805319/92972798-42e82c00-f459-11ea-8a78-4d5a3f58a1b9.png)

Important note: every url, service, workspace or whatever is referenced in the bot tasks (info that is tied to a particular twilio account), must be added to the `fromIds` and `toIds` input files in order to make the bot work out of the box. `staging.json` and `prod.json` files have been updated to the current state of the bot.