### PR TITLE
Change Sync Client error log

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -61,7 +61,7 @@ const setUpSharedStateClient = () => {
       const syncToken = await issueSyncToken();
       await sharedStateClient.updateToken(syncToken);
     } catch (err) {
-      console.log('SYNC TOKEN ERROR', err);
+      console.error('SYNC TOKEN ERROR', err);
     }
   };
 
@@ -72,7 +72,7 @@ const setUpSharedStateClient = () => {
       sharedStateClient = new SyncClient(syncToken);
       sharedStateClient.on('tokenAboutToExpire', () => updateSharedStateToken());
     } catch (err) {
-      console.log('SYNC CLIENT INIT ERROR', err);
+      console.error('SYNC CLIENT INIT ERROR', err);
     }
   };
 


### PR DESCRIPTION
Changed logs when there's a Synnc Client initialization to be an error instead, in order to be reported to Rollbar.