### PR TITLE
Quiet down log output to Rollbar

### DIFF
--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -6,7 +6,7 @@
     "bootstrap": "flex-plugin check-start",
     "postinstall": "npm run bootstrap",
     "prestart": "npm run bootstrap",
-    "dev": "SKIP_PREFLIGHT_CHECK=true npm start",
+    "dev": "SKIP_PREFLIGHT_CHECK=true NO_MONITORING=true npm start",
     "start": "flex-plugin start",
     "build": "flex-plugin build",
     "predeploy": "npm run build",

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -233,7 +233,7 @@ export default class HrmFormPlugin extends FlexPlugin {
    * @param manager { import('@twilio/flex-ui').Manager }
    */
   init(flex, manager) {
-    setUpMonitoring(this, manager.workerClient);
+    if (!process.env.NO_MONITORING) setUpMonitoring(this, manager.workerClient);
 
     console.log(`Welcome to ${PLUGIN_NAME} Version ${PLUGIN_VERSION}`);
     this.registerReducers(manager);

--- a/plugin-hrm-form/src/utils/setUpMonitoring.js
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.js
@@ -42,6 +42,8 @@ function setUpRollbarLogger(plugin, workerClient) {
       },
     },
     ignoredMessages: ['Warning: Failed prop type'],
+    maxItems: 500,
+    ignoreDuplicateErrors: true,
   });
 
   const myLogManager = new Flex.Log.LogManager({

--- a/plugin-hrm-form/src/utils/setUpMonitoring.js
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.js
@@ -28,7 +28,7 @@ function setUpDatadogRum(workerClient) {
 
 function setUpRollbarLogger(plugin, workerClient) {
   plugin.Rollbar = new Rollbar({
-    reportLevel: 'warning',
+    reportLevel: 'error',
     accessToken: rollbarAccessToken,
     captureUncaught: true,
     captureUnhandledRejections: true,


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-251

In order to send less items to Rollbar:
- Changed loglevel to `error`.
- Added an env-var to `npm run dev` script in order to avoid sending items from the development local server.