### PR TITLE
Continue to support transfers with manual pull

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -29,8 +29,7 @@ export const getConfig = () => {
 
   const hrmBaseUrl = manager.serviceConfiguration.attributes.hrm_base_url;
   const serverlessBaseUrl = manager.serviceConfiguration.attributes.serverless_base_url;
-  const worker = manager.workerClient;
-  const workerSid = worker.sid;
+  const workerSid = manager.workerClient.sid;
   const { helpline, counselorLanguage, helplineLanguage } = manager.workerClient.attributes;
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
@@ -42,7 +41,6 @@ export const getConfig = () => {
   return {
     hrmBaseUrl,
     serverlessBaseUrl,
-    worker,
     workerSid,
     helpline,
     currentWorkspace,

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -67,16 +67,10 @@ export const issueSyncToken = async (): Promise<string> => {
 
 // eslint-disable-next-line import/no-unused-modules
 export const adjustChatCapacity = async (adjustment: 'increase' | 'decrease'): Promise<void> => {
-  const { worker, workerSid } = getConfig();
-
-  // find will return a tuple with [channelSid, channelResource]
-  const [channelSid] = Array.from(worker.channels).find(c => c[1].taskChannelUniqueName === 'chat') as [string, any]; // type-casting as some Twilio types are missing
+  const { workerSid } = getConfig();
 
   const body = {
-    workspaceSid: worker.workspaceSid,
     workerSid,
-    channelSid,
-    workerLimit: worker.attributes.maxMessageCapacity,
     adjustment,
   };
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-256
This PR is related to: https://github.com/tech-matters/serverless/pull/25

This PR simplifies the call to `adjustChatCapacity` (serverless) from the plugin, as more logic has been moved to it.

Note: this PR is going to be merged against #218, and then into staging and deployed, in order to preserve transfers when adding manual pull.