### PR TITLE
Fix pre-survey not filling the form

### DIFF
--- a/plugin-hrm-form/src/utils/prepopulateForm.js
+++ b/plugin-hrm-form/src/utils/prepopulateForm.js
@@ -9,8 +9,8 @@ export const prepopulateForm = task => {
   if (task.attributes.memory) {
     const { answers } = task.attributes.memory.twilio.collected_data.collect_survey;
 
-    const gender = answers.gender.error ? 'Unknown' : mapGender(answers.gender.answer);
-    const age = mapAge(answers.age.answer);
+    const gender = !answers.gender || answers.gender.error ? 'Unknown' : mapGender(answers.gender.answer);
+    const age = !answers.age || answers.age.error ? 'Unknown' : mapAge(answers.age.answer);
 
     if (answers.about_self.answer === 'Yes') {
       Manager.getInstance().store.dispatch(Actions.prepopulateFormChild(gender, age, task.taskSid));


### PR DESCRIPTION
Pre-survey information is not being copied into the form because if there's an error, `answers.age` and `answers.gender` fields may be undefined in the chatbot memory. This PR adds 'Unknown' as value in such cases.