### PR TITLE
Fixed error that wrongly populates the form with caller info

### DIFF
--- a/plugin-hrm-form/src/utils/prepopulateForm.js
+++ b/plugin-hrm-form/src/utils/prepopulateForm.js
@@ -9,6 +9,9 @@ export const prepopulateForm = task => {
   if (task.attributes.memory) {
     const { answers } = task.attributes.memory.twilio.collected_data.collect_survey;
 
+    // If can't know if call is child or caller, do nothing here
+    if (!answers.about_self || !['Yes', 'No'].includes(answers.about_self.answer)) return;
+
     const gender = !answers.gender || answers.gender.error ? 'Unknown' : mapGender(answers.gender.answer);
     const age = !answers.age || answers.age.error ? 'Unknown' : mapAge(answers.age.answer);
 

--- a/plugin-hrm-form/src/utils/prepopulateForm.js
+++ b/plugin-hrm-form/src/utils/prepopulateForm.js
@@ -17,9 +17,9 @@ export const prepopulateForm = task => {
 
     if (answers.about_self.answer === 'Yes') {
       Manager.getInstance().store.dispatch(Actions.prepopulateFormChild(gender, age, task.taskSid));
-    } else {
+    } else if (answers.about_self.answer === 'No') {
       Manager.getInstance().store.dispatch(Actions.prepopulateFormCaller(gender, age, task.taskSid));
-    }
+    } else return;
 
     // Open tabbed form to first tab
     Manager.getInstance().store.dispatch(RoutingActions.changeRoute({ route: 'tabbed-forms' }, task.taskSid));


### PR DESCRIPTION
If pre-survey does not contain info about caller (child or someone in behalf), the form gets wrongly populated with caller info. This PR fixes that behavior.