### PR TITLE
Records channelType in Flex Insights

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -103,7 +103,7 @@ test('saveInsightsData for data callType', async () => {
       conversation_attribute_2: 'Child calling about self',
       conversation_attribute_3: 'Boy',
       conversation_attribute_4: '13-15',
-      conversation_attribute_6: 'Voice',
+      conversation_attribute_6: 'Call',
     },
   };
 

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -2,15 +2,16 @@
 import { saveInsightsData } from '../../services/InsightsService';
 
 test('saveInsightsData for non-data callType', async () => {
-  const previousAttributtes = {
+  const previousAttributes = {
     taskSid: 'task-sid',
+    channelType: 'sms',
     conversations: {
       content: 'content',
     },
   };
 
   const twilioTask = {
-    attributes: previousAttributtes,
+    attributes: previousAttributes,
     setAttributes: jest.fn(),
   };
 
@@ -24,9 +25,11 @@ test('saveInsightsData for non-data callType', async () => {
 
   const expectedNewAttributes = {
     taskSid: 'task-sid',
+    channelType: 'sms',
     conversations: {
       content: 'content',
       conversation_attribute_2: 'Abusive',
+      conversation_attribute_6: 'SMS',
     },
   };
 
@@ -34,15 +37,16 @@ test('saveInsightsData for non-data callType', async () => {
 });
 
 test('saveInsightsData for data callType', async () => {
-  const previousAttributtes = {
+  const previousAttributes = {
     taskSid: 'task-sid',
+    channelType: 'voice',
     conversations: {
       content: 'content',
     },
   };
 
   const twilioTask = {
-    attributes: previousAttributtes,
+    attributes: previousAttributes,
     setAttributes: jest.fn(),
   };
 
@@ -92,12 +96,14 @@ test('saveInsightsData for data callType', async () => {
 
   const expectedNewAttributes = {
     taskSid: 'task-sid',
+    channelType: 'voice',
     conversations: {
       content: 'content',
       conversation_attribute_1: 'Unspecified/Other - Missing children;Bullying;Addictive behaviours',
       conversation_attribute_2: 'Child calling about self',
       conversation_attribute_3: 'Boy',
       conversation_attribute_4: '13-15',
+      conversation_attribute_6: 'Voice',
     },
   };
 

--- a/plugin-hrm-form/src/utils/mappers.js
+++ b/plugin-hrm-form/src/utils/mappers.js
@@ -42,6 +42,8 @@ export const mapChannelForInsights = channel => {
       return 'Facebook';
     case channelTypes.web:
       return 'Web';
+    case channelTypes.voice:
+      return 'Call';
     default:
       return mapChannel(channel);
   }

--- a/plugin-hrm-form/src/utils/mappers.js
+++ b/plugin-hrm-form/src/utils/mappers.js
@@ -35,6 +35,18 @@ export const mapChannel = channel => {
   }
 };
 
+// Flex Insights reporting uses slightly different channel names than other uses
+export const mapChannelForInsights = channel => {
+  switch (channel) {
+    case channelTypes.facebook:
+      return 'Facebook';
+    case channelTypes.web:
+      return 'Web';
+    default:
+      return mapChannel(channel);
+  }
+};
+
 export const mapAge = age => {
   let ageStr;
   if (age === undefined) {


### PR DESCRIPTION
Now that we have unfortunately needed to abandon using separate TaskChannels for different channel types, we can no longer rely on the Communication Channel in Flex Insights to record the channel of a contact.  This PR uses Custom Conversation Attribute 6 to record `channelType` using the same words as we had in Communication Channel previously.

One note to remember:  we will need to localize some of these words ('Call', 'Web') for non-English helplines.