### PR TITLE
v0.9 bug fixes

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -203,7 +203,8 @@ export default class HrmFormPlugin extends FlexPlugin {
    * @param manager { import('@twilio/flex-ui').Manager }
    */
   init(flex, manager) {
-    if (!process.env.NO_MONITORING) setUpMonitoring(this, manager.workerClient);
+    const monitoringEnv = manager.serviceConfiguration.attributes.monitoringEnv || 'staging';
+    if (!process.env.NO_MONITORING) setUpMonitoring(this, manager.workerClient, monitoringEnv);
 
     console.log(`Welcome to ${PLUGIN_NAME} Version ${PLUGIN_VERSION}`);
     this.registerReducers(manager);

--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -170,8 +170,7 @@ const setUpActions = setupObject => {
   // bind setupObject to the functions that requires some initializaton
   const transferOverride = ActionFunctions.customTransferTask(setupObject);
   const wrapupOverride = ActionFunctions.wrapupTask(setupObject);
-  const beforeWrapupAction = ActionFunctions.beforeWrapupTask(setupObject);
-  const beforeCompleteAction = ActionFunctions.sendInsightsData(setupObject);
+  const beforeCompleteAction = ActionFunctions.beforeCompleteTask(setupObject);
 
   Flex.Actions.addListener('beforeAcceptTask', ActionFunctions.initializeContactForm);
 
@@ -183,8 +182,6 @@ const setUpActions = setupObject => {
     Flex.Actions.addListener('afterCancelTransfer', ActionFunctions.afterCancelTransfer);
 
   Flex.Actions.replaceAction('HangupCall', ActionFunctions.hangupCall);
-
-  Flex.Actions.addListener('beforeWrapupTask', beforeWrapupAction);
 
   Flex.Actions.replaceAction('WrapupTask', wrapupOverride);
 

--- a/plugin-hrm-form/src/utils/setUpMonitoring.js
+++ b/plugin-hrm-form/src/utils/setUpMonitoring.js
@@ -5,14 +5,12 @@ import { datadogRum } from '@datadog/browser-rum';
 import { PLUGIN_VERSION } from '../HrmFormPlugin';
 import { rollbarAccessToken, datadogAccessToken } from '../private/secret';
 
-const environment = 'production'; // maybe we should use envars for this?
-
-function setUpDatadogRum(workerClient) {
+function setUpDatadogRum(workerClient, monitoringEnv) {
   datadogRum.init({
     applicationId: 'a9a65b9e-69a4-438e-ae45-4c47e52fb0fa',
     clientToken: datadogAccessToken,
     site: 'datadoghq.com',
-    env: environment,
+    env: monitoringEnv,
     version: PLUGIN_VERSION,
     sampleRate: 100,
     trackInteractions: true,
@@ -27,14 +25,14 @@ function setUpDatadogRum(workerClient) {
   });
 }
 
-function setUpRollbarLogger(plugin, workerClient) {
+function setUpRollbarLogger(plugin, workerClient, monitoringEnv) {
   plugin.Rollbar = new Rollbar({
     reportLevel: 'error',
     accessToken: rollbarAccessToken,
     captureUncaught: true,
     captureUnhandledRejections: true,
     payload: {
-      environment,
+      environment: monitoringEnv,
       person: {
         id: workerClient.sid,
         account: workerClient.accountSid,
@@ -83,7 +81,7 @@ function setUpRollbarLogger(plugin, workerClient) {
   myLogManager.prepare().then(myLogManager.start);
 }
 
-export default function setUpMonitoring(plugin, workerClient) {
-  setUpDatadogRum(workerClient);
-  setUpRollbarLogger(plugin, workerClient);
+export default function setUpMonitoring(plugin, workerClient, monitoringEnv) {
+  setUpDatadogRum(workerClient, monitoringEnv);
+  setUpRollbarLogger(plugin, workerClient, monitoringEnv);
 }


### PR DESCRIPTION
This PR fixes two bugs:
- Chat capacity is decreased after a task is transferred to another counselor (1st commit).
- After accepting a task, if it's a transferred one, the state of the form saved by previous counselor is loaded into current form, OR chatbot memory is loaded otherwise (2nd commit). Previous behavior loaded chatbot memory in every scenario, sometimes overriding original counselor's input (e.g. if chatbot memory have unknown age but 1st counselor manage to capture that data, we want it to be preserved after a transfer).