### PR TITLE
Reduce logging in the TabbedForms area

### DIFF
--- a/plugin-hrm-form/src/components/HrmForm.tsx
+++ b/plugin-hrm-form/src/components/HrmForm.tsx
@@ -1,12 +1,11 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withTaskContext, ITask } from '@twilio/flex-ui';
 import { connect } from 'react-redux';
 
 import CallTypeButtons from './callTypeButtons';
 import TabbedForms from './tabbedForms';
 import Case from './case';
-import { formType } from '../types';
 import { namespace, routingBase } from '../states';
 import * as RoutingActions from '../states/routing/actions';
 import { RoutingState } from '../states/routing/reducer';
@@ -22,6 +21,7 @@ type OwnProps = {
   handleFocus: any;
   handleSelectSearchResult: any;
   changeTab: any;
+  changeRoute: any;
   handleValidateForm: any;
 };
 
@@ -70,19 +70,6 @@ const HrmForm: React.FC<Props> = props => {
 };
 
 HrmForm.displayName = 'HrmForm';
-HrmForm.propTypes = {
-  form: formType.isRequired,
-  handleBlur: PropTypes.func.isRequired,
-  handleCategoryToggle: PropTypes.func.isRequired,
-  handleChange: PropTypes.func.isRequired,
-  handleCallTypeButtonClick: PropTypes.func.isRequired,
-  handleCompleteTask: PropTypes.func.isRequired,
-  handleFocus: PropTypes.func.isRequired,
-  handleSelectSearchResult: PropTypes.func.isRequired,
-  changeTab: PropTypes.func.isRequired,
-  changeRoute: PropTypes.func.isRequired,
-  handleValidateForm: PropTypes.func.isRequired,
-};
 
 const mapStateToProps = (state, ownProps: OwnProps) => {
   const routingState: RoutingState = state[namespace][routingBase];

--- a/plugin-hrm-form/src/states/ContactState.js
+++ b/plugin-hrm-form/src/states/ContactState.js
@@ -16,6 +16,7 @@ import {
   PREPOPULATE_FORM_CALLER,
 } from './ActionTypes';
 import { INITIALIZE_CONTACT_STATE, RECREATE_CONTACT_STATE, REMOVE_CONTACT_STATE } from './types';
+import callTypes from './DomainConstants';
 import { countSelectedCategories } from './ValidationRules';
 import { copySearchResultIntoTask } from './contacts/helpers';
 import { getConfig } from '../HrmFormPlugin';
@@ -33,7 +34,6 @@ const findOrRecreate = (tasks, taskId) => {
 
   if (targetedTask === undefined) {
     const recreatedTask = recreateBlankForm();
-    console.log(`Had to recreate state for taskId ${taskId}`);
     return recreatedTask;
   }
 
@@ -47,10 +47,6 @@ const initialState = {
 export class Actions {
   static handleChange = (taskId, parents, name, value) => ({ type: HANDLE_CHANGE, name, taskId, value, parents });
 
-  /*
-   * There has to be a better way to do this rather than a one-off, but MUI does not make it easy
-   * static handleCallTypeButtonClick = (taskId, value, e) => ({type: HANDLE_CALLTYPE_BUTTON_CLICK, taskId: taskId, value: value});
-   */
   static handleCallTypeButtonClick = (taskId, value) => ({
     type: HANDLE_CHANGE,
     name: 'callType',
@@ -85,7 +81,6 @@ export const handleSelectSearchResult = (searchResult, taskId) => ({
   taskId,
 });
 
-// Will replace the below when we move over to field objects
 export function editNestedField(original, parents, name, change) {
   if (parents.length === 0) {
     return {
@@ -138,10 +133,6 @@ export function reduce(state = initialState, action) {
     }
 
     case HANDLE_CHANGE: {
-      console.log(
-        `!!!!!!!!!!!HANDLE CHANGE: action.name = ${action.name}, action.value = ${action.value}, task = ${action.taskId}, parents: ${action.parents}`,
-      );
-
       const { strings } = getConfig();
 
       const currentForm = findOrRecreate(state.tasks, action.taskId);
@@ -172,7 +163,6 @@ export function reduce(state = initialState, action) {
     }
 
     case INITIALIZE_CONTACT_STATE: {
-      console.log(`!!!!!!!!!CREATING NEW ENTRY FOR ${action.taskId}`);
       return {
         ...state,
         tasks: {
@@ -210,7 +200,6 @@ export function reduce(state = initialState, action) {
     }
 
     case REMOVE_CONTACT_STATE: {
-      console.log(`!!!!!!!!!DELETING ENTRY FOR ${action.taskId}`);
       return {
         ...state,
         tasks: omit(state.tasks, action.taskId),
@@ -256,7 +245,7 @@ export function reduce(state = initialState, action) {
             ...currentTask,
             callType: {
               ...currentTask.callType,
-              value: 'Child calling about self',
+              value: callTypes.child,
             },
             childInformation: {
               ...currentTask.childInformation,
@@ -286,7 +275,7 @@ export function reduce(state = initialState, action) {
             ...currentTask,
             callType: {
               ...currentTask.callType,
-              value: 'Someone calling about a child',
+              value: callTypes.caller,
             },
             callerInformation: {
               ...currentTask.callerInformation,

--- a/plugin-hrm-form/src/types/index.js
+++ b/plugin-hrm-form/src/types/index.js
@@ -10,7 +10,7 @@ export const counselorType = PropTypes.shape({
 });
 
 export const fieldType = PropTypes.shape({
-  value: PropTypes.oneOfType([PropTypes.string, counselorType]),
+  value: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, counselorType]),
   error: PropTypes.string,
   validation: PropTypes.arrayOf(PropTypes.string),
   touched: PropTypes.bool,
@@ -43,7 +43,7 @@ const categoryType = PropTypes.arrayOf(fieldType);
 
 const categoriesType = PropTypes.shape({
   error: PropTypes.string,
-  validation: PropTypes.string,
+  validation: PropTypes.arrayOf(PropTypes.string),
   touched: PropTypes.bool,
   categories: PropTypes.arrayOf(categoryType),
 });

--- a/plugin-hrm-form/src/types/index.js
+++ b/plugin-hrm-form/src/types/index.js
@@ -94,7 +94,7 @@ export const formType = PropTypes.shape({
 });
 
 export const localizationType = PropTypes.shape({
-  strings: PropTypes.object.isRequired,
+  manager: PropTypes.object.isRequired,
   isCallTask: PropTypes.func.isRequired,
 });
 


### PR DESCRIPTION
This removes unnecessary console.logs and fixes some propType warnings.  The commits are separately from each other and can be reviewed independently.