### PR TITLE
Move FieldText to TS and clear up DOM element warnings in TabbedForms

### DIFF
--- a/plugin-hrm-form/src/components/FieldText.tsx
+++ b/plugin-hrm-form/src/components/FieldText.tsx
@@ -11,9 +11,10 @@ type OwnProps = {
   placeholder?: string;
   field: FormFieldType;
   rows?: number;
-  handleBlur: any;
-  handleChange: any;
-  handleFocus: any;
+  // Someday we should make this consistent with DefaultEventHandlers in /components/common/forms/types.ts
+  handleBlur: React.FocusEventHandler<HTMLDivElement | HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement>;
+  handleChange: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement>;
+  handleFocus: React.FocusEventHandler<HTMLDivElement | HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement>;
 };
 
 const FieldText: React.FC<OwnProps> = ({

--- a/plugin-hrm-form/src/components/FieldText.tsx
+++ b/plugin-hrm-form/src/components/FieldText.tsx
@@ -1,14 +1,32 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { StyledInput, StyledLabel, ErrorText, TextField } from '../styles/HrmStyles';
 import RequiredAsterisk from './RequiredAsterisk';
-import { fieldType } from '../types';
+import { FormFieldType } from './common/forms/types';
 
-/**
- * @type {React.FC<any>}
- */
-const FieldText = ({ id, label, placeholder, field, rows, handleBlur, handleChange, handleFocus, ...rest }) => (
+type OwnProps = {
+  id: string;
+  label?: string | JSX.Element;
+  placeholder?: string;
+  field: FormFieldType;
+  rows?: number;
+  handleBlur: any;
+  handleChange: any;
+  handleFocus: any;
+};
+
+const FieldText: React.FC<OwnProps> = ({
+  id,
+  label,
+  placeholder,
+  field,
+  rows,
+  handleBlur,
+  handleChange,
+  handleFocus,
+  ...rest
+}) => (
   <TextField {...rest}>
     <StyledLabel htmlFor={id}>
       {label}
@@ -31,16 +49,6 @@ const FieldText = ({ id, label, placeholder, field, rows, handleBlur, handleChan
 
 FieldText.displayName = 'FieldText';
 
-FieldText.propTypes = {
-  id: PropTypes.string.isRequired,
-  label: PropTypes.string,
-  placeholder: PropTypes.string,
-  field: fieldType.isRequired,
-  rows: PropTypes.number,
-  handleBlur: PropTypes.func.isRequired,
-  handleChange: PropTypes.func.isRequired,
-  handleFocus: PropTypes.func.isRequired,
-};
 FieldText.defaultProps = {
   label: '',
   placeholder: '',

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -365,8 +365,8 @@ export const CategoryCheckboxField = styled('div')<BaseCheckboxProps>`
 `;
 CategoryCheckboxField.displayName = 'CategoryCheckboxField';
 
-export const StyledCategoryCheckbox = styled(props => (
-  <Checkbox {...props} classes={{ root: 'root', checked: 'checked' }} />
+export const StyledCategoryCheckbox = styled(({ color, ...rest }: BaseCheckboxProps) => (
+  <Checkbox {...rest} classes={{ root: 'root', checked: 'checked' }} />
 ))<BaseCheckboxProps>`
   &&&.root {
     color: ${({ disabled, color, theme }) => (disabled ? `${theme.colors.categoryDisabledColor}33` : color)};

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -169,7 +169,9 @@ type StyledSelectProps = {
   isPlaceholder?: boolean;
 };
 
-export const StyledSelect = styled(Select)<StyledSelectProps>`
+export const StyledSelect = styled(({ isPlaceholder = false, ...rest }: StyledSelectProps) => <Select {...rest} />)<
+  StyledSelectProps
+>`
   flex-grow: 0;
   flex-shrink: 0;
   width: 217px;

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -434,7 +434,9 @@ StyledTabs.displayName = 'StyledTabs';
 
 type StyledTabProps = { searchTab?: boolean };
 
-export const StyledTab = styled(props => <Tab {...props} classes={{ selected: 'selected' }} />)<StyledTabProps>`
+export const StyledTab = styled(({ searchTab = false, ...rest }: StyledTabProps) => (
+  <Tab {...rest} classes={{ selected: 'selected' }} />
+))<StyledTabProps>`
   && {
     min-width: ${({ searchTab }) => (searchTab ? '50px' : '130px')};
     width: ${({ searchTab }) => (searchTab ? '50px' : '130px')};


### PR DESCRIPTION
Eliminates the following console warnings:
* Failed prop type: Invalid prop `label` of type `object` supplied to `FieldText`, expected `string`.
* React does not recognize the `searchTab` prop on a DOM element
* React does not recognize the `isPlaceholder` prop on a DOM element
* Failed prop type: Invalid prop color of value #506BA599 supplied to Checkbox, expected one of [“primary”,“secondary”,“default”].

Moves `FieldText` to TS for the first one.  For the others, deconstructing the named property and passing `...rest` to the nested component.