### PR TITLE
Don't validate for missing categories on category tab clicked

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
@@ -97,15 +97,6 @@ const TabbedForms = props => {
     />,
   );
 
-  /**
-   * this is hokey
-   * we need to be able to mark that the categories field has been touched
-   * the only way to do this that I see is this.  Blech.
-   */
-  if (tab === 2 && !form.caseInformation.categories.touched) {
-    props.handleFocus(taskId, ['caseInformation'], 'categories');
-  }
-
   const tabs = [];
   tabs.push(<StyledTab searchTab key="Search" icon={<SearchIcon />} />);
   if (isCallerType) {


### PR DESCRIPTION
This error:
`Warning: Cannot update during an existing state transition (such as within render). Render methods should be a pure function of props and state.%s,\n    in TabbedForms`
is caused by the code removed in this PR.  We're calling a redux action while in the render.  I wrote this code ages ago, and my goal was to have the validation run so that if you click on the Categories tab, and then you click away from it BEFORE adding any categories, it will put the error icon in the tab.  However, I don't think we really need this.  We will still validate the form before submission and block submit if there are no categories.  And people have noticed that the error icon on categories shows up at weird times.

I would still like to have it show the error icon when you click away, and I'm open to ideas.  But if no one has ideas, I'm happy to just check this in to get rid of the warning.