### PR TITLE
[WIP] Prototyping form customization (with rhf)

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -1190,9 +1190,9 @@
       }
     },
     "@craco/craco": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-5.6.4.tgz",
-      "integrity": "sha512-/Qi6yPMOBC7SEZJEDI5vYaPiGFs7HzO4AAZkGB0W3MX2OCw4u4FZC+ZO6TBptGzM3QLrF7WFt5AyQnXhNBcn3A==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-5.7.0.tgz",
+      "integrity": "sha512-HpThSg+JZ8FuXtaRuNxLe/RH4TqRe7f6bZfB8tO5ukDthMrf8sKUNOkSS9vnsRbycVEAAuaOamXw+T6LPmqlIg==",
       "requires": {
         "cross-spawn": "^7.0.0",
         "lodash": "^4.17.15",
@@ -2649,9 +2649,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.161",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
-      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA=="
+      "version": "4.14.162",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz",
+      "integrity": "sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig=="
     },
     "@types/lodash.get": {
       "version": "4.4.6",
@@ -4945,9 +4945,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.4.0.tgz",
-      "integrity": "sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
+      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ=="
     },
     "cli-table": {
       "version": "0.3.1",
@@ -8233,11 +8233,6 @@
             "through": "^2.3.6"
           }
         },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -8339,11 +8334,6 @@
             "strip-ansi": "^6.0.0",
             "through": "^2.3.6"
           }
-        },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -15824,6 +15814,11 @@
       "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.3.tgz",
       "integrity": "sha512-gR2jvjUgIXI7ceFWJkr8owX4vKhV0IJoXIf/Dt7gESFe5OKiSz2H6d10mKTW8fN134NDI16J4HgEgq9pKqJd5A==",
       "dev": true
+    },
+    "react-hook-form": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.9.4.tgz",
+      "integrity": "sha512-9zD9iKYt6pN6aUxKvJycAmnMGuNmZJzO11V+uOxiQkq/8DncomqROjqdck2u2/wbDYN8/mAFamQmmBaIkn4ziw=="
     },
     "react-hotkeys": {
       "version": "2.0.0",

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -29,6 +29,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-hook-form": "^6.9.4",
     "react-keyboard-event-handler": "^1.5.4",
     "react-scripts": "^3.4.0",
     "react-test-renderer": "16.13.1",

--- a/plugin-hrm-form/src/components/common/forms/ChildForm.tsx
+++ b/plugin-hrm-form/src/components/common/forms/ChildForm.tsx
@@ -19,7 +19,7 @@ const ChildForm: React.FC<Props> = ({ contactForm, dispatch, task }) => {
   const defaultValues = contactForm.childForm;
   const methods = useForm({ defaultValues, shouldFocusError: false });
 
-  const { getValues } = methods;
+  const { getValues, trigger } = methods;
 
   const childFormDefinition = React.useMemo(() => {
     console.log('>>> useMemo called');
@@ -41,6 +41,9 @@ const ChildForm: React.FC<Props> = ({ contactForm, dispatch, task }) => {
       <form onSubmit={methods.handleSubmit(onSubmit)}>
         {childFormDefinition}
 
+        <button type="button" onClick={() => trigger()}>
+          Validate whenever we want
+        </button>
         <input type="submit" />
       </form>
     </FormProvider>

--- a/plugin-hrm-form/src/components/common/forms/ChildForm.tsx
+++ b/plugin-hrm-form/src/components/common/forms/ChildForm.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { ITask, withTaskContext } from '@twilio/flex-ui';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { RootState, namespace, contactsBase } from '../../../states';
+import { updateForm } from '../../../states/contacts/actions';
+import { createFormFromDefinition } from './formGenerators';
+import ChildFormDefinition from '../../../formDefinitions/childForm.json';
+import type { FormDefinition } from './types';
+
+type OwnProps = { task: ITask };
+
+// eslint-disable-next-line no-use-before-define
+type Props = OwnProps & ConnectedProps<typeof connector>;
+
+const ChildForm: React.FC<Props> = ({ contactForm, dispatch, task }) => {
+  const defaultValues = contactForm.childForm;
+  const methods = useForm({ defaultValues, shouldFocusError: false });
+
+  const { getValues } = methods;
+
+  const childFormDefinition = React.useMemo(() => {
+    console.log('>>> useMemo called');
+    const onBlur = () => {
+      const data = getValues();
+      dispatch(updateForm(task.taskSid, 'childForm', data));
+    };
+
+    // TODO: fix this typecasting
+    return createFormFromDefinition(ChildFormDefinition as FormDefinition)(onBlur);
+  }, [dispatch, getValues, task.taskSid]);
+
+  const onSubmit = data => console.log(data);
+
+  console.log('>>> re-render');
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>
+        {childFormDefinition}
+
+        <input type="submit" />
+      </form>
+    </FormProvider>
+  );
+};
+
+ChildForm.displayName = 'ChildForm';
+
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
+  contactForm: state[namespace][contactsBase].tasks[ownProps.task.taskSid],
+});
+
+const connector = connect(mapStateToProps);
+// @ts-ignore
+export default withTaskContext(connector(ChildForm));

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, ValidationRules } from 'react-hook-form';
 
 import { FormItem, FormRow } from '../../../styles/HrmStyles';
 import type { FormItemDefinition, FormDefinition } from './types';
@@ -12,8 +12,20 @@ const ConnectForm: React.FC<{ children: <P extends ReturnType<typeof useFormCont
   return children({ ...methods });
 };
 
+const getRules = (field: FormItemDefinition): ValidationRules => ({
+  max: field.max,
+  maxLength: field.maxLength,
+  min: field.min,
+  minLength: field.minLength,
+  pattern: field.pattern,
+  required: field.required,
+  validate: field.validate,
+});
+
 // eslint-disable-next-line react/display-name
 const getInputType = (field: FormItemDefinition) => (onBlur: () => void) => {
+  const rules = getRules(field);
+
   switch (field.type) {
     case 'input':
       return (
@@ -23,8 +35,30 @@ const getInputType = (field: FormItemDefinition) => (onBlur: () => void) => {
             return (
               <FormItem>
                 <label htmlFor={field.name}>{field.label}</label>
-                <input name={field.name} onBlur={onBlur} ref={register({ required: field.required })} />
+                <input name={field.name} onBlur={onBlur} ref={register(rules)} />
                 {field.required && errors[field.name] && <span>This field is required</span>}
+              </FormItem>
+            );
+          }}
+        </ConnectForm>
+      );
+    case 'numeric input':
+      return (
+        <ConnectForm key={`${field.name}-input`}>
+          {({ errors, register }) => {
+            console.log('>>> input rerender');
+            return (
+              <FormItem>
+                <label htmlFor={field.name}>{field.label}</label>
+                <input
+                  name={field.name}
+                  onBlur={onBlur}
+                  ref={register({
+                    ...rules,
+                    pattern: { value: /^[0-9]+$/g, message: 'This field only accepts numeric input.' },
+                  })}
+                />
+                {errors[field.name] && <span>{errors[field.name].message}</span>}
               </FormItem>
             );
           }}
@@ -36,7 +70,7 @@ const getInputType = (field: FormItemDefinition) => (onBlur: () => void) => {
           {({ errors, register }) => (
             <FormItem>
               <label htmlFor={field.name}>{field.label}</label>
-              <select name={field.name} onBlur={onBlur} ref={register({ required: field.required })}>
+              <select name={field.name} onBlur={onBlur} ref={register(rules)}>
                 {field.options.map(o => (
                   <option key={`${field.name}-${o.value}-option`} value={o.value}>
                     {o.label}

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -22,7 +22,7 @@ const getInputType = (field: FormItemDefinition) => (onBlur: () => void) => {
             console.log('>>> input rerender');
             return (
               <FormItem>
-                <span>{field.label}</span>
+                <label htmlFor={field.name}>{field.label}</label>
                 <input name={field.name} onBlur={onBlur} ref={register({ required: field.required })} />
                 {field.required && errors[field.name] && <span>This field is required</span>}
               </FormItem>
@@ -35,7 +35,7 @@ const getInputType = (field: FormItemDefinition) => (onBlur: () => void) => {
         <ConnectForm key={`${field.name}-select`}>
           {({ errors, register }) => (
             <FormItem>
-              <span>{field.label}</span>
+              <label htmlFor={field.name}>{field.label}</label>
               <select name={field.name} onBlur={onBlur} ref={register({ required: field.required })}>
                 {field.options.map(o => (
                   <option key={`${field.name}-${o.value}-option`} value={o.value}>

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { FormItem, FormRow } from '../../../styles/HrmStyles';
+import type { FormItemDefinition, FormDefinition } from './types';
+
+const ConnectForm: React.FC<{ children: <P extends ReturnType<typeof useFormContext>>(args: P) => JSX.Element }> = ({
+  children,
+}) => {
+  const methods = useFormContext();
+
+  return children({ ...methods });
+};
+
+// eslint-disable-next-line react/display-name
+const getInputType = (field: FormItemDefinition) => (onBlur: () => void) => {
+  switch (field.type) {
+    case 'input':
+      return (
+        <ConnectForm key={`${field.name}-input`}>
+          {({ errors, register }) => {
+            console.log('>>> input rerender');
+            return (
+              <FormItem>
+                <span>{field.label}</span>
+                <input name={field.name} onBlur={onBlur} ref={register({ required: field.required })} />
+                {field.required && errors[field.name] && <span>This field is required</span>}
+              </FormItem>
+            );
+          }}
+        </ConnectForm>
+      );
+    case 'select':
+      return (
+        <ConnectForm key={`${field.name}-select`}>
+          {({ errors, register }) => (
+            <FormItem>
+              <span>{field.label}</span>
+              <select name={field.name} onBlur={onBlur} ref={register({ required: field.required })}>
+                {field.options.map(o => (
+                  <option key={`${field.name}-${o.value}-option`} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+              {field.required && errors[field.name] && <span>This field is required</span>}
+            </FormItem>
+          )}
+        </ConnectForm>
+      );
+    default:
+      return null;
+  }
+};
+
+export const createFormFromDefinition = (definition: FormDefinition) => (onBlur: () => void): JSX.Element[] => {
+  console.log('>>>> createFormFromDefinition called');
+
+  if (!definition.length) return [];
+
+  if (definition.length === 1)
+    return [
+      <FormRow key={`${definition[0].name}-form-row`}>
+        {getInputType(definition[0])(onBlur)}
+        <div />
+      </FormRow>,
+    ];
+
+  const [x, y, ...rest] = definition;
+  const row = (
+    <FormRow key={`${x.name}-${y.name}-form-row`}>
+      {getInputType(x)(onBlur)}
+      {getInputType(y)(onBlur)}
+    </FormRow>
+  );
+  return [row, ...createFormFromDefinition(rest)(onBlur)];
+};

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -30,3 +30,25 @@ export type DefaultEventHandlers = (
   handleFocus: React.FocusEventHandler<HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement>;
   handleChange: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement>;
 };
+
+/**
+ * Types that may be used for customizable forms
+ */
+
+type InputDefinition = {
+  name: string;
+  label: string; // todo: this could be a code from the localized strings object
+  type: 'input';
+  required?: boolean;
+};
+
+type SelectDefinition = {
+  name: string;
+  label: string; // todo: this could be a code from the localized strings object
+  type: 'select';
+  options: { value: any; label: string }[];
+  required?: boolean;
+};
+
+export type FormItemDefinition = InputDefinition | SelectDefinition;
+export type FormDefinition = FormItemDefinition[];

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -1,3 +1,5 @@
+import type { ValidationRules } from 'react-hook-form';
+
 export type FormFieldType = { value: string; error?: string; validation?: string[]; touched?: boolean };
 
 export function isFormFieldType(object: any): object is FormFieldType {
@@ -39,16 +41,21 @@ type InputDefinition = {
   name: string;
   label: string; // todo: this could be a code from the localized strings object
   type: 'input';
-  required?: boolean;
-};
+  // required?: boolean;
+} & ValidationRules;
+
+type NumericInputDefinition = {
+  name: string;
+  label: string; // todo: this could be a code from the localized strings object
+  type: 'numeric input';
+} & ValidationRules;
 
 type SelectDefinition = {
   name: string;
   label: string; // todo: this could be a code from the localized strings object
   type: 'select';
   options: { value: any; label: string }[];
-  required?: boolean;
-};
+} & ValidationRules;
 
-export type FormItemDefinition = InputDefinition | SelectDefinition;
+export type FormItemDefinition = InputDefinition | NumericInputDefinition | SelectDefinition;
 export type FormDefinition = FormItemDefinition[];

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
@@ -14,6 +14,7 @@ import IssueCategorizationTab from './IssueCategorizationTab';
 import CaseInformationTab from './CaseInformationTab';
 import BottomBar from './BottomBar';
 import { hasTaskControl } from '../../utils/transfer';
+import ChildForm from '../common/forms/ChildForm';
 
 const TabbedForms = props => {
   const { task, form } = props;
@@ -80,11 +81,12 @@ const TabbedForms = props => {
   }
 
   body.push(
-    <ChildInformationTab
-      childInformation={form.childInformation}
-      handleCheckboxClick={handleCheckboxClick}
-      defaultEventHandlers={defaultEventHandlers}
-    />,
+    <ChildForm />
+    // <ChildInformationTab
+    //   childInformation={form.childInformation}
+    //   handleCheckboxClick={handleCheckboxClick}
+    //   defaultEventHandlers={defaultEventHandlers}
+    // />,
   );
 
   body.push(<IssueCategorizationTab form={form} taskId={taskId} handleCategoryToggle={handleCategoryToggle} />);

--- a/plugin-hrm-form/src/formDefinitions/childForm.json
+++ b/plugin-hrm-form/src/formDefinitions/childForm.json
@@ -32,5 +32,10 @@
       { "value": "female", "label": "Girl" }, 
       { "value": "unknown", "label": "Unknown" }
     ]
+  },
+  {
+    "name": "phone",
+    "label": "Phone",
+    "type": "numeric input"
   }
 ]

--- a/plugin-hrm-form/src/formDefinitions/childForm.json
+++ b/plugin-hrm-form/src/formDefinitions/childForm.json
@@ -34,6 +34,17 @@
     ]
   },
   {
+    "name": "anumber",
+    "label": "A Number",
+    "type": "select",
+    "options": [
+      { "value": 0, "label": "--Please choose an option--" },
+      { "value": 1, "label": "1" }, 
+      { "value": 2, "label": "2" }, 
+      { "value": 3, "label": "3" }
+    ]
+  },
+  {
     "name": "phone",
     "label": "Phone",
     "type": "numeric input"

--- a/plugin-hrm-form/src/formDefinitions/childForm.json
+++ b/plugin-hrm-form/src/formDefinitions/childForm.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "firstName",
+    "label": "First Name",
+    "type": "input",
+    "required": true
+  },
+  {
+    "name": "lastName",
+    "label": "Last Name",
+    "type": "input"
+  },
+  {
+    "name": "age",
+    "label": "Age",
+    "type": "select",
+    "options": [
+      { "value": "", "label": "--Please choose an option--" },
+      { "value": "0-03", "label": "<= 3" }, 
+      { "value": "04-06", "label": "04-06" }, 
+      { "value": "06-09", "label": "06-09" }
+    ],
+    "required": true
+  },
+  {
+    "name": "gender",
+    "label": "Gender",
+    "type": "select",
+    "options": [
+      { "value": "", "label": "--Please choose an option--" },
+      { "value": "male", "label": "Boy" }, 
+      { "value": "female", "label": "Girl" }, 
+      { "value": "unknown", "label": "Unknown" }
+    ]
+  }
+]

--- a/plugin-hrm-form/src/states/contacts/actions.ts
+++ b/plugin-hrm-form/src/states/contacts/actions.ts
@@ -1,0 +1,11 @@
+import * as t from './types';
+
+// Action creators
+export const initFormAction = (taskSid: string): t.ContactsActionType => ({ type: t.INIT_FORM, taskSid });
+
+export const updateForm = (taskId: string, parent: string, payload: any): t.ContactsActionType => ({
+  type: t.UPDATE_FORM,
+  taskId,
+  parent,
+  payload,
+});

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -3,6 +3,7 @@ import { omit } from 'lodash';
 import * as t from './types';
 import ChildFormDefinition from '../../formDefinitions/childForm.json';
 import { INITIALIZE_CONTACT_STATE, RECREATE_CONTACT_STATE, REMOVE_CONTACT_STATE, GeneralActionType } from '../types';
+import type { FormItemDefinition, FormDefinition } from '../../components/common/forms/types';
 
 type TaskEntry = {
   childForm: { [key: string]: string | boolean };
@@ -14,7 +15,25 @@ export type ContactsState = {
   };
 };
 
-export const initialChildForm = ChildFormDefinition.reduce((acc, f) => ({ ...acc, [f.name]: '' }), {});
+const getInitialValue = (def: FormItemDefinition) => {
+  switch (def.type) {
+    case 'input':
+      return '';
+    case 'numeric input':
+      return '';
+    case 'select':
+      return def.options[0].value;
+    default:
+      return null;
+  }
+};
+
+const createFormItem = <T extends {}>(obj: T, def: FormItemDefinition) => ({
+  ...obj,
+  [def.name]: getInitialValue(def),
+});
+
+export const initialChildForm = (ChildFormDefinition as FormDefinition).reduce(createFormItem, {});
 
 const newTaskEntry: TaskEntry = { childForm: initialChildForm };
 

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -1,0 +1,63 @@
+import { omit } from 'lodash';
+
+import * as t from './types';
+import ChildFormDefinition from '../../formDefinitions/childForm.json';
+import { INITIALIZE_CONTACT_STATE, RECREATE_CONTACT_STATE, REMOVE_CONTACT_STATE, GeneralActionType } from '../types';
+
+type TaskEntry = {
+  childForm: { [key: string]: string | boolean };
+};
+
+export type ContactsState = {
+  tasks: {
+    [taskId: string]: TaskEntry;
+  };
+};
+
+export const initialChildForm = ChildFormDefinition.reduce((acc, f) => ({ ...acc, [f.name]: '' }), {});
+
+const newTaskEntry: TaskEntry = { childForm: initialChildForm };
+
+const initialState: ContactsState = { tasks: {} };
+
+// eslint-disable-next-line import/no-unused-modules
+export function reduce(state = initialState, action: t.ContactsActionType | GeneralActionType): ContactsState {
+  switch (action.type) {
+    case INITIALIZE_CONTACT_STATE:
+      return {
+        ...state,
+        tasks: {
+          ...state.tasks,
+          [action.taskId]: newTaskEntry,
+        },
+      };
+    case RECREATE_CONTACT_STATE:
+      if (state.tasks[action.taskId]) return state;
+
+      return {
+        ...state,
+        tasks: {
+          ...state.tasks,
+          [action.taskId]: newTaskEntry,
+        },
+      };
+    case REMOVE_CONTACT_STATE:
+      return {
+        ...state,
+        tasks: omit(state.tasks, action.taskId),
+      };
+    case t.UPDATE_FORM:
+      return {
+        ...state,
+        tasks: {
+          ...state.tasks,
+          [action.taskId]: {
+            ...state.tasks[action.taskId],
+            [action.parent]: action.payload,
+          },
+        },
+      };
+    default:
+      return state;
+  }
+}

--- a/plugin-hrm-form/src/states/contacts/types.ts
+++ b/plugin-hrm-form/src/states/contacts/types.ts
@@ -1,0 +1,17 @@
+// Action types
+export const INIT_FORM = 'INIT_FORM';
+export const UPDATE_FORM = 'UPDATE_FORM';
+
+type InitFormAction = {
+  type: typeof INIT_FORM;
+  taskSid: string;
+};
+
+type UpdateForm = {
+  type: typeof UPDATE_FORM;
+  taskId: string;
+  parent: string;
+  payload: any;
+};
+
+export type ContactsActionType = InitFormAction | UpdateForm;

--- a/plugin-hrm-form/src/states/index.ts
+++ b/plugin-hrm-form/src/states/index.ts
@@ -7,6 +7,7 @@ import { reduce as ConnectedCaseReducer } from './case/reducer';
 import { reduce as QueuesStatusReducer } from './queuesStatus/reducer';
 import { reduce as ConfigurationReducer } from './configuration/reducer';
 import { reduce as RoutingReducer } from './routing/reducer';
+import { reduce as ContactsReducer } from './contacts/reducer';
 
 // Register your redux store under a unique namespace
 export const namespace = 'plugin-hrm-form';
@@ -16,6 +17,7 @@ export const connectedCaseBase = 'connectedCase';
 export const queuesStatusBase = 'queuesStatusState';
 export const configurationBase = 'configuration';
 export const routingBase = 'routing';
+export const contactsBase = 'contacts';
 
 const reducers = {
   [contactFormsBase]: ContactStateReducer,
@@ -24,6 +26,7 @@ const reducers = {
   [connectedCaseBase]: ConnectedCaseReducer,
   [configurationBase]: ConfigurationReducer,
   [routingBase]: RoutingReducer,
+  [contactsBase]: ContactsReducer,
 };
 
 // Combine the reducers

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -321,6 +321,18 @@ export const NameFields = styled('div')`
 `;
 NameFields.displayName = 'NameFields';
 
+export const FormRow = styled(NameFields)`
+  margin: 10px 0;
+`;
+FormRow.displayName = 'FormRow';
+
+export const FormItem = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+FormItem.displayName = 'FormItem';
+
 export const ColumnarBlock = styled('div')`
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Notes on this task: https://benetech.app.box.com/notes/729346531651

This PR is a prototype for generating forms from a config file (json) introducing [React Hook Forms](https://github.com/react-hook-form/react-hook-form) library. The form state is saved internally in the form component, and copied into Redux onBlur event, validation is handled by rhf components, updates to global state are dispatched on each onBlur event (can be easily changed to be other event tho) and structure for the global state needs to change for this approach. Initially, the child tab info is the one being generated this way.