### PR TITLE
[WIP] Prototyping form customization (with current form handling) 

### DIFF
--- a/plugin-hrm-form/src/components/FieldSelect.jsx
+++ b/plugin-hrm-form/src/components/FieldSelect.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Template } from '@twilio/flex-ui';
 
 import { ErrorText, StyledLabel, StyledMenuItem, StyledSelect, TextField } from '../styles/HrmStyles';
 import RequiredAsterisk from './RequiredAsterisk';
@@ -24,7 +25,7 @@ const renderOptions = options =>
       case 'object':
         return (
           <StyledMenuItem key={option.value} value={option}>
-            {option.label}
+            <Template code={option.label} />
           </StyledMenuItem>
         );
       default:
@@ -50,7 +51,9 @@ const FieldSelect = ({
   const isPlaceholder = !(typeof field.value === 'object' ? Boolean(field.value.label) : Boolean(field.value));
 
   const renderValue =
-    typeof field.value === 'object' ? option => option.label || placeholder : option => option || placeholder;
+    typeof field.value === 'object'
+      ? option => <Template code={option.label} /> || placeholder
+      : option => option || placeholder;
 
   return (
     <TextField {...rest}>

--- a/plugin-hrm-form/src/components/common/forms/ChildForm.tsx
+++ b/plugin-hrm-form/src/components/common/forms/ChildForm.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+import { createFormFromDefinition } from './formGenerators';
+import ChildFormDefinition from '../../../formDefinitions/childForm.json';
+import type { FormDefinition } from './types';
+import { Container } from '../../../styles/HrmStyles';
+
+type OwnProps = { childInformation: any; defaultEventHandlers: any };
+
+// eslint-disable-next-line no-use-before-define
+type Props = OwnProps;
+
+const ChildForm: React.FC<Props> = ({ childInformation, defaultEventHandlers }) => {
+  const childFormDefinition = React.useMemo(() => {
+    console.log('>>> useMemo called');
+
+    const handlers = (parents: string[], name: string) => defaultEventHandlers(['childInformation', ...parents], name);
+
+    // TODO: fix this typecasting
+    return createFormFromDefinition(handlers)(childInformation)(ChildFormDefinition as FormDefinition);
+  }, [childInformation, defaultEventHandlers]);
+
+  console.log('>>> re-render');
+
+  return <Container>{childFormDefinition}</Container>;
+};
+
+ChildForm.displayName = 'ChildForm';
+
+export default ChildForm;

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { get } from 'lodash';
+import { Template } from '@twilio/flex-ui';
 
 import FieldText from '../../FieldText';
 import FieldSelect from '../../FieldSelect';
@@ -9,13 +10,15 @@ import { getParents } from './helpers';
 
 // eslint-disable-next-line react/display-name
 const getInputType = defaultEventHandlers => field => (def: FormItemDefinition) => {
+  const label = <Template code={def.label} />;
+
   const parents = getParents(def);
   switch (def.type) {
     case 'input':
       return (
         <FieldText
           id={[...parents, def.name].join('')}
-          label={def.label}
+          label={label}
           field={field}
           {...defaultEventHandlers(parents, def.name)}
         />
@@ -25,7 +28,7 @@ const getInputType = defaultEventHandlers => field => (def: FormItemDefinition) 
         <FieldSelect
           id={[...parents, def.name].join('')}
           name={def.name}
-          label={def.label}
+          label={label}
           options={def.options}
           field={field}
           {...defaultEventHandlers(parents, def.name)}

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -2,19 +2,33 @@ import React from 'react';
 import { get } from 'lodash';
 
 import FieldText from '../../FieldText';
+import FieldSelect from '../../FieldSelect';
 import { FormRow } from '../../../styles/HrmStyles';
 import { FormItemDefinition, FormDefinition } from './types';
+import { getParents } from './helpers';
 
 // eslint-disable-next-line react/display-name
 const getInputType = defaultEventHandlers => field => (def: FormItemDefinition) => {
+  const parents = getParents(def);
   switch (def.type) {
     case 'input':
       return (
         <FieldText
-          id={[...def.parents, def.name].join('')}
+          id={[...parents, def.name].join('')}
           label={def.label}
           field={field}
-          {...defaultEventHandlers(def.parents, def.name)}
+          {...defaultEventHandlers(parents, def.name)}
+        />
+      );
+    case 'select':
+      return (
+        <FieldSelect
+          id={[...parents, def.name].join('')}
+          name={def.name}
+          label={def.label}
+          options={def.options}
+          field={field}
+          {...defaultEventHandlers(parents, def.name)}
         />
       );
     default:
@@ -30,7 +44,9 @@ export const createFormFromDefinition = defaultEventHandlers => form => (definit
   if (definition.length === 1)
     return [
       <FormRow key={`${definition[0].name}-form-row`}>
-        {getInputType(defaultEventHandlers)(get(form, [...definition[0].parents, definition[0].name]))(definition[0])}
+        {getInputType(defaultEventHandlers)(get(form, [...getParents(definition[0]), definition[0].name]))(
+          definition[0],
+        )}
         <div />
       </FormRow>,
     ];
@@ -38,8 +54,8 @@ export const createFormFromDefinition = defaultEventHandlers => form => (definit
   const [x, y, ...rest] = definition;
   const row = (
     <FormRow key={`${x.name}-${y.name}-form-row`}>
-      {getInputType(defaultEventHandlers)(get(form, [...x.parents, x.name]))(x)}
-      {getInputType(defaultEventHandlers)(get(form, [...y.parents, y.name]))(y)}
+      {getInputType(defaultEventHandlers)(get(form, [...getParents(x), x.name]))(x)}
+      {getInputType(defaultEventHandlers)(get(form, [...getParents(y), y.name]))(y)}
     </FormRow>
   );
   return [row, ...createFormFromDefinition(defaultEventHandlers)(form)(rest)];

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { get } from 'lodash';
+
+import FieldText from '../../FieldText';
+import { FormRow } from '../../../styles/HrmStyles';
+import { FormItemDefinition, FormDefinition } from './types';
+
+// eslint-disable-next-line react/display-name
+const getInputType = defaultEventHandlers => field => (def: FormItemDefinition) => {
+  switch (def.type) {
+    case 'input':
+      return (
+        <FieldText
+          id={[...def.parents, def.name].join('')}
+          label={def.label}
+          field={field}
+          {...defaultEventHandlers(def.parents, def.name)}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+export const createFormFromDefinition = defaultEventHandlers => form => (definition: FormDefinition): JSX.Element[] => {
+  console.log('>>>> createFormFromDefinition called');
+
+  if (!definition.length) return [];
+
+  if (definition.length === 1)
+    return [
+      <FormRow key={`${definition[0].name}-form-row`}>
+        {getInputType(defaultEventHandlers)(get(form, [...definition[0].parents, definition[0].name]))(definition[0])}
+        <div />
+      </FormRow>,
+    ];
+
+  const [x, y, ...rest] = definition;
+  const row = (
+    <FormRow key={`${x.name}-${y.name}-form-row`}>
+      {getInputType(defaultEventHandlers)(get(form, [...x.parents, x.name]))(x)}
+      {getInputType(defaultEventHandlers)(get(form, [...y.parents, y.name]))(y)}
+    </FormRow>
+  );
+  return [row, ...createFormFromDefinition(defaultEventHandlers)(form)(rest)];
+};

--- a/plugin-hrm-form/src/components/common/forms/helpers.ts
+++ b/plugin-hrm-form/src/components/common/forms/helpers.ts
@@ -1,4 +1,4 @@
-import { FormValues, isFormFieldType } from './types';
+import { FormValues, isFormFieldType, FormItemDefinition } from './types';
 import { isNotCategory } from '../../../states/ContactFormStateFactory';
 
 export const getFormValues = <T>(formInformation: T): FormValues<T> => {
@@ -13,3 +13,5 @@ export const getFormValues = <T>(formInformation: T): FormValues<T> => {
 
   return values;
 };
+
+export const getParents = (def: FormItemDefinition) => def.parents || [];

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -30,3 +30,26 @@ export type DefaultEventHandlers = (
   handleFocus: React.FocusEventHandler<HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement>;
   handleChange: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement>;
 };
+
+/**
+ * Types that may be used for customizable forms
+ */
+
+type InputDefinition = {
+  name: string;
+  label: string; // todo: this could be a code from the localized strings object
+  type: 'input';
+  required?: boolean;
+  parents: string[];
+};
+
+type SelectDefinition = {
+  name: string;
+  label: string; // todo: this could be a code from the localized strings object
+  type: 'select';
+  parents: string[];
+  options: { value: any; label: string }[];
+};
+
+export type FormItemDefinition = InputDefinition | SelectDefinition;
+export type FormDefinition = FormItemDefinition[];

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -35,21 +35,21 @@ export type DefaultEventHandlers = (
  * Types that may be used for customizable forms
  */
 
-type InputDefinition = {
+type ItemBase = {
   name: string;
   label: string; // todo: this could be a code from the localized strings object
-  type: 'input';
+  parents?: string[];
   required?: boolean;
-  parents: string[];
 };
 
+type InputDefinition = {
+  type: 'input';
+} & ItemBase;
+
 type SelectDefinition = {
-  name: string;
-  label: string; // todo: this could be a code from the localized strings object
   type: 'select';
-  parents: string[];
   options: { value: any; label: string }[];
-};
+} & ItemBase;
 
 export type FormItemDefinition = InputDefinition | SelectDefinition;
 export type FormDefinition = FormItemDefinition[];

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
@@ -14,6 +14,7 @@ import IssueCategorizationTab from './IssueCategorizationTab';
 import CaseInformationTab from './CaseInformationTab';
 import BottomBar from './BottomBar';
 import { hasTaskControl } from '../../utils/transfer';
+import ChildForm from '../common/forms/ChildForm';
 
 const TabbedForms = props => {
   const { task, form } = props;
@@ -79,13 +80,13 @@ const TabbedForms = props => {
     );
   }
 
-  body.push(
-    <ChildInformationTab
-      childInformation={form.childInformation}
-      handleCheckboxClick={handleCheckboxClick}
-      defaultEventHandlers={defaultEventHandlers}
-    />,
-  );
+  // eslint-disable-next-line multiline-comment-style
+  // <ChildInformationTab
+  //   childInformation={form.childInformation}
+  //   handleCheckboxClick={handleCheckboxClick}
+  //   defaultEventHandlers={defaultEventHandlers}
+  // />,
+  body.push(<ChildForm defaultEventHandlers={defaultEventHandlers} childInformation={form.childInformation} />);
 
   body.push(<IssueCategorizationTab form={form} taskId={taskId} handleCategoryToggle={handleCategoryToggle} />);
 

--- a/plugin-hrm-form/src/formDefinitions/childForm.json
+++ b/plugin-hrm-form/src/formDefinitions/childForm.json
@@ -15,15 +15,55 @@
   {
     "name": "age",
     "label": "Age",
-    "parents": [],
     "type": "input",
     "required": true
   },
   {
     "name": "gender",
     "label": "Gender",
-    "parents": [],
-    "type": "input",
-    "required": true
+    "type": "select",
+    "options": [
+      { "value": "", "label": "--Please choose an option--" },
+      { "value": "Male", "label": "Male" }, 
+      { "value": "Female", "label": "Female" }, 
+      { "value": "Non-Binary", "label": "Non-Binary" },
+      { "value": "Unknown", "label": "Unknown" }
+    ]
+  },
+  {
+    "name": "language",
+    "label": "Language",
+    "type": "select",
+    "options": [
+      { "value": "", "label": "--Please choose an option--" },
+      { "value": "Unknown", "label": "Unknown" },
+      { "value": "Afrikaans", "label": "Afrikaans" },
+      { "value": "English", "label": "English" },
+      { "value": "Ndebele", "label": "Ndebele" },
+      { "value": "Other", "label": "Other" },
+      { "value": "Sepedi", "label": "Sepedi" },
+      { "value": "Sign Language", "label": "Sign Language" },
+      { "value": "Sotho", "label": "Sotho" },
+      { "value": "Swazi", "label": "Swazi" },
+      { "value": "Tshivenda", "label": "Tshivenda" },
+      { "value": "Tsonga", "label": "Tsonga" },
+      { "value": "Tswana", "label": "Tswana" },
+      { "value": "Xhosa", "label": "Xhosa" },
+      { "value": "Zulu", "label": "Zulu" }
+    ]
+  },
+  {
+    "name": "livingSituation",
+    "label": "Living Situation",
+    "type": "select",
+    "options": [
+      { "value": "", "label": "--Please choose an option--" },
+      { "value": "Foster care", "label": "Foster care" }, 
+      { "value": "Group facility", "label": "Group facility" }, 
+      { "value": "On their own", "label": "On their own" },
+      { "value": "With parent(s) or guardian(s)", "label": "With parent(s) or guardian(s)" }, 
+      { "value": "With relatives", "label": "With relatives" }, 
+      { "value": "Unknown", "label": "Unknown" }
+    ]
   }
 ]

--- a/plugin-hrm-form/src/formDefinitions/childForm.json
+++ b/plugin-hrm-form/src/formDefinitions/childForm.json
@@ -23,7 +23,7 @@
     "label": "Gender",
     "type": "select",
     "options": [
-      { "value": "", "label": "--Please choose an option--" },
+      { "value": "", "label": "SelectChoseAnOption" },
       { "value": "Male", "label": "Male" }, 
       { "value": "Female", "label": "Female" }, 
       { "value": "Non-Binary", "label": "Non-Binary" },
@@ -35,7 +35,7 @@
     "label": "Language",
     "type": "select",
     "options": [
-      { "value": "", "label": "--Please choose an option--" },
+      { "value": "", "label": "SelectChoseAnOption" },
       { "value": "Unknown", "label": "Unknown" },
       { "value": "Afrikaans", "label": "Afrikaans" },
       { "value": "English", "label": "English" },
@@ -57,7 +57,7 @@
     "label": "Living Situation",
     "type": "select",
     "options": [
-      { "value": "", "label": "--Please choose an option--" },
+      { "value": "", "label": "SelectChoseAnOption" },
       { "value": "Foster care", "label": "Foster care" }, 
       { "value": "Group facility", "label": "Group facility" }, 
       { "value": "On their own", "label": "On their own" },

--- a/plugin-hrm-form/src/formDefinitions/childForm.json
+++ b/plugin-hrm-form/src/formDefinitions/childForm.json
@@ -3,34 +3,27 @@
     "name": "firstName",
     "label": "First Name",
     "type": "input",
+    "parents": ["name"],
     "required": true
   },
   {
     "name": "lastName",
     "label": "Last Name",
+    "parents": ["name"],
     "type": "input"
   },
   {
     "name": "age",
     "label": "Age",
-    "type": "select",
-    "options": [
-      { "value": "", "label": "--Please choose an option--" },
-      { "value": "0-03", "label": "<= 3" }, 
-      { "value": "04-06", "label": "04-06" }, 
-      { "value": "06-09", "label": "06-09" }
-    ],
+    "parents": [],
+    "type": "input",
     "required": true
   },
   {
     "name": "gender",
     "label": "Gender",
-    "type": "select",
-    "options": [
-      { "value": "", "label": "--Please choose an option--" },
-      { "value": "male", "label": "Boy" }, 
-      { "value": "female", "label": "Girl" }, 
-      { "value": "unknown", "label": "Unknown" }
-    ]
+    "parents": [],
+    "type": "input",
+    "required": true
   }
 ]

--- a/plugin-hrm-form/src/formDefinitions/childForm.json
+++ b/plugin-hrm-form/src/formDefinitions/childForm.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "firstName",
+    "label": "First Name",
+    "type": "input",
+    "required": true
+  },
+  {
+    "name": "lastName",
+    "label": "Last Name",
+    "type": "input"
+  },
+  {
+    "name": "age",
+    "label": "Age",
+    "type": "select",
+    "options": [
+      { "value": "", "label": "--Please choose an option--" },
+      { "value": "0-03", "label": "<= 3" }, 
+      { "value": "04-06", "label": "04-06" }, 
+      { "value": "06-09", "label": "06-09" }
+    ],
+    "required": true
+  },
+  {
+    "name": "gender",
+    "label": "Gender",
+    "type": "select",
+    "options": [
+      { "value": "", "label": "--Please choose an option--" },
+      { "value": "male", "label": "Boy" }, 
+      { "value": "female", "label": "Girl" }, 
+      { "value": "unknown", "label": "Unknown" }
+    ]
+  }
+]

--- a/plugin-hrm-form/src/states/ContactFormStateFactory.js
+++ b/plugin-hrm-form/src/states/ContactFormStateFactory.js
@@ -1,3 +1,5 @@
+import ChildFormDefinition from '../formDefinitions/childForm.json';
+
 export const ValidationType = {
   REQUIRED: 'REQUIRED', // Will not be applied if in the callerInformation tab and callType is not caller.  Will not be applied when callType is standalone.
 };
@@ -22,8 +24,46 @@ export function isNotSubcategory(value) {
   return notSubcategory.includes(value);
 }
 
-// TODO: add tab order?
+/**
+ * @param {string} key
+ */
+const createIntermediate = () => ({
+  type: FieldType.INTERMEDIATE,
+});
 
+/**
+ *
+ * @param {import('../components/common/forms/types').FormItemDefinition} def
+ */
+const createFormItem = (obj, def) => {
+  if (!def.parents.length) {
+    return {
+      ...obj,
+      [def.name]: {
+        type: FieldType.TEXT_INPUT,
+        validation: def.required ? [ValidationType.REQUIRED] : null,
+      },
+    };
+  }
+
+  const [p, ...rest] = def.parents;
+  const newDef = { ...def, parents: rest };
+
+  if (obj[p]) {
+    return {
+      ...obj,
+      [p]: createFormItem(obj[p], newDef),
+    };
+  }
+
+  const intermidiate = createIntermediate();
+  return {
+    ...obj,
+    [p]: createFormItem(intermidiate, newDef),
+  };
+};
+
+// TODO: add tab order?
 const defaultFormDefinition = {
   callType: {
     type: FieldType.CALL_TYPE,

--- a/plugin-hrm-form/src/states/ContactFormStateFactory.js
+++ b/plugin-hrm-form/src/states/ContactFormStateFactory.js
@@ -34,17 +34,43 @@ const createIntermediate = () => ({
 });
 
 /**
- *
+ * @param {import('../components/common/forms/types').FormItemDefinition} def
+ */
+const createFormLeaf = def => {
+  switch (def.type) {
+    case 'input':
+      return {
+        type: FieldType.TEXT_INPUT,
+        value: '',
+        validation: def.required ? [ValidationType.REQUIRED] : null,
+        touched: false,
+      };
+    case 'select':
+      return {
+        type: FieldType.SELECT_SINGLE,
+        value: def.options[0],
+        validation: def.required ? [ValidationType.REQUIRED] : null,
+        touched: false,
+      };
+    default:
+      return {
+        type: FieldType.TEXT_INPUT,
+        value: '',
+        validation: def.required ? [ValidationType.REQUIRED] : null,
+        touched: false,
+      };
+  }
+};
+
+/**
+ * @param {{}} obj
  * @param {import('../components/common/forms/types').FormItemDefinition} def
  */
 const createFormItem = (obj, def) => {
   if (!getParents(def).length) {
     return {
       ...obj,
-      [def.name]: {
-        type: FieldType.TEXT_INPUT,
-        validation: def.required ? [ValidationType.REQUIRED] : null,
-      },
+      [def.name]: createFormLeaf(def),
     };
   }
 

--- a/plugin-hrm-form/src/states/ContactFormStateFactory.js
+++ b/plugin-hrm-form/src/states/ContactFormStateFactory.js
@@ -24,9 +24,10 @@ export function isNotSubcategory(value) {
   return notSubcategory.includes(value);
 }
 
-/**
- * @param {string} key
- */
+const createTab = () => ({
+  type: FieldType.TAB,
+});
+
 const createIntermediate = () => ({
   type: FieldType.INTERMEDIATE,
 });
@@ -62,6 +63,9 @@ const createFormItem = (obj, def) => {
     [p]: createFormItem(intermidiate, newDef),
   };
 };
+
+// create childInformation inside a tab field type
+const childInformation = ChildFormDefinition.reduce(createFormItem, createTab());
 
 // TODO: add tab order?
 const defaultFormDefinition = {
@@ -133,90 +137,93 @@ const defaultFormDefinition = {
       },
     },
   },
-  childInformation: {
-    type: FieldType.TAB,
-    name: {
-      type: FieldType.INTERMEDIATE,
-      firstName: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-      lastName: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-    },
-    gender: {
-      type: FieldType.SELECT_SINGLE,
-      validation: [ValidationType.REQUIRED],
-    },
-    age: {
-      type: FieldType.SELECT_SINGLE,
-      validation: [ValidationType.REQUIRED],
-    },
-    language: {
-      type: FieldType.SELECT_SINGLE,
-      validation: null,
-    },
-    nationality: {
-      type: FieldType.SELECT_SINGLE,
-      validation: null,
-    },
-    ethnicity: {
-      type: FieldType.SELECT_SINGLE,
-      validation: null,
-    },
-    school: {
-      type: FieldType.INTERMEDIATE,
-      name: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-      gradeLevel: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-    },
-    location: {
-      type: FieldType.INTERMEDIATE,
-      streetAddress: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-      city: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-      stateOrCounty: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-      postalCode: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-      phone1: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-      phone2: {
-        type: FieldType.TEXT_INPUT,
-        validation: null,
-      },
-    },
-    refugee: {
-      type: FieldType.CHECKBOX,
-      value: false,
-    },
-    disabledOrSpecialNeeds: {
-      type: FieldType.CHECKBOX,
-      value: false,
-    },
-    hiv: {
-      type: FieldType.CHECKBOX,
-      value: false,
-    },
-  },
+  childInformation,
+  /*
+   * childInformation: {
+   *   type: FieldType.TAB,
+   *   name: {
+   *     type: FieldType.INTERMEDIATE,
+   *     firstName: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *     lastName: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *   },
+   *   gender: {
+   *     type: FieldType.SELECT_SINGLE,
+   *     validation: [ValidationType.REQUIRED],
+   *   },
+   *   age: {
+   *     type: FieldType.SELECT_SINGLE,
+   *     validation: [ValidationType.REQUIRED],
+   *   },
+   *   language: {
+   *     type: FieldType.SELECT_SINGLE,
+   *     validation: null,
+   *   },
+   *   nationality: {
+   *     type: FieldType.SELECT_SINGLE,
+   *     validation: null,
+   *   },
+   *   ethnicity: {
+   *     type: FieldType.SELECT_SINGLE,
+   *     validation: null,
+   *   },
+   *   school: {
+   *     type: FieldType.INTERMEDIATE,
+   *     name: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *     gradeLevel: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *   },
+   *   location: {
+   *     type: FieldType.INTERMEDIATE,
+   *     streetAddress: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *     city: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *     stateOrCounty: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *     postalCode: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *     phone1: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *     phone2: {
+   *       type: FieldType.TEXT_INPUT,
+   *       validation: null,
+   *     },
+   *   },
+   *   refugee: {
+   *     type: FieldType.CHECKBOX,
+   *     value: false,
+   *   },
+   *   disabledOrSpecialNeeds: {
+   *     type: FieldType.CHECKBOX,
+   *     value: false,
+   *   },
+   *   hiv: {
+   *     type: FieldType.CHECKBOX,
+   *     value: false,
+   *   },
+   * },
+   */
   caseInformation: {
     type: FieldType.TAB,
     categories: {

--- a/plugin-hrm-form/src/states/ContactFormStateFactory.js
+++ b/plugin-hrm-form/src/states/ContactFormStateFactory.js
@@ -1,4 +1,5 @@
 import ChildFormDefinition from '../formDefinitions/childForm.json';
+import { getParents } from '../components/common/forms/helpers';
 
 export const ValidationType = {
   REQUIRED: 'REQUIRED', // Will not be applied if in the callerInformation tab and callType is not caller.  Will not be applied when callType is standalone.
@@ -37,7 +38,7 @@ const createIntermediate = () => ({
  * @param {import('../components/common/forms/types').FormItemDefinition} def
  */
 const createFormItem = (obj, def) => {
-  if (!def.parents.length) {
+  if (!getParents(def).length) {
     return {
       ...obj,
       [def.name]: {

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -326,13 +326,6 @@ export const FormRow = styled(NameFields)`
 `;
 FormRow.displayName = 'FormRow';
 
-export const FormItem = styled('div')`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-FormItem.displayName = 'FormItem';
-
 export const ColumnarBlock = styled('div')`
   display: flex;
   flex-direction: column;

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -321,6 +321,18 @@ export const NameFields = styled('div')`
 `;
 NameFields.displayName = 'NameFields';
 
+export const FormRow = styled(NameFields)`
+  margin: 10px 0;
+`;
+FormRow.displayName = 'FormRow';
+
+export const FormItem = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+FormItem.displayName = 'FormItem';
+
 export const ColumnarBlock = styled('div')`
   display: flex;
   flex-direction: column;

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -178,5 +178,7 @@
   "ContactDetails-GeneralDetails": "General Details",
 
   "ManualPullButtonText": "Add Another Task",
-  "NoTaskAssignableNotification": "No task assignable to you at the moment."
+  "NoTaskAssignableNotification": "No task assignable to you at the moment.",
+
+  "SelectChoseAnOption": "--Please choose an option--"
 }


### PR DESCRIPTION
Notes on this task: https://benetech.app.box.com/notes/729346531651

This PR is a prototype for generating forms from a config file (json) without introducing any new tool into our stack. The form state, validation, updates and structure are handled the same way we are doing it right now. Initially, the child tab info is the one being generated this way, making use only of text input fields.