### PR TITLE
Changes spelling of counselor to counsellor

### DIFF
--- a/plugin-hrm-form/src/components/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/ContactDetails.tsx
@@ -96,11 +96,17 @@ const Details = ({
         expanded={detailsExpanded[GENERAL_DETAILS]}
         handleExpandClick={() => handleExpandDetailsSection(GENERAL_DETAILS)}
       >
-        <SectionEntry description="Channel" value={formattedChannel} />
-        <SectionEntry description="Phone Number" value={isPhoneContact ? customerNumber : ''} />
-        <SectionEntry description="Conversation Duration" value={formattedDuration} />
-        <SectionEntry description="Counselor" value={counselor} />
-        <SectionEntry description="Date/Time" value={formattedDate} />
+        <SectionEntry description={strings['ContactDetails-GeneralDetails-Channel']} value={formattedChannel} />
+        <SectionEntry
+          description={strings['ContactDetails-GeneralDetails-PhoneNumber']}
+          value={isPhoneContact ? customerNumber : ''}
+        />
+        <SectionEntry
+          description={strings['ContactDetails-GeneralDetails-ConversationDuration']}
+          value={formattedDuration}
+        />
+        <SectionEntry description={strings['ContactDetails-GeneralDetails-Counselor']} value={counselor} />
+        <SectionEntry description={strings['ContactDetails-GeneralDetails-DateTime']} value={formattedDate} />
       </Section>
       {callType === callTypes.caller && (
         <CallerSection

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -46,7 +46,7 @@ class SearchForm extends Component {
 
     const counselorsOptions = this.props.counselors.map(e => ({ label: e.fullName, value: e.sid }));
 
-    const { helpline } = getConfig();
+    const { helpline, strings } = getConfig();
     const searchParams = {
       ...this.props.values,
       counselor: counselor.value, // backend expects only counselor's SID
@@ -71,7 +71,7 @@ class SearchForm extends Component {
           <Row>
             <FieldText
               id="Search_FirstName"
-              label="Name"
+              label={strings['SearchForm-Name']}
               placeholder="First"
               field={getField(firstName)}
               {...this.defaultEventHandlers('firstName')}
@@ -91,7 +91,7 @@ class SearchForm extends Component {
             <FieldSelect
               id="Search_Counselor"
               name="counselor"
-              label="Counselor"
+              label={strings['SearchForm-Counselor']}
               placeholder="Name"
               field={getField(counselor)}
               options={[{ label: '', value: '' }, ...counselorsOptions]}
@@ -100,7 +100,7 @@ class SearchForm extends Component {
             />
             <FieldDate
               id="Search_DateFrom"
-              label="Date range"
+              label={strings['SearchForm-DateRange']}
               placeholder="Start Date"
               field={getField(dateFrom)}
               {...this.defaultEventHandlers('dateFrom')}
@@ -117,7 +117,7 @@ class SearchForm extends Component {
           <Row>
             <FieldText
               id="Search_CustomerPhoneNumber"
-              label="Phone"
+              label={strings['SearchForm-Phone']}
               field={getField(phoneNumber)}
               {...this.defaultEventHandlers('phoneNumber')}
               onKeyPress={submitOnEnter}
@@ -126,7 +126,7 @@ class SearchForm extends Component {
         </Container>
         <BottomButtonBar>
           <StyledNextStepButton type="button" disabled={!isTouched} roundCorners={true} onClick={submitSearch}>
-            Search
+            <Template code="SearchForm-Button" />
           </StyledNextStepButton>
         </BottomButtonBar>
       </>

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -20,7 +20,7 @@
   "CallType-abusive": "Abusive",
   "CallType-CloseContact": "Close Contact",
 
-  "CallTypeAndCounselor-Label": "Counselor: ",
+  "CallTypeAndCounselor-Label": "Counsellor: ",
 
   "CallTypeButtons-Categorize": "categorize this contact",
   "CallTypeButtons-Or": "Or was this contact…",
@@ -43,6 +43,12 @@
   "NonDataCallTypeDialog-CloseConfirm": "Are you sure?",
 
   "SearchContactsAndCases-Title": "Search for Contacts and Cases",
+
+  "SearchForm-Name": "Name",
+  "SearchForm-Counselor": "Counsellor",
+  "SearchForm-DateRange": "Date Range",
+  "SearchForm-Phone": "Phone",
+  "SearchForm-Button": "Search",
 
   "SearchResultsIndex-Back": "Return to search criteria",
   "SearchResultsIndex-Result": " result",
@@ -67,7 +73,7 @@
   "SectionEntry-No": "No",
 
   "SharedStateSaveFormError": "The information stored in the form couldn't be saved. Task will be transferred anyway.",
-  "SharedStateLoadFormError": "The information stored in the form by previous counselor couldn't be retrieved. Starting current task with clear contact form.",
+  "SharedStateLoadFormError": "The information stored in the form by previous counsellor couldn't be retrieved. Starting current task with clear contact form.",
 
   "Transfer-TransferButton": "Transfer",
   "Transfer-AcceptTransferButton": "Accept Transfer",
@@ -122,7 +128,7 @@
   "Case-AddHouseholdSection": "Household Information",
   "Case-CaseSummarySection": "Case Summary",
   "Case-CaseDetailsChildName": "Child Name",
-  "Case-CaseDetailsOwner": "Counselor",
+  "Case-CaseDetailsOwner": "Counsellor",
   "Case-CaseDetailsDateOpened": "Date Opened",
   "Case-CaseDetailsStatusLabel": "Status",
   "Case-CaseDetailsStatusOpen": "Open",
@@ -132,7 +138,7 @@
   "Case-AddNoteTypeHere": "Type here to add note...",
   "Case-AddCaseSummaryHere": "Add case summary here...",
   "Case-ActionHeaderAdded": "Added:",
-  "Case-ActionHeaderCounselor": "Counselor:",
+  "Case-ActionHeaderCounselor": "Counsellor:",
   "Case-CloseButton": "Close",
   "Case-ViewButton": "View",
   "Case-PerpetratorName": "Perpetrator Name: ",
@@ -154,7 +160,7 @@
   "CaseList-THCase": "Case #",
   "CaseList-THChildName": "Child's Name",
   "CaseList-THSummary": "Summary",
-  "CaseList-THCounselor": "Counselor",
+  "CaseList-THCounselor": "Counsellor",
   "CaseList-THOpened": "Opened",
   "CaseList-THUpdated": "Updated",
   "CaseList-THCategory": "Category",
@@ -194,6 +200,11 @@
   "CallerSection-Ethnicity": "Ethnicity",
 
   "ContactDetails-GeneralDetails": "General Details",
+  "ContactDetails-GeneralDetails-Channel": "Channel",
+  "ContactDetails-GeneralDetails-PhoneNumber": "Phone Number",
+  "ContactDetails-GeneralDetails-ConversationDuration": "Conversation Duration",
+  "ContactDetails-GeneralDetails-Counselor": "Counsellor",
+  "ContactDetails-GeneralDetails-DateTime": "Date/Time",
 
   "ManualPullButtonText": "Another Task",
   "NoTaskAssignableNotification": "No task assignable to you at the moment.",

--- a/plugin-hrm-form/src/translations/en-US/messages.json
+++ b/plugin-hrm-form/src/translations/en-US/messages.json
@@ -1,4 +1,4 @@
 {
-  "WelcomeMsg": "Hi, this is the counselor. How can I help you?",
-  "GoodbyeMsg": "The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help."
+  "WelcomeMsg": "Hi, this is the counsellor. How can I help you?",
+  "GoodbyeMsg": "The counsellor has left the chat. Thank you for reaching out. Please contact us again if you need more help."
 }


### PR DESCRIPTION
Per https://bugs.benetech.org/browse/CHI-302: "It's currently using the US spelling and more of the helplines will use British English so we may as well change it now for the first few implementations."

This does not change any of our variables, just the strings that the user will see.  I have tried to catch everything but please point out anything I've missed.

I have also introduced localization in two places: the General Details section of the Contact Details, and the Search Form.  I think these seem like reasonable things to localize, as the strings will change per helpline but the fields are less likely to change.  I don't recommend localizing the other sections of the Contact Details, since we will be customizing many of those values.

A companion PR for webchat is here: https://github.com/tech-matters/webchat/pull/12

And we will also need to change two messages in the Autopilot configuration.
