### PR TITLE
Fix bug when sending Welcome Message (webchat)

### DIFF
--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -2,12 +2,13 @@
 import React from 'react';
 import { ITask, withTaskContext } from '@twilio/flex-ui';
 import { connect, ConnectedProps } from 'react-redux';
-import { useFormContext } from 'react-hook-form';
+import { FieldError, useFormContext } from 'react-hook-form';
 import { isFuture } from 'date-fns';
+import { get } from 'lodash';
 
 import { createFormFromDefinition } from '../common/forms/formGenerators';
 import { updateContactLessTask } from '../../states/ContactState';
-import { Container, ColumnarBlock, TwoColumnLayout, Box } from '../../styles/HrmStyles';
+import { Container, ColumnarBlock, TwoColumnLayout, Box, FormError } from '../../styles/HrmStyles';
 import type { RootState } from '../../states';
 import { formDefinition } from './ContactlessTaskTabDefinition';
 import { splitDate, splitTime } from '../../utils/helpers';
@@ -21,11 +22,11 @@ type OwnProps = {
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task }) => {
-  const { getValues, setError, watch, errors } = useFormContext();
+  const { getValues, register, setError, trigger, watch, errors } = useFormContext();
 
   const contactlessTaskForm = React.useMemo(() => {
     const updateCallBack = () => {
-      const { contactlessTask } = getValues();
+      const { isFutureAux, ...contactlessTask } = getValues().contactlessTask;
       dispatch(updateContactLessTask(contactlessTask, task.taskSid));
     };
     return createFormFromDefinition(formDefinition)(['contactlessTask'])(updateCallBack).map(i => (
@@ -35,17 +36,38 @@ const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task }) => {
     ));
   }, [dispatch, getValues, task.taskSid]);
 
+  // Add invisible field that errors if date + time are future (triggered by validaiton)
+  React.useEffect(() => {
+    register('contactlessTask.isFutureAux', {
+      validate: () => {
+        const { contactlessTask } = getValues();
+        const { date, time } = contactlessTask;
+        if (date && time) {
+          const [y, m, d] = splitDate(date);
+          const [mm, hh] = splitTime(time);
+          if (isFuture(new Date(y, m - 1, d, mm, hh))) {
+            return 'TimeCantBeGreaterThanNow'; // return non-null to generate an error, using the localized error key
+          }
+        }
+
+        return null;
+      },
+    });
+  }, [getValues, register, setError]);
+
   const date = watch('contactlessTask.date');
   const time = watch('contactlessTask.time');
 
+  // Trigger validation on isFutureAux (triggered by date or time onChange)
   React.useEffect(() => {
-    if (date && time) {
-      const [y, m, d] = splitDate(date);
-      const [mm, hh] = splitTime(time);
-      if (isFuture(new Date(y, m - 1, d, mm, hh)))
-        setError('contactlessTask.time', { message: 'TimeCantBeGreaterThanNow' });
-    }
-  }, [date, errors, setError, time]);
+    trigger('contactlessTask.isFutureAux');
+  }, [date, time, trigger]);
+
+  // Replicate error in time if there is error in isFutureAux
+  const isFutureError: FieldError = get(errors, 'contactlessTask.isFutureAux');
+  React.useEffect(() => {
+    if (isFutureError) setError('contactlessTask.time', { message: isFutureError.message });
+  }, [isFutureError, setError]);
 
   return (
     <div style={{ height: '100%', display: display ? 'block' : 'none' }}>

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -1,3 +1,5 @@
+import { isFuture } from 'date-fns';
+
 import { channelTypes, otherContactChannels } from '../../states/DomainConstants';
 import type { FormDefinition } from '../common/forms/types';
 import { mapChannelForInsights } from '../../utils/mappers';
@@ -25,7 +27,7 @@ export const formDefinition: FormDefinition = [
     required: { value: true, message: 'RequiredFieldError' },
     validate: date => {
       const [y, m, d] = splitDate(date);
-      return new Date(y, m - 1, d).getTime() > Date.now() ? 'DateCantBeGreaterThanToday' : null;
+      return isFuture(new Date(y, m - 1, d)) ? 'DateCantBeGreaterThanToday' : null;
     },
   },
   {

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
@@ -26,6 +26,7 @@ const TabbedForms = props => {
     defaultValues: initialValues,
     shouldFocusError: false,
     shouldUnregister: false,
+    mode: 'onChange',
   });
 
   const { task, form } = props;

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -158,7 +158,6 @@ export const customTransferTask = setupObject => async (payload, original) => {
   if (mode === transferModes.warm) {
     await TransferHelpers.clearTransferMeta(payload.task);
     window.alert(Manager.getInstance().strings['Transfer-ChatWarmNotAllowed']);
-    return Promise.resolve();
   }
 
   const memberToKick = mode === transferModes.cold ? TransferHelpers.getMemberToKick(payload.task, identity) : '';

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import { Manager, TaskHelper, Actions as FlexActions, ActionFunction, ReplacedActionFunction } from '@twilio/flex-ui';
+import { Manager, TaskHelper, Actions as FlexActions, StateHelper } from '@twilio/flex-ui';
 
 // eslint-disable-next-line no-unused-vars
 import { DEFAULT_TRANSFER_MODE, getConfig } from '../HrmFormPlugin';
@@ -23,7 +23,7 @@ const getStateContactForms = taskSid => {
 
 /**
  * Saves the end time of the conversation (used to save the duration of the conversation)
- * @type {ActionFunction}
+ * @type {import('@twilio/flex-ui').ActionFunction}
  */
 const saveEndMillis = async payload => {
   Manager.getInstance().store.dispatch(Actions.saveEndMillis(payload.task.taskSid));
@@ -32,8 +32,8 @@ const saveEndMillis = async payload => {
 /**
  * A function that calls fun with the payload of the replaced action
  * and continues with the Twilio execution
- * @param {ActionFunction} fun
- * @returns {ReplacedActionFunction}
+ * @param {import('@twilio/flex-ui').ActionFunction} fun
+ * @returns {import('@twilio/flex-ui').ReplacedActionFunction}
  */
 const fromActionFunction = fun => async (payload, original) => {
   await fun(payload);
@@ -78,7 +78,7 @@ const getTaskLanguage = ({ helplineLanguage, configuredLanguage }) => ({ task })
 
 /**
  * @param {string} messageKey
- * @returns {(setupObject: ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }) => ActionFunction}
+ * @returns {(setupObject: ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }) => import('@twilio/flex-ui').ActionFunction}
  */
 const sendMessageOfKey = messageKey => setupObject => async payload => {
   const { getMessage } = setupObject;
@@ -95,7 +95,7 @@ const sendGoodbyeMessage = sendMessageOfKey('GoodbyeMsg');
 
 /**
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {ActionFunction}
+ * @returns {import('@twilio/flex-ui').ActionFunction}
  */
 export const afterAcceptTask = setupObject => async payload => {
   const manager = Manager.getInstance();
@@ -107,8 +107,20 @@ export const afterAcceptTask = setupObject => async payload => {
 
   // To enable for all chat based task, change condition to "if (TaskHelper.isChatBasedTask(task))"
   if (task.attributes.channelType === channelTypes.web) {
-    // Ignore event payload as we already have everything we want in afterAcceptTask arguments
-    manager.chatClient.once('channelJoined', () => setTimeout(() => sendWelcomeMessage(setupObject)(payload), 0));
+    const sendWelcomeMessageOrRetry = ms => {
+      setTimeout(() => {
+        // if this took more than 2100ms (100 + 200 + ... + 600) just let it go. Should we increase this to 5500ms? (if ms >= 1000)? Retry forever makes no sense to me but that's an option too
+        if (ms >= 600) return;
+
+        const channelState = StateHelper.getChatChannelStateForTask(task);
+        // if channel is not ready, add 100ms and retry
+        if (channelState.isLoadingChannel) sendWelcomeMessageOrRetry(ms + 100);
+        else sendWelcomeMessage(setupObject)(payload);
+      }, ms);
+    };
+
+    // Ignore event payload as we already have everything we want in afterAcceptTask arguments. Start at 0ms as many users are able to send the message after channel promise resolves, with no delay
+    manager.chatClient.once('channelJoined', () => sendWelcomeMessageOrRetry(0));
   }
 };
 
@@ -128,7 +140,7 @@ const safeTransfer = async (transferFunction, task) => {
 /**
  * Custom override for TransferTask action. Saves the form to share with another counseler (if possible) and then starts the transfer
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {ReplacedActionFunction}
+ * @returns {import('@twilio/flex-ui').ReplacedActionFunction}
  */
 export const customTransferTask = setupObject => async (payload, original) => {
   const { identity, workerSid, counselorName } = setupObject;
@@ -204,7 +216,7 @@ const saveInsights = async payload => {
 /**
  * Submits the form to the hrm backend (if it should), and saves the insights. Used before task is completed
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {ActionFunction}
+ * @returns {import('@twilio/flex-ui').ActionFunction}
  */
 const sendInsightsData = setupObject => async payload => {
   const { featureFlags } = setupObject;
@@ -218,7 +230,7 @@ const sendInsightsData = setupObject => async payload => {
 
 /**
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {ActionFunction}
+ * @returns {import('@twilio/flex-ui').ActionFunction}
  */
 const decreaseChatCapacity = setupObject => async payload => {
   const { featureFlags } = setupObject;
@@ -228,7 +240,7 @@ const decreaseChatCapacity = setupObject => async payload => {
 
 /**
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
- * @returns {ActionFunction}
+ * @returns {import('@twilio/flex-ui').ActionFunction}
  */
 export const beforeCompleteTask = setupObject => async payload => {
   await sendInsightsData(setupObject)(payload);

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -121,7 +121,7 @@ export const afterAcceptTask = setupObject => async payload => {
     };
 
     // Ignore event payload as we already have everything we want in afterAcceptTask arguments. Start at 0ms as many users are able to send the message right away
-    manager.chatClient.once('channelJoined', () => trySendWelcomeMessage(0));
+    manager.chatClient.once('channelJoined', () => trySendWelcomeMessage(0, 0));
   }
 };
 

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -107,12 +107,16 @@ export const afterAcceptTask = setupObject => async payload => {
 
   // To enable for all chat based task, change condition to "if (TaskHelper.isChatBasedTask(task))"
   if (task.attributes.channelType === channelTypes.web) {
-    const trySendWelcomeMessage = ms => {
+    const trySendWelcomeMessage = (ms, retries) => {
       setTimeout(() => {
         const channelState = StateHelper.getChatChannelStateForTask(task);
         // if channel is not ready, wait 200ms and retry
-        if (channelState.isLoadingChannel) trySendWelcomeMessage(200);
-        else sendWelcomeMessage(setupObject)(payload);
+        if (channelState.isLoadingChannel) {
+          if (retries < 10) trySendWelcomeMessage(200, retries + 1);
+          else console.error('Failed to send welcome message: max retries reached.');
+        } else {
+          sendWelcomeMessage(setupObject)(payload);
+        }
       }, ms);
     };
 

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -107,20 +107,17 @@ export const afterAcceptTask = setupObject => async payload => {
 
   // To enable for all chat based task, change condition to "if (TaskHelper.isChatBasedTask(task))"
   if (task.attributes.channelType === channelTypes.web) {
-    const sendWelcomeMessageOrRetry = ms => {
+    const trySendWelcomeMessage = ms => {
       setTimeout(() => {
-        // if this took more than 2100ms (100 + 200 + ... + 600) just let it go. Should we increase this to 5500ms? (if ms >= 1000)? Retry forever makes no sense to me but that's an option too
-        if (ms >= 600) return;
-
         const channelState = StateHelper.getChatChannelStateForTask(task);
-        // if channel is not ready, add 100ms and retry
-        if (channelState.isLoadingChannel) sendWelcomeMessageOrRetry(ms + 100);
+        // if channel is not ready, wait 200ms and retry
+        if (channelState.isLoadingChannel) trySendWelcomeMessage(200);
         else sendWelcomeMessage(setupObject)(payload);
       }, ms);
     };
 
-    // Ignore event payload as we already have everything we want in afterAcceptTask arguments. Start at 0ms as many users are able to send the message after channel promise resolves, with no delay
-    manager.chatClient.once('channelJoined', () => sendWelcomeMessageOrRetry(0));
+    // Ignore event payload as we already have everything we want in afterAcceptTask arguments. Start at 0ms as many users are able to send the message right away
+    manager.chatClient.once('channelJoined', () => trySendWelcomeMessage(0));
   }
 };
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-340

This PR:
- fixes a bug when sending the welcome message: if the channel is not ready, wait 200ms and retry, repeat until channel is ready and the message succeeds or 2000ms (2 seconds) elapsed, reporting the following error to Rollbar:
![Screenshot from 2020-11-30 10-32-08](https://user-images.githubusercontent.com/15805319/100616175-7d928f80-32f7-11eb-89fd-6bc3ef4aad99.png)
- fixes bug on contactless task form validation: currently, if `date` + `time` are future, UI reflects an error, but you can still submit the form because `onSubmit`, validation triggers but there is no validation that fails at this point (the UI error is set from an `useEffect`, and cleared when validation triggers). This PR fixes this, introducing a new (invisible and unused) field `isFutureAux` in the form with a validation that fails if `date` + `time` are future, and if `isFutureAux` have an error, it is then replicated to `time` input (again, from an `useEffect`, but that runs **after** the validation was triggered, making the form invalid when trying to submit it).