### PR TITLE
Remove icons in standalone search

### DIFF
--- a/plugin-hrm-form/src/components/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/ContactDetails.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
-import { ButtonBase, IconButton } from '@material-ui/core';
-import { MoreHoriz, Link as LinkIcon } from '@material-ui/icons';
+import { IconButton } from '@material-ui/core';
+import { Link as LinkIcon } from '@material-ui/icons';
 
 import { DetailsContainer, NameContainer, DetNameText, ContactDetailsIcon } from '../styles/search';
 import Section from './Section';
@@ -21,14 +21,11 @@ import {
 import { CallerSection, ContactDetailsSections } from './common/ContactDetails';
 import { getConfig } from '../HrmFormPlugin';
 
-const MoreHorizIcon = ContactDetailsIcon(MoreHoriz);
-
 const Details = ({
   contact,
   detailsExpanded,
   showActionIcons,
   handleOpenConnectDialog,
-  handleMockedMessage,
   handleExpandDetailsSection,
 }) => {
   // Object destructuring on contact
@@ -91,9 +88,6 @@ const Details = ({
             >
               <LinkIcon style={{ color: '#ffffff' }} />
             </IconButton>
-            <ButtonBase style={{ padding: 0 }} onClick={handleMockedMessage}>
-              <MoreHorizIcon style={{ color: '#ffffff' }} />
-            </ButtonBase>
           </>
         )}
       </NameContainer>
@@ -184,13 +178,11 @@ Details.propTypes = {
   contact: contactType.isRequired,
   detailsExpanded: PropTypes.objectOf(PropTypes.bool).isRequired,
   handleOpenConnectDialog: PropTypes.func,
-  handleMockedMessage: PropTypes.func,
   handleExpandDetailsSection: PropTypes.func.isRequired,
   showActionIcons: PropTypes.bool,
 };
 Details.defaultProps = {
   handleOpenConnectDialog: () => null,
-  handleMockedMessage: () => null,
   showActionIcons: false,
 };
 

--- a/plugin-hrm-form/src/components/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/ContactDetails.tsx
@@ -4,7 +4,7 @@ import { format } from 'date-fns';
 import { IconButton } from '@material-ui/core';
 import { Link as LinkIcon } from '@material-ui/icons';
 
-import { DetailsContainer, NameContainer, DetNameText, ContactDetailsIcon } from '../styles/search';
+import { DetailsContainer, NameContainer, DetNameText } from '../styles/search';
 import Section from './Section';
 import SectionEntry from './SectionEntry';
 import callTypes, { channelTypes } from '../states/DomainConstants';

--- a/plugin-hrm-form/src/components/search/ContactDetails/index.jsx
+++ b/plugin-hrm-form/src/components/search/ContactDetails/index.jsx
@@ -16,6 +16,7 @@ class ContactDetails extends Component {
   static propTypes = {
     currentIsCaller: PropTypes.bool.isRequired,
     contact: contactType.isRequired,
+    showActionIcons: PropTypes.objectOf(PropTypes.bool).isRequired,
     detailsExpanded: PropTypes.objectOf(PropTypes.bool).isRequired,
     handleBack: PropTypes.func.isRequired,
     handleSelectSearchResult: PropTypes.func,
@@ -49,7 +50,7 @@ class ContactDetails extends Component {
   };
 
   render() {
-    const { contact, detailsExpanded, currentIsCaller } = this.props;
+    const { contact, detailsExpanded, currentIsCaller, showActionIcons } = this.props;
 
     return (
       <Container>
@@ -71,7 +72,7 @@ class ContactDetails extends Component {
           </ButtonBase>
         </Row>
         <GeneralContactDetails
-          showActionIcons
+          showActionIcons={showActionIcons}
           contact={contact}
           detailsExpanded={detailsExpanded}
           handleOpenConnectDialog={this.handleOpenConnectDialog}

--- a/plugin-hrm-form/src/components/search/ContactPreview/ConnectContact.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ConnectContact.tsx
@@ -10,12 +10,11 @@ import { CallTypes } from '../../../states/DomainConstants';
 type OwnProps = {
   callType: CallTypes;
   onOpenConnectDialog: () => void;
-  showConnectIcon: Boolean;
 };
 
 type Props = OwnProps;
 
-const ConnectContact: React.FC<Props> = ({ callType, onOpenConnectDialog, showConnectIcon }) => {
+const ConnectContact: React.FC<Props> = ({ callType, onOpenConnectDialog }) => {
   const isNonDataContact = isNonDataCallType(callType);
 
   if (isNonDataContact) {
@@ -28,7 +27,7 @@ const ConnectContact: React.FC<Props> = ({ callType, onOpenConnectDialog, showCo
         <HiddenText>
           <Template code="ContactPreview-CopyButton" />
         </HiddenText>
-        {showConnectIcon && <ConnectIcon />}
+        <ConnectIcon />
       </StyledButtonBase>
     </Flex>
   );

--- a/plugin-hrm-form/src/components/search/ContactPreview/ConnectContact.tsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ConnectContact.tsx
@@ -10,11 +10,12 @@ import { CallTypes } from '../../../states/DomainConstants';
 type OwnProps = {
   callType: CallTypes;
   onOpenConnectDialog: () => void;
+  showConnectIcon: Boolean;
 };
 
 type Props = OwnProps;
 
-const ConnectContact: React.FC<Props> = ({ callType, onOpenConnectDialog }) => {
+const ConnectContact: React.FC<Props> = ({ callType, onOpenConnectDialog, showConnectIcon }) => {
   const isNonDataContact = isNonDataCallType(callType);
 
   if (isNonDataContact) {
@@ -27,7 +28,7 @@ const ConnectContact: React.FC<Props> = ({ callType, onOpenConnectDialog }) => {
         <HiddenText>
           <Template code="ContactPreview-CopyButton" />
         </HiddenText>
-        <ConnectIcon />
+        {showConnectIcon && <ConnectIcon />}
       </StyledButtonBase>
     </Flex>
   );

--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
@@ -9,13 +9,17 @@ import { ContactWrapper } from '../../../styles/search';
 import { Flex } from '../../../styles/HrmStyles';
 import ConnectContact from './ConnectContact';
 
-const ContactPreview = ({ contact, handleOpenConnectDialog, handleViewDetails }) => {
+const ContactPreview = ({ contact, handleOpenConnectDialog, handleViewDetails, showConnectIcon }) => {
   const { counselor } = contact;
   const { callSummary } = contact.details.caseInformation;
 
   return (
     <Flex>
-      <ConnectContact callType={contact.overview.callType} onOpenConnectDialog={handleOpenConnectDialog} />
+      <ConnectContact
+        showConnectIcon={showConnectIcon}
+        callType={contact.overview.callType}
+        onOpenConnectDialog={handleOpenConnectDialog}
+      />
       <ContactWrapper key={contact.contactId}>
         <ChildNameAndDate
           channel={contact.overview.channel}
@@ -38,6 +42,7 @@ ContactPreview.propTypes = {
   contact: contactType.isRequired,
   handleOpenConnectDialog: PropTypes.func.isRequired,
   handleViewDetails: PropTypes.func.isRequired,
+  showConnectIcon: PropTypes.bool.isRequired,
 };
 
 export default ContactPreview;

--- a/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
+++ b/plugin-hrm-form/src/components/search/ContactPreview/ContactPreview.jsx
@@ -15,11 +15,9 @@ const ContactPreview = ({ contact, handleOpenConnectDialog, handleViewDetails, s
 
   return (
     <Flex>
-      <ConnectContact
-        showConnectIcon={showConnectIcon}
-        callType={contact.overview.callType}
-        onOpenConnectDialog={handleOpenConnectDialog}
-      />
+      {showConnectIcon && (
+        <ConnectContact callType={contact.overview.callType} onOpenConnectDialog={handleOpenConnectDialog} />
+      )}
       <ContactWrapper key={contact.contactId}>
         <ChildNameAndDate
           channel={contact.overview.channel}

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import { ButtonBase } from '@material-ui/core';
 import { Template, Tab as TwilioTab, ITask } from '@twilio/flex-ui';
 
+import { standaloneTaskSid } from '../../../states/search/reducer';
 import ContactPreview from '../ContactPreview';
 import CasePreview from '../CasePreview';
 import { SearchContactResult, SearchCaseResult, SearchContact } from '../../../types/types';
@@ -71,6 +72,7 @@ const SearchResults: React.FC<Props> = ({
   handleViewDetails,
   changeSearchPage,
   currentPage,
+  showConnectIcon,
 }) => {
   const [currentContact, setCurrentContact] = useState(null);
   const [anchorEl, setAnchorEl] = useState(null);
@@ -208,6 +210,7 @@ const SearchResults: React.FC<Props> = ({
                 contacts.length > 0 &&
                 contacts.map(contact => (
                   <ContactPreview
+                    showConnectIcon={showConnectIcon}
                     key={contact.contactId}
                     contact={contact}
                     handleOpenConnectDialog={handleOpenConnectDialog(contact)}
@@ -257,9 +260,11 @@ const mapStateToProps = (state, ownProps) => {
   const searchContactsState = state[namespace][searchContactsBase];
   const taskId = ownProps.task.taskSid;
   const taskSearchState = searchContactsState.tasks[taskId];
+  const isStandaloneSearch = taskId === standaloneTaskSid;
 
   return {
     currentPage: taskSearchState.currentPage,
+    showConnectIcon: !isStandaloneSearch,
   };
 };
 

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -7,6 +7,7 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import { ITask, withTaskContext } from '@twilio/flex-ui';
 
+import { standaloneTaskSid } from '../../states/search/reducer';
 import SearchForm from './SearchForm';
 import SearchResults, { CONTACTS_PER_PAGE, CASES_PER_PAGE } from './SearchResults';
 import ContactDetails from './ContactDetails';
@@ -133,6 +134,7 @@ const Search: React.FC<Props> = props => {
       case SearchPages.details:
         return (
           <ContactDetails
+            showActionIcons={props.showActionIcons}
             currentIsCaller={props.currentIsCaller}
             contact={currentContact}
             detailsExpanded={props.detailsExpanded}
@@ -170,6 +172,7 @@ const mapStateToProps = (state, ownProps) => {
   const taskId = ownProps.task.taskSid;
   const taskSearchState = searchContactsState.tasks[taskId];
   const { counselors } = state[namespace][configurationBase];
+  const isStandaloneSearch = taskId === standaloneTaskSid;
 
   return {
     isRequesting: taskSearchState.isRequesting,
@@ -181,6 +184,7 @@ const mapStateToProps = (state, ownProps) => {
     searchCasesResults: taskSearchState.searchCasesResult,
     detailsExpanded: taskSearchState.detailsExpanded,
     counselorsHash: counselors.hash,
+    showActionIcons: !isStandaloneSearch,
   };
 };
 

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.jsx
@@ -144,7 +144,7 @@ const TabbedForms = props => {
 
   return (
     <FormProvider {...methods}>
-      <form style={{ height: '100%' }}>
+      <div role="form" style={{ height: '100%' }}>
         <TabbedFormsContainer>
           <TopNav>
             <TransparentButton onClick={handleBackButton}>&lt; BACK</TransparentButton>
@@ -164,7 +164,7 @@ const TabbedForms = props => {
             optionalButtons={optionalButtons}
           />
         </TabbedFormsContainer>
-      </form>
+      </div>
     </FormProvider>
   );
 };


### PR DESCRIPTION
- Removed `MoreHorizIcon` (...) in all scenarios
- Removed `LinkIcon` for Standalone search scenario.
- Fixed Flex reboot issue by chaging `<form>` wrapper to a `<div>`