### PR TITLE
Forms Generators

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -1,5 +1,5 @@
 import * as Flex from '@twilio/flex-ui';
-import { FlexPlugin } from 'flex-plugin';
+import { FlexPlugin, loadCSS } from 'flex-plugin';
 import SyncClient from 'twilio-sync';
 
 import './styles/GlobalOverrides';
@@ -205,8 +205,10 @@ export default class HrmFormPlugin extends FlexPlugin {
    * @param manager { import('@twilio/flex-ui').Manager }
    */
   init(flex, manager) {
+    loadCSS('https://use.fontawesome.com/releases/v5.15.1/css/solid.css');
+
     const monitoringEnv = manager.serviceConfiguration.attributes.monitoringEnv || 'staging';
-    if (!process.env.NO_MONITORING) setUpMonitoring(this, manager.workerClient, monitoringEnv);
+    if (process.env.NODE_ENV !== 'development') setUpMonitoring(this, manager.workerClient, monitoringEnv);
 
     console.log(`Welcome to ${PLUGIN_NAME} Version ${PLUGIN_VERSION}`);
     this.registerReducers(manager);

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -14,9 +14,15 @@ import {
   FormError,
   Row,
   FormInput,
+  FormDateInput,
+  FormTimeInput,
+  FormCheckBoxWrapper,
+  FormCheckbox,
+  FormMixedCheckbox,
   FormSelect,
   FormOption,
   FormSelectWrapper,
+  FormTextArea,
 } from '../../../styles/HrmStyles';
 import type { FormItemDefinition, FormDefinition, SelectOption, MixedOrBool } from './types';
 
@@ -38,7 +44,7 @@ const getRules = (field: FormItemDefinition): ValidationRules =>
   pick(field, ['max', 'maxLength', 'min', 'minLength', 'pattern', 'required', 'validate']);
 
 /**
- * Creates a Form with each input conntected to RHF's wrapping Context, based on the definition.
+ * Creates a Form with each input connected to RHF's wrapping Context, based on the definition.
  * @param {string[]} parents Array of parents. Allows you to easily create nested form fields. https://react-hook-form.com/api#register.
  * @param {() => void} updateCallback Callback called to update form state. When is the callback called is specified in the input type.
  * @param {FormItemDefinition} def Definition for a single input.
@@ -61,13 +67,14 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     {rules.required && <RequiredAsterisk />}
                   </Box>
                 </Row>
-                <input
+                <FormInput
                   id={path}
                   name={path}
+                  error={Boolean(error)}
                   aria-invalid={Boolean(error)}
                   aria-describedby={`${path}-error`}
                   onBlur={updateCallback}
-                  ref={register(rules)}
+                  innerRef={register(rules)}
                 />
                 {error && (
                   <FormError>
@@ -92,13 +99,14 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     {rules.required && <RequiredAsterisk />}
                   </Box>
                 </Row>
-                <input
+                <FormInput
                   id={path}
                   name={path}
+                  error={Boolean(error)}
                   aria-invalid={Boolean(error)}
                   aria-describedby={`${path}-error`}
                   onBlur={updateCallback}
-                  ref={register({
+                  innerRef={register({
                     ...rules,
                     pattern: { value: /^[0-9]+$/g, message: 'This field only accepts numeric input.' },
                   })}
@@ -215,21 +223,19 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
             const error = get(errors, path);
             return (
               <FormLabel htmlFor={path}>
-                <Row>
-                  <Box marginBottom="8px">
-                    <Template code={`${def.label}`} />
-                    {rules.required && <RequiredAsterisk />}
-                  </Box>
-                </Row>
-                <input
-                  id={path}
-                  name={path}
-                  aria-invalid={Boolean(error)}
-                  aria-describedby={`${path}-error`}
-                  type="checkbox"
-                  onChange={updateCallback}
-                  ref={register(rules)}
-                />
+                <FormCheckBoxWrapper error={Boolean(error)}>
+                  <FormCheckbox
+                    id={path}
+                    name={path}
+                    type="checkbox"
+                    aria-invalid={Boolean(error)}
+                    aria-describedby={`${path}-error`}
+                    onChange={updateCallback}
+                    innerRef={register(rules)}
+                  />
+                  <Template code={`${def.label}`} />
+                  {rules.required && <RequiredAsterisk />}
+                </FormCheckBoxWrapper>
                 {error && (
                   <FormError>
                     <Template id={`${path}-error`} code={error.message} />
@@ -259,27 +265,24 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
 
             return (
               <FormLabel htmlFor={path}>
-                <Row>
-                  <Box marginBottom="8px">
-                    <Template code={`${def.label}`} />
-                    {rules.required && <RequiredAsterisk />}
-                  </Box>
-                </Row>
-                <FormInput
-                  id={path}
-                  type="checkbox"
-                  error={Boolean(error)}
-                  aria-invalid={Boolean(error)}
-                  aria-checked={checked}
-                  aria-describedby={`${path}-error`}
-                  className="mixed-checkbox" // this grabs the styles imported from mixedCheckbox.css
-                  onBlur={updateCallback}
-                  onChange={() => {
-                    if (checked === 'mixed') setChecked(false);
-                    if (checked === false) setChecked(true);
-                    if (checked === true) setChecked('mixed');
-                  }}
-                />
+                <FormCheckBoxWrapper error={Boolean(error)}>
+                  <FormMixedCheckbox
+                    id={path}
+                    type="checkbox"
+                    className="mixed-checkbox"
+                    aria-invalid={Boolean(error)}
+                    aria-checked={checked}
+                    aria-describedby={`${path}-error`}
+                    onBlur={updateCallback}
+                    onChange={() => {
+                      if (checked === 'mixed') setChecked(true);
+                      if (checked === true) setChecked(false);
+                      if (checked === false) setChecked('mixed');
+                    }}
+                  />
+                  <Template code={`${def.label}`} />
+                  {rules.required && <RequiredAsterisk />}
+                </FormCheckBoxWrapper>
                 {error && (
                   <FormError>
                     <Template id={`${path}-error`} code={error.message} />
@@ -303,13 +306,14 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     {rules.required && <RequiredAsterisk />}
                   </Box>
                 </Row>
-                <textarea
+                <FormTextArea
                   id={path}
                   name={path}
+                  error={Boolean(error)}
                   aria-invalid={Boolean(error)}
                   aria-describedby={`${path}-error`}
                   onBlur={updateCallback}
-                  ref={register(rules)}
+                  innerRef={register(rules)}
                   rows={10}
                 />
                 {error && (
@@ -335,7 +339,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     {rules.required && <RequiredAsterisk />}
                   </Box>
                 </Row>
-                <FormInput
+                <FormTimeInput
                   type="time"
                   id={path}
                   name={path}
@@ -368,7 +372,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     {rules.required && <RequiredAsterisk />}
                   </Box>
                 </Row>
-                <FormInput
+                <FormDateInput
                   type="date"
                   id={path}
                   name={path}
@@ -392,6 +396,16 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
       return null;
   }
 };
+
+/**
+ * Creates a Form with each input connected to RHF's wrapping Context, based on the definition.
+ * @param {FormDefinition} definition Form definition (schema).
+ * @param {string[]} parents Array of parents. Allows you to easily create nested form fields. https://react-hook-form.com/api#register.
+ * @param {() => void} updateCallback Callback called to update form state. When is the callback called is specified in the input type (getInputType).
+ */
+export const createFormFromDefinition = (definition: FormDefinition) => (parents: string[]) => (
+  updateCallback: () => void,
+): JSX.Element[] => definition.map(getInputType(parents, updateCallback));
 
 /**
  * Utility functions to create initial state from definition
@@ -418,26 +432,30 @@ export const getInitialValue = (def: FormItemDefinition) => {
   }
 };
 
-/**
- * Creates a Form with each input conntected to RHF's wrapping Context, based on the definition.
- * @param {FormDefinition} definition Form definition (schema).
- * @param {string[]} parents Array of parents. Allows you to easily create nested form fields. https://react-hook-form.com/api#register.
- * @param {() => void} updateCallback Callback called to update form state. When is the callback called is specified in the input type (getInputType).
- */
-export const createFormFromDefinition = (definition: FormDefinition) => (parents: string[]) => (
-  updateCallback: () => void,
-): JSX.Element[] => definition.map(getInputType(parents, updateCallback));
+export const createFormItem = <T extends {}>(obj: T, def: FormItemDefinition) => ({
+  ...obj,
+  [def.name]: getInitialValue(def),
+});
 
-export const buildTwoColumnFormLayout = (formItems: JSX.Element[]) => {
-  const items = formItems.map(i => (
-    <Box key={`${i.key}-wrapping-box`} marginTop="5px" marginBottom="5px">
+export const disperseInputs = (margin: number) => (formItems: JSX.Element[]) =>
+  formItems.map(i => (
+    <Box key={`${i.key}-wrapping-box`} marginTop={`${margin.toString()}px`} marginBottom={`${margin.toString()}px`}>
       {i}
     </Box>
   ));
 
+export const splitInHalf = (formItems: JSX.Element[]) => {
   const m = Math.ceil(formItems.length / 2);
 
-  const [l, r] = [items.slice(0, m), items.slice(m)];
+  const [l, r] = [formItems.slice(0, m), formItems.slice(m)];
+
+  return [l, r];
+};
+
+export const buildTwoColumnFormLayout = (formItems: JSX.Element[]) => {
+  const items = disperseInputs(5)(formItems);
+
+  const [l, r] = splitInHalf(items);
 
   return (
     <TwoColumnLayout>
@@ -446,8 +464,3 @@ export const buildTwoColumnFormLayout = (formItems: JSX.Element[]) => {
     </TwoColumnLayout>
   );
 };
-
-export const createFormItem = <T extends {}>(obj: T, def: FormItemDefinition) => ({
-  ...obj,
-  [def.name]: getInitialValue(def),
-});

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -6,9 +6,9 @@ import { FieldError, useFormContext } from 'react-hook-form';
 import { isFuture } from 'date-fns';
 import { get } from 'lodash';
 
-import { createFormFromDefinition } from '../common/forms/formGenerators';
+import { createFormFromDefinition, disperseInputs } from '../common/forms/formGenerators';
 import { updateContactLessTask } from '../../states/ContactState';
-import { Container, ColumnarBlock, TwoColumnLayout, Box } from '../../styles/HrmStyles';
+import { Container, ColumnarBlock, TwoColumnLayout } from '../../styles/HrmStyles';
 import type { RootState } from '../../states';
 import { formDefinition } from './ContactlessTaskTabDefinition';
 import { splitDate, splitTime } from '../../utils/helpers';
@@ -29,11 +29,10 @@ const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task }) => {
       const { isFutureAux, ...rest } = getValues().contactlessTask;
       dispatch(updateContactLessTask(rest, task.taskSid));
     };
-    return createFormFromDefinition(formDefinition)(['contactlessTask'])(updateCallBack).map(i => (
-      <Box key={`${i.key}-wrapping-box`} marginTop="5px" marginBottom="5px">
-        {i}
-      </Box>
-    ));
+
+    const tab = createFormFromDefinition(formDefinition)(['contactlessTask'])(updateCallBack);
+
+    return disperseInputs(5)(tab);
   }, [dispatch, getValues, task.taskSid]);
 
   // Add invisible field that errors if date + time are future (triggered by validaiton)

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -622,9 +622,8 @@ FormItem.displayName = 'FormItem';
 export const FormLabel = styled('label')`
   display: flex;
   flex-direction: column;
-  text-transform: uppercase;
   font-size: 13px;
-  letter-spacing: 2px;
+  letter-spacing: 1px;
   min-height: 18px;
 `;
 FormLabel.displayName = 'FormLabel';
@@ -639,6 +638,7 @@ export const FormError = styled('span')`
 FormError.displayName = 'FormError';
 
 type FormInputProps = { error?: boolean };
+
 export const FormInput = styled('input')<FormInputProps>`
   /* ---------- Input ---------- */
   & {
@@ -664,8 +664,10 @@ export const FormInput = styled('input')<FormInputProps>`
     box-shadow: none;
     border: 1px solid rgba(0, 59, 129, 0.37);
   }
+`;
+FormInput.displayName = 'FormInput';
 
-  /* ---------- Date ---------- */
+export const FormDateInput = styled(FormInput)`
   &[type='date']::-webkit-clear-button,
   &[type='date']::-webkit-inner-spin-button {
     -webkit-appearance: none;
@@ -673,8 +675,10 @@ export const FormInput = styled('input')<FormInputProps>`
   }
   /* &[type='date'] {} */
   /* &[type='date']::-webkit-calendar-picker-indicator {} */
+`;
+FormDateInput.displayName = 'FormDateInput';
 
-  /* ---------- Time ---------- */
+export const FormTimeInput = styled(FormInput)`
   &[type='time']::-webkit-datetime-edit-fields-wrapper {
     display: flex;
   }
@@ -689,32 +693,86 @@ export const FormInput = styled('input')<FormInputProps>`
    &[type='time']::-webkit-datetime-edit-minute-field {}
    &[type='time']::-webkit-datetime-edit-ampm-field {}
   */
+`;
+FormTimeInput.displayName = 'FormTimeInput';
 
-  /* ---------- Mixed Checkbox ---------- */
-  &[class~='mixed-checkbox'][type='checkbox'] {
+export const FormTextArea = styled('textarea')<FormInputProps>`
+  & {
+    display: flex;
+    flex-grow: 0;
+    font-family: Open Sans;
+    font-size: 12px;
+    line-height: 1.33;
+    letter-spacing: normal;
+    box-sizing: border-box; /* Tells the browser to account for any border and padding in the values you specify for an element's width and height. https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing*/
+    width: 217px;
+    border-radius: 4px;
+    background-color: ${props => props.theme.colors.inputBackgroundColor};
+    color: ${props =>
+      props.theme.calculated.lightTheme ? props.theme.colors.darkTextColor : props.theme.colors.lightTextColor};
+    border: ${props => (props.error ? '1px solid #CB3232' : 'none')};
+    boxshadow: ${props => (props.error ? '0px 0px 0px 2px rgba(234,16,16,0.2)' : 'none')};
+    padding: 0 7px;
+  }
+  &:focus {
+    background-color: ${props => props.theme.colors.inputBackgroundColor};
+    box-shadow: none;
+    border: 1px solid rgba(0, 59, 129, 0.37);
+  }
+`;
+
+export const FormCheckBoxWrapper = styled(Row)<FormInputProps>`
+  box-sizing: border-box; /* Tells the browser to account for any border and padding in the values you specify for an element's width and height. https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing*/
+  width: 217px;
+  height: 36px;
+  border-radius: 4px;
+  border: ${props => (props.error ? '1px solid #CB3232' : 'none')};
+  boxshadow: ${props => (props.error ? '0px 0px 0px 2px rgba(234,16,16,0.2)' : 'none')};
+`;
+FormCheckBoxWrapper.displayName = 'FormCheckBoxWrapper';
+
+const CheckboxBase = styled('input')<FormInputProps>`
+  &[type='checkbox'] {
     display: inline-block;
     position: relative;
     padding-left: 1.4em;
     cursor: default;
+    margin-right: 5px;
   }
-  &[class~='mixed-checkbox'][type='checkbox']::before,
-  &[class~='mixed-checkbox'][type='checkbox']::after {
+  &[type='checkbox']::before,
+  &[type='checkbox']::after {
     position: absolute;
     top: 50%;
     left: 7px;
     transform: translate(-50%, -50%);
     content: '';
   }
-  &[class~='mixed-checkbox'][type='checkbox']::before {
-    width: 14px;
-    height: 14px;
+  &[type='checkbox']::before {
+    width: 13px;
+    height: 13px;
     border: 1px solid hsl(0, 0%, 66%);
     border-radius: 0.2em;
     background-image: linear-gradient(to bottom, hsl(300, 3%, 93%), #fff 30%);
   }
-  &[class~='mixed-checkbox'][type='checkbox']:active::before {
+  &[type='checkbox']:active::before {
     background-image: linear-gradient(to bottom, hsl(300, 3%, 73%), hsl(300, 3%, 93%) 30%);
   }
+`;
+
+export const FormCheckbox = styled(CheckboxBase)`
+  &[type='checkbox']:checked::before {
+    border-color: #5dba32;
+    background: #5dba32;
+  }
+  &[type='checkbox']:checked::after {
+    font-family: 'Font Awesome 5 Free';
+    content: '\f00c';
+    color: #ffffff;
+  }
+`;
+FormCheckbox.displayName = 'FormCheckbox';
+
+export const FormMixedCheckbox = styled(CheckboxBase)`
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='false']::before {
     border-color: #d13821;
     background: #d13821;
@@ -735,13 +793,12 @@ export const FormInput = styled('input')<FormInputProps>`
   }
   /* To disable the outline when focused */
   /* &[class~=mixed-checkbox][type=checkbox]:focus {
-    outline: none;
-  } */
+  outline: none;
+} */
   /* Other stuff that we can use to style the pseudo elements */
   /* &[class~=mixed-checkbox][type=checkbox][aria-checked="true"]:active::before  */
   /* &[class~=mixed-checkbox][type=checkbox]:focus::before */
 `;
-FormInput.displayName = 'FormInput';
 
 export const FormSelectWrapper = styled('div')`
   position: relative;


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-317

This PR:
- Improves styles for the forms, making them look more like what we have now.
- Reorganizes styles and some UI generation helpers

NOTE: in this PR, a second "settings button" is included in the left nav. That button opens a screen full with a bunch of inputs in order to make testing easier. The code related to this has been removed, in order to try it out, checkout to the commit `9ba7363`.

______________

The idea of this PR is to finish the required work on the form generators. The main code is contained in `src/components/forms/formGenerators.tsx` (introduced in a previous PR but reworked here).
The key entry point for using this is the `createFormFromDefinition` function:
```
export const createFormFromDefinition = (definition: FormDefinition) => (parents: string[]) => (
  updateCallback: () => void,
): JSX.Element[] => definition.map(getInputType(parents, updateCallback));

```
The basic idea of this generators is that if you provide a form definition (`definition: FormDefinition` following the schema described at the bottom of `src/components/forms/types.ts`), the `createFormFromDefinition` function will return an array of html inputs, each one connected to the React-Hook-Form wrapper (for this to work, the generated array must be child of a `FormProvider`, [examples here](https://react-hook-form.com/api)). The inputs are connected to the provider via the `ConnectForm` high order component, which will provide all of the form methods (refer to [rhf docs](https://react-hook-form.com/api) for details). 
The second parameter is an array of string called `parents`, that specifies the levels of nesting that this will have inside of the broader form (many "arrays" of inputs can be connected to the same form, each of them representing a different property of the entire form, like `childInformation`, `callerInformation`, etc). Each component will receive the `parents` array, and a `name` describing itself. The resulting string from concatenating the `parents` and `name` will be used to refer to this particular input, following the "dot joined conventions" that [rhf follows](https://react-hook-form.com/api#register). The definition of each input contains, besides its name, a lot more of important information, like the label (localized template string), the type of the input, different options depending on the type and validation rules.
The `createFormFromDefinition` receives a 3rd parameter `updateCallback: () => void`, that is the function that will be called `onChange` / `onBlur` (depending on the input type), and can be used to trigger local or global state updates, api calls, etc. This function is now being called in specific events, but can be better abstracted to be an object of event handlers, in order to provide better granularity and more reusability (future work).
The responsibility on how to display the inputs is delegated to the component rendering the form. The styles for each input is coupled in this version, but can be abstracted as an extra parameter (future work).

For the rest of the functions in the `formGenerators.tsx` file:
- `getInputType` creates an individual input from a given `FormItemDefinition`, using the `parents` and `updateCallback` mentioned above. The definition for each input contains all the required information like name, type, validation, etc.
- `getInitialValue` is a helper that returns the "initial state" for each input type, used for example, when first creating the "empty contact state" for a freshly accepted task.
- `createStateItem` uses above helper and combined with `Array.reduce` make easy to create the "empty state" for all the components described in a `FormDefinition`.
- rest of the functions are just UI helpers for the tabbed forms particular use case, barely abstracted.

The rest of the files changing in this PR are for styling.