### PR TITLE
Allow missing helpline param for contactless function

### DIFF
--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -84,7 +84,7 @@ export const assignMeContactlessTask = async () => {
   const body = {
     targetSid: workerSid,
     transferTargetType: 'worker',
-    helpline,
+    helpline: helpline || '',
   };
 
   const response = await fetchProtectedApi('/createContactlessTask', body);


### PR DESCRIPTION
Without this change, a worker with a missing helpline attribute will not be able to create a contactless task.  A value of `"undefined"` will be passed to the serverless function, and an error of `Uncaught (in promise) Error: Couldn't match task to queue in workspace WSXXXXX for account ACXXXXXX` will be generated.

@GPaoloni I will just go ahead and merge this because it's so small, but please take a quick look when you get a chance.