### PR TITLE
Do not let warm text transfers go through

### DIFF
--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -146,11 +146,13 @@ const safeTransfer = async (transferFunction, task) => {
 export const customTransferTask = setupObject => async (payload, original) => {
   const mode = payload.options.mode || DEFAULT_TRANSFER_MODE;
 
-  // Currently (as of 2 Dec 2020) warm text transfers are not supported.
-  // We shortcut the rest of the function to save extra time and unnecessary visual changes.
+  /*
+   * Currently (as of 2 Dec 2020) warm text transfers are not supported.
+   * We shortcut the rest of the function to save extra time and unnecessary visual changes.
+   */
   if (!TaskHelper.isCallTask(payload.task) && mode === transferModes.warm) {
     window.alert(Manager.getInstance().strings['Transfer-ChatWarmNotAllowed']);
-    return; // Not calling original(payload) prevents the additional "Task cannot be transferred" notification
+    return () => undefined; // Not calling original(payload) prevents the additional "Task cannot be transferred" notification
   }
 
   const { identity, workerSid, counselorName } = setupObject;


### PR DESCRIPTION
@GPaoloni please read [CHI-380](https://bugs.benetech.org/browse/CHI-380) for background.

This PR fixes CHI-380.  After warning that we can't do a warm text transfer, we don't `return`, so we continue to try to do the transfer.  This PR adds a `return` and also moves that check up earlier in the function so that we don't have to start and then roll back all of the transfer metadata preparation.

The grand mystery is that this bug is **not** happening on production, and I don't understand how that could be happening.