### PR TITLE
Make contact details to show custom information

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.js
@@ -1,93 +1,30 @@
-import { transformForm, saveToHrm } from '../../services/ContactService';
-import { FieldType, ValidationType, recreateBlankForm } from '../../states/ContactFormStateFactory';
+import { set } from 'lodash/fp';
+
+import { transformForm, saveToHrm, createCategoriesObject } from '../../services/ContactService';
+import { FieldType, recreateBlankForm } from '../../states/ContactFormStateFactory';
+import { createNewTaskEntry } from '../../states/contacts/reducer';
 import callTypes, { channelTypes } from '../../states/DomainConstants';
+import callerFormDefinition from '../../formDefinitions/tabbedForms/CallerInformationTab.json';
+import caseInfoFormDefinition from '../../formDefinitions/tabbedForms/CaseInformationTab.json';
+import childFormDefinition from '../../formDefinitions/tabbedForms/ChildInformationTab.json';
+import categoriesFormDefinition from '../../formDefinitions/tabbedForms/IssueCategorizationTab.json';
 
 describe('transformForm', () => {
   test('removes control information and presents values only', () => {
     const oldForm = {
-      callType: {
-        type: FieldType.CALL_TYPE,
-        value: callTypes.caller,
-      },
-      callerInformation: {
-        type: FieldType.TAB,
-        name: {
-          type: FieldType.INTERMEDIATE,
-          firstName: {
-            type: FieldType.TEXT_INPUT,
-            value: 'myFirstName',
-            touched: true,
-            error: null,
-            validation: null,
-          },
-        },
-      },
-      childInformation: {
-        type: FieldType.TAB,
-        gender: {
-          type: FieldType.SELECT_SINGLE,
-          validation: [ValidationType.REQUIRED],
-          touched: true,
-          value: 'Male',
-        },
-        refugee: {
-          type: FieldType.CHECKBOX,
-          value: false,
-        },
-      },
-      caseInformation: {
-        type: FieldType.TAB,
-        categories: {
-          type: FieldType.CHECKBOX_FIELD,
-          validation: [ValidationType.REQUIRED],
-          error: null,
-          category1: {
-            type: FieldType.INTERMEDIATE,
-            sub1: {
-              type: FieldType.CHECKBOX,
-              value: true,
-            },
-            sub2: {
-              type: FieldType.CHECKBOX,
-              value: false,
-            },
-          },
-        },
-        status: {
-          value: '',
-          type: FieldType.SELECT_SINGLE,
-          validation: null,
-        },
-        callSummary: {
-          type: FieldType.TEXT_BOX,
-          validation: null,
-          value: 'My summary',
-        },
-      },
-      contactlessTask: {
-        channel: '',
-        date: '',
-        time: '',
-      },
-    };
-    const expected = {
       callType: callTypes.caller,
       callerInformation: {
-        name: {
-          firstName: 'myFirstName',
-        },
+        firstName: 'myFirstName',
+        lastName: '',
       },
       childInformation: {
+        firstName: 'child',
+        lastName: '',
         gender: 'Male',
         refugee: false,
       },
+      categories: ['Abuse.Abduction'],
       caseInformation: {
-        categories: {
-          category1: {
-            sub1: true,
-            sub2: false,
-          },
-        },
         status: '',
         callSummary: 'My summary',
       },
@@ -96,33 +33,53 @@ describe('transformForm', () => {
         date: '',
         time: '',
       },
+      metadata: {},
+    };
+
+    const expected = {
+      definitionVersion: 'v1',
+      callType: callTypes.caller,
+      callerInformation: { name: { firstName: 'myFirstName', lastName: '' } },
+      childInformation: {
+        gender: 'Male',
+        refugee: false,
+        name: { firstName: 'child', lastName: '' },
+      },
+      caseInformation: {
+        // copy paste from ContactService. This will come from redux later on and we can mockup definitions
+        categories: oldForm.categories.reduce((acc, path) => set(path, true, acc), createCategoriesObject()),
+        status: '',
+        callSummary: 'My summary',
+      },
+      contactlessTask: {
+        channel: '',
+        date: '',
+        time: '',
+      },
+      metadata: {},
     };
     expect(transformForm(oldForm)).toStrictEqual(expected);
   });
 });
 
+// The tabbed form definitions, used to create new form state.
+const definitions = {
+  callerFormDefinition,
+  caseInfoFormDefinition,
+  categoriesFormDefinition,
+  childFormDefinition,
+};
+
 const createForm = ({ callType, childFirstName }, contactlessTaskInfo = undefined) => {
-  const blankForm = recreateBlankForm();
+  const blankForm = createNewTaskEntry(definitions)(false);
   const contactlessTask = contactlessTaskInfo || blankForm.contactlessTask;
 
   return {
     ...blankForm,
-    callType: {
-      type: FieldType.CALL_TYPE,
-      value: callType,
-    },
+    callType,
     childInformation: {
       ...blankForm.childInformation,
-      name: {
-        ...blankForm.childInformation.name,
-        firstName: {
-          type: FieldType.TEXT_INPUT,
-          value: childFirstName,
-          touched: true,
-          error: null,
-          validation: null,
-        },
-      },
+      firstName: childFirstName,
     },
     contactlessTask,
   };
@@ -148,6 +105,7 @@ describe('saveToHrm()', () => {
 
   test('data calltype saves form data', async () => {
     const form = createForm({ callType: callTypes.child, childFirstName: 'Jill' });
+
     const mockedFetch = jest.spyOn(global, 'fetch').mockImplementation(() => fetchSuccess);
 
     await saveToHrm(task, form, hrmBaseUrl, workerSid, helpline);

--- a/plugin-hrm-form/src/components/ContactDetails.tsx
+++ b/plugin-hrm-form/src/components/ContactDetails.tsx
@@ -3,23 +3,22 @@ import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 import { IconButton } from '@material-ui/core';
 import { Link as LinkIcon } from '@material-ui/icons';
+import { Template } from '@twilio/flex-ui';
 
+import { Row } from '../styles/HrmStyles';
 import { DetailsContainer, NameContainer, DetNameText } from '../styles/search';
 import Section from './Section';
 import SectionEntry from './SectionEntry';
 import callTypes, { channelTypes } from '../states/DomainConstants';
 import { isNonDataCallType } from '../states/ValidationRules';
 import { contactType } from '../types';
-import {
-  formatAddress,
-  formatDuration,
-  formatName,
-  formatCategories,
-  mapChannel,
-  mapChannelForInsights,
-} from '../utils';
-import { CallerSection, ContactDetailsSections } from './common/ContactDetails';
-import { getConfig } from '../HrmFormPlugin';
+import { formatDuration, formatName, formatCategories, mapChannel, mapChannelForInsights } from '../utils';
+import { ContactDetailsSections } from './common/ContactDetails';
+import { unNestInformation } from '../services/ContactService';
+import type { FormDefinition } from './common/forms/types';
+import CallerInformationTab from '../formDefinitions/tabbedForms/CallerInformationTab.json';
+import CaseInformationTab from '../formDefinitions/tabbedForms/CaseInformationTab.json';
+import ChildInformationTab from '../formDefinitions/tabbedForms/ChildInformationTab.json';
 
 const Details = ({
   contact,
@@ -32,17 +31,6 @@ const Details = ({
   const { overview, details, counselor } = contact;
   const { dateTime, name: childName, customerNumber, callType, channel, conversationDuration, categories } = overview;
   const child = details.childInformation;
-  const {
-    callSummary,
-    referredTo,
-    status,
-    keepConfidential,
-    okForCaseWorkerToCall,
-    howDidTheChildHearAboutUs,
-    didYouDiscussRightsWithTheChild,
-    didTheChildFeelWeSolvedTheirProblem,
-    wouldTheChildRecommendUsToAFriend,
-  } = details.caseInformation;
 
   // Format the obtained information
   const isDataCall = !isNonDataCallType(callType);
@@ -52,20 +40,10 @@ const Details = ({
     channel === 'default' ? mapChannelForInsights(details.contactlessTask.channel) : mapChannel(channel);
   const formattedDate = `${format(new Date(dateTime), 'MMM d, yyyy / h:mm aaaaa')}m`;
   const formattedDuration = formatDuration(conversationDuration);
-  const formattedChildAddress = formatAddress(
-    child.location.streetAddress,
-    child.location.city,
-    child.location.stateOrCounty,
-    child.location.postalCode,
-  );
 
   const isPhoneContact =
     channel === channelTypes.voice || channel === channelTypes.sms || channel === channelTypes.whatsapp;
-  const [category1, category2, category3] = formatCategories(categories);
-
-  const isNonDataContact = isNonDataCallType(contact.overview.callType);
-
-  const { strings } = getConfig();
+  const formattedCategories = formatCategories(categories);
 
   const {
     GENERAL_DETAILS,
@@ -83,7 +61,7 @@ const Details = ({
           <>
             <IconButton
               onClick={handleOpenConnectDialog}
-              disabled={isNonDataContact}
+              disabled={!isDataCall}
               style={{ paddingTop: 0, paddingBottom: 0 }}
             >
               <LinkIcon style={{ color: '#ffffff' }} />
@@ -92,7 +70,7 @@ const Details = ({
         )}
       </NameContainer>
       <Section
-        sectionTitle={strings['ContactDetails-GeneralDetails']}
+        sectionTitle={<Template code="ContactDetails-GeneralDetails" />}
         expanded={detailsExpanded[GENERAL_DETAILS]}
         handleExpandClick={() => handleExpandDetailsSection(GENERAL_DETAILS)}
       >
@@ -103,69 +81,73 @@ const Details = ({
         <SectionEntry description="Date/Time" value={formattedDate} />
       </Section>
       {callType === callTypes.caller && (
-        <CallerSection
+        <Section
+          sectionTitle={<Template code="TabbedForms-AddCallerInfoTab" />}
           expanded={detailsExpanded[CALLER_INFORMATION]}
           handleExpandClick={() => handleExpandDetailsSection(CALLER_INFORMATION)}
-          sectionTitleTemplate="TabbedForms-AddCallerInfoTab"
-          values={details.callerInformation}
-        />
+          buttonDataTestid="ContactDetails-Section-CallerInformation"
+        >
+          {(CallerInformationTab as FormDefinition).map(e => (
+            <SectionEntry
+              key={`CallerInformation-${e.label}`}
+              description={<Template code={e.label} />}
+              value={unNestInformation(e, contact.details.callerInformation)}
+            />
+          ))}
+        </Section>
       )}
       {isDataCall && (
         <Section
-          sectionTitle={strings['TabbedForms-AddChildInfoTab']}
+          sectionTitle={<Template code="TabbedForms-AddChildInfoTab" />}
           expanded={detailsExpanded[CHILD_INFORMATION]}
           handleExpandClick={() => handleExpandDetailsSection(CHILD_INFORMATION)}
           buttonDataTestid="ContactDetails-Section-ChildInformation"
         >
-          <SectionEntry description="Name" value={childOrUnknown} />
-          <SectionEntry description="Address" value={formattedChildAddress} />
-          <SectionEntry description="Phone #1" value={child.location.phone1} />
-          <SectionEntry description="Phone #2" value={child.location.phone2} />
-          <SectionEntry description="Gender" value={child.gender} />
-          <SectionEntry description="Age Range" value={child.age} />
-          <SectionEntry description="Language" value={child.language} />
-          <SectionEntry description="Nationality" value={child.nationality} />
-          <SectionEntry description="Ethnicity" value={child.ethnicity} />
-          <SectionEntry description="School Name" value={child.school.name} />
-          <SectionEntry description="Grade Level" value={child.school.gradeLevel} />
-          <SectionEntry description="Refugee?" value={child.refugee} />
-          <SectionEntry description="Disabled/Special Needs?" value={child.disabledOrSpecialNeeds} />
-          <SectionEntry description="HIV Positive?" value={child.hiv} />
+          {(ChildInformationTab as FormDefinition).map(e => (
+            <SectionEntry
+              key={`ChildInformation-${e.label}`}
+              description={<Template code={e.label} />}
+              value={unNestInformation(e, contact.details.childInformation)}
+            />
+          ))}
         </Section>
       )}
       {isDataCall && (
         <Section
-          sectionTitle={strings['TabbedForms-CategoriesTab']}
+          sectionTitle={<Template code="TabbedForms-CategoriesTab" />}
           expanded={detailsExpanded[ISSUE_CATEGORIZATION]}
           handleExpandClick={() => handleExpandDetailsSection(ISSUE_CATEGORIZATION)}
         >
-          {Boolean(category1) && <SectionEntry description="Category 1" value={category1} />}
-          {Boolean(category2) && <SectionEntry description="Category 2" value={category2} />}
-          {Boolean(category3) && <SectionEntry description="Category 3" value={category3} />}
-          {!(category1 || category2 || category3) && <SectionEntry description="No category provided" value="" />}
+          {formattedCategories.length ? (
+            formattedCategories.map((c, index) => (
+              <SectionEntry
+                key={`Category ${index + 1}`}
+                description={
+                  <Row>
+                    <Template code="Category" /> {index + 1}
+                  </Row>
+                }
+                value={c}
+              />
+            ))
+          ) : (
+            <SectionEntry description="No category provided" value="" />
+          )}
         </Section>
       )}
       {isDataCall && (
         <Section
-          sectionTitle={strings['TabbedForms-AddCaseInfoTab']}
+          sectionTitle={<Template code="TabbedForms-AddCaseInfoTab" />}
           expanded={detailsExpanded[CONTACT_SUMMARY]}
           handleExpandClick={() => handleExpandDetailsSection(CONTACT_SUMMARY)}
         >
-          <SectionEntry description="Call Summary" value={callSummary} />
-          <SectionEntry description="Status" value={status} />
-          <SectionEntry description="Referred To" value={referredTo} />
-          <SectionEntry description="Keep Confidential?" value={keepConfidential} />
-          <SectionEntry description="OK for the case worker to call?" value={okForCaseWorkerToCall} />
-          <SectionEntry description="How did the child hear about us?" value={howDidTheChildHearAboutUs} />
-          <SectionEntry description="Did you discuss rights with the child?" value={didYouDiscussRightsWithTheChild} />
-          <SectionEntry
-            description="Did the child feel we solved their problem?"
-            value={didTheChildFeelWeSolvedTheirProblem}
-          />
-          <SectionEntry
-            description="Would the child recommend us to a friend?"
-            value={wouldTheChildRecommendUsToAFriend}
-          />
+          {CaseInformationTab.map(e => (
+            <SectionEntry
+              key={`CaseInformation-${e.label}`}
+              description={<Template code={e.label} />}
+              value={contact.details.caseInformation[e.name]}
+            />
+          ))}
         </Section>
       )}
     </DetailsContainer>

--- a/plugin-hrm-form/src/services/ContactService.js
+++ b/plugin-hrm-form/src/services/ContactService.js
@@ -17,7 +17,6 @@ import categoriesFormDefinition from '../formDefinitions/tabbedForms/IssueCatego
  * Un-nests the information (caller/child) as it comes from DB, to match the form structure
  * @param {import('../components/common/forms/types').FormItemDefinition} e
  * @param {import('../types/types').ContactRawJson['callerInformation'] | import('../types/types').ContactRawJson['childInformation']} obj
- * @returns {import('../states/contacts/reducer').TaskEntry['callerInformation'] | import('../states/contacts/reducer').TaskEntry['childInformation']}
  */
 export const unNestInformation = (e, obj) =>
   ['firstName', 'lastName'].includes(e.name) ? obj.name[e.name] : obj[e.name];

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -206,5 +206,6 @@
   "TimeCantBeGreaterThanNow": "Time can't be greater than now.",
 
   "OfflineContactFirstLine": "Offline Contact",
-  "OfflineContactSecondLine": "in progress"
+  "OfflineContactSecondLine": "in progress",
+  "Category": "Category"
 }


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-335

This PR updates ContactDetails component to consume all of the defined input fields.

Important note: this PR is not taking into consideration form versioning. While The form is saved with the version number (so it can be used in the future), we are now only using the v1 definition to consume the data. This will change soon, when we move to the final structure for fetching definition versions if needed.