### PR TITLE
Bug fix: dependent select & 3-way checkbox losing state

### DIFF
--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -472,12 +472,12 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
 export const createFormFromDefinition = (definition: FormDefinition) => (parents: string[]) => (initialValues: any) => (
   updateCallback: () => void,
 ): JSX.Element[] => {
-  const f = getInputType(parents, updateCallback);
+  const bindGetInputType = getInputType(parents, updateCallback);
 
   return definition.map((e: FormItemDefinition) => {
-    const v = get(initialValues, e.name);
-    const initialValue = v === undefined ? getInitialValue(e) : v;
-    return f(e)(initialValue);
+    const maybeValue = get(initialValues, e.name);
+    const initialValue = maybeValue === undefined ? getInitialValue(e) : maybeValue;
+    return bindGetInputType(e)(initialValue);
   });
 };
 

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -27,6 +27,41 @@ import {
 } from '../../../styles/HrmStyles';
 import type { FormItemDefinition, FormDefinition, SelectOption, MixedOrBool } from './types';
 
+/**
+ * Utility functions to create initial state from definition
+ * @param {FormItemDefinition} def Definition for a single input of a Form
+ */
+export const getInitialValue = (def: FormItemDefinition) => {
+  switch (def.type) {
+    case 'input':
+    case 'numeric-input':
+    case 'textarea':
+    case 'date-input':
+    case 'time-input':
+      return '';
+    case 'select':
+      return def.options[0].value;
+    case 'dependent-select':
+      return def.defaultOption.value;
+    case 'checkbox':
+      return false;
+    case 'mixed-checkbox':
+      return def.initialChecked === undefined ? 'mixed' : def.initialChecked;
+    default:
+      return null;
+  }
+};
+
+/**
+ * Adds a new property to the given object, with the name of the given form item definition, and initial value will depend on it
+ * @param obj the object to which add a property related to the provided form item definition
+ * @param def the provided form item definition
+ */
+export const createStateItem = <T extends {}>(obj: T, def: FormItemDefinition) => ({
+  ...obj,
+  [def.name]: getInitialValue(def),
+});
+
 export const ConnectForm: React.FC<{
   children: <P extends ReturnType<typeof useFormContext>>(args: P) => JSX.Element;
 }> = ({ children }) => {
@@ -50,7 +85,9 @@ const getRules = (field: FormItemDefinition): ValidationRules =>
  * @param {() => void} updateCallback Callback called to update form state. When is the callback called is specified in the input type.
  * @param {FormItemDefinition} def Definition for a single input.
  */
-const getInputType = (parents: string[], updateCallback: () => void) => (def: FormItemDefinition) => {
+const getInputType = (parents: string[], updateCallback: () => void) => (def: FormItemDefinition) => (
+  initialValue: any, // TODO: restrict this type
+) => {
   const rules = getRules(def);
   const path = [...parents, def.name].join('.');
 
@@ -76,6 +113,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                   aria-describedby={`${path}-error`}
                   onBlur={updateCallback}
                   innerRef={register(rules)}
+                  defaultValue={initialValue}
                 />
                 {error && (
                   <FormError>
@@ -111,6 +149,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     ...rules,
                     pattern: { value: /^[0-9]+$/g, message: 'This field only accepts numeric input.' },
                   })}
+                  defaultValue={initialValue}
                 />
                 {error && (
                   <FormError>
@@ -144,6 +183,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     aria-describedby={`${path}-error`}
                     onBlur={updateCallback}
                     innerRef={register(rules)}
+                    defaultValue={initialValue}
                   >
                     {def.options.map(o => (
                       <FormOption key={`${path}-${o.value}`} value={o.value} isEmptyValue={o.value === ''}>
@@ -166,25 +206,35 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
       return (
         <ConnectForm key={path}>
           {({ errors, register, watch, setValue }) => {
+            const isMounted = React.useRef(false); // mutable value to avoid reseting the state in the first render. This preserves the "intialValue" provided
+            const prevDependeeValue = React.useRef(undefined); // mutable value to store previous dependeeValue
+
             const dependeePath = [...parents, def.dependsOn].join('.');
             const dependeeValue = watch(dependeePath);
 
-            React.useEffect(() => setValue(path, def.defaultOption.value, { shouldValidate: true }), [
-              setValue,
-              dependeeValue,
-            ]);
+            React.useEffect(() => {
+              if (isMounted.current && prevDependeeValue.current && dependeeValue !== prevDependeeValue.current) {
+                setValue(path, def.defaultOption.value, { shouldValidate: true });
+              } else isMounted.current = true;
+
+              prevDependeeValue.current = dependeeValue;
+            }, [setValue, dependeeValue]);
 
             const error = get(errors, path);
             const hasOptions = Boolean(dependeeValue && def.options[dependeeValue]);
+            const shouldInitialize = initialValue && !isMounted.current;
 
             const validate = (data: any) =>
               hasOptions && def.required && data === def.defaultOption.value ? 'RequiredFieldError' : null;
 
+            // eslint-disable-next-line no-nested-ternary
             const options: SelectOption[] = hasOptions
               ? [def.defaultOption, ...def.options[dependeeValue]]
+              : shouldInitialize
+              ? [def.defaultOption, { label: initialValue, value: initialValue }]
               : [def.defaultOption];
 
-            const disabled = !hasOptions;
+            const disabled = !hasOptions && !shouldInitialize;
 
             return (
               <DependentSelectLabel htmlFor={path} disabled={disabled}>
@@ -204,6 +254,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     onBlur={updateCallback}
                     innerRef={register({ validate })}
                     disabled={disabled}
+                    defaultValue={initialValue}
                   >
                     {options.map(o => (
                       <FormOption key={`${path}-${o.value}`} value={o.value} isEmptyValue={o.value === ''}>
@@ -239,6 +290,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                       aria-describedby={`${path}-error`}
                       onChange={updateCallback}
                       innerRef={register(rules)}
+                      defaultChecked={initialValue}
                     />
                   </Box>
                   <Template code={`${def.label}`} />
@@ -262,7 +314,8 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
               register(path, rules);
             }, [register]);
 
-            const initialChecked = def.initialChecked === undefined ? 'mixed' : def.initialChecked;
+            const initialChecked =
+              initialValue === undefined || typeof initialValue !== 'boolean' ? 'mixed' : initialValue;
             const [checked, setChecked] = React.useState<MixedOrBool>(initialChecked);
 
             React.useEffect(() => {
@@ -325,6 +378,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                   onBlur={updateCallback}
                   innerRef={register(rules)}
                   rows={10}
+                  defaultValue={initialValue}
                 />
                 {error && (
                   <FormError>
@@ -358,6 +412,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                   aria-describedby={`${path}-error`}
                   onBlur={updateCallback}
                   innerRef={register(rules)}
+                  defaultValue={initialValue}
                 />
                 {error && (
                   <FormError>
@@ -391,6 +446,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                   aria-describedby={`${path}-error`}
                   onBlur={updateCallback}
                   innerRef={register(rules)}
+                  defaultValue={initialValue}
                 />
                 {error && (
                   <FormError>
@@ -413,44 +469,17 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
  * @param {string[]} parents Array of parents. Allows you to easily create nested form fields. https://react-hook-form.com/api#register.
  * @param {() => void} updateCallback Callback called to update form state. When is the callback called is specified in the input type (getInputType).
  */
-export const createFormFromDefinition = (definition: FormDefinition) => (parents: string[]) => (
+export const createFormFromDefinition = (definition: FormDefinition) => (parents: string[]) => (initialValues: any) => (
   updateCallback: () => void,
-): JSX.Element[] => definition.map(getInputType(parents, updateCallback));
+): JSX.Element[] => {
+  const f = getInputType(parents, updateCallback);
 
-/**
- * Utility functions to create initial state from definition
- * @param {FormItemDefinition} def Definition for a single input of a Form
- */
-export const getInitialValue = (def: FormItemDefinition) => {
-  switch (def.type) {
-    case 'input':
-    case 'numeric-input':
-    case 'textarea':
-    case 'date-input':
-    case 'time-input':
-      return '';
-    case 'select':
-      return def.options[0].value;
-    case 'dependent-select':
-      return def.defaultOption.value;
-    case 'checkbox':
-      return false;
-    case 'mixed-checkbox':
-      return def.initialChecked === undefined ? 'mixed' : def.initialChecked;
-    default:
-      return null;
-  }
+  return definition.map((e: FormItemDefinition) => {
+    const v = get(initialValues, e.name);
+    const initialValue = v === undefined ? getInitialValue(e) : v;
+    return f(e)(initialValue);
+  });
 };
-
-/**
- * Adds a new property to the given object, with the name of the given form item definition, and initial value will depend on it
- * @param obj the object to which add a property related to the provided form item definition
- * @param def the provided form item definition
- */
-export const createStateItem = <T extends {}>(obj: T, def: FormItemDefinition) => ({
-  ...obj,
-  [def.name]: getInitialValue(def),
-});
 
 export const disperseInputs = (margin: number) => (formItems: JSX.Element[]) =>
   formItems.map(i => (

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -10,18 +10,22 @@ import { createFormFromDefinition, disperseInputs } from '../common/forms/formGe
 import { updateForm } from '../../states/contacts/actions';
 import { Container, ColumnarBlock, TwoColumnLayout, TabbedFormTabContainer } from '../../styles/HrmStyles';
 import type { RootState } from '../../states';
+import type { TaskEntry } from '../../states/contacts/reducer';
 import { formDefinition } from './ContactlessTaskTabDefinition';
 import { splitDate, splitTime } from '../../utils/helpers';
 
 type OwnProps = {
   task: ITask;
   display: boolean;
+  initialValues: TaskEntry[keyof TaskEntry];
 };
 
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task }) => {
+const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task, initialValues }) => {
+  const [initialForm] = React.useState(initialValues); // grab initial values in first render only. This value should never change or will ruin the memoization below
+
   const { getValues, register, setError, setValue, watch, errors } = useFormContext();
 
   const contactlessTaskForm = React.useMemo(() => {
@@ -30,10 +34,10 @@ const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task }) => {
       dispatch(updateForm(task.taskSid, 'contactlessTask', rest));
     };
 
-    const tab = createFormFromDefinition(formDefinition)(['contactlessTask'])(updateCallBack);
+    const tab = createFormFromDefinition(formDefinition)(['contactlessTask'])(initialForm)(updateCallBack);
 
     return disperseInputs(5)(tab);
-  }, [dispatch, getValues, task.taskSid]);
+  }, [dispatch, getValues, initialForm, task.taskSid]);
 
   // Add invisible field that errors if date + time are future (triggered by validaiton)
   React.useEffect(() => {

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedFormTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedFormTab.tsx
@@ -17,12 +17,19 @@ import { createFormFromDefinition, disperseInputs, splitInHalf } from '../common
 import type { FormDefinition } from '../common/forms/types';
 import type { TaskEntry } from '../../states/contacts/reducer';
 
-type OwnProps = { task: ITask; display: boolean; definition: FormDefinition; tabPath: keyof TaskEntry };
+type OwnProps = {
+  task: ITask;
+  display: boolean;
+  definition: FormDefinition;
+  tabPath: keyof TaskEntry;
+  initialValues: TaskEntry['callerInformation'] | TaskEntry['childInformation'] | TaskEntry['caseInformation'];
+};
 
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const TabbedFormTab: React.FC<Props> = ({ task, display, definition, tabPath, updateForm }) => {
+const TabbedFormTab: React.FC<Props> = ({ task, display, definition, tabPath, initialValues, updateForm }) => {
+  const [initialForm] = React.useState(initialValues); // grab initial values in first render only. This value should never change or will ruin the memoization below
   const { getValues } = useFormContext();
 
   const [l, r] = React.useMemo(() => {
@@ -31,12 +38,11 @@ const TabbedFormTab: React.FC<Props> = ({ task, display, definition, tabPath, up
       updateForm(task.taskSid, tabPath, values);
     };
 
-    // TODO: fix this typecasting
-    const generatedForm = createFormFromDefinition(definition)([tabPath])(updateCallback);
+    const generatedForm = createFormFromDefinition(definition)([tabPath])(initialForm)(updateCallback);
 
     const margin = 12;
     return splitInHalf(disperseInputs(margin)(generatedForm));
-  }, [definition, getValues, tabPath, task.taskSid, updateForm]);
+  }, [definition, getValues, initialForm, tabPath, task.taskSid, updateForm]);
 
   return (
     <TabbedFormTabContainer display={display}>

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -7,7 +7,7 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { namespace, contactFormsBase, routingBase, RootState } from '../../states';
 import { updateCallType, updateForm } from '../../states/contacts/actions';
-import { unNestInformation, deTransformValue } from '../../services/ContactService';
+import { searchResultToContactForm, deTransformValue } from '../../services/ContactService';
 import { changeRoute } from '../../states/routing/actions';
 import type { TaskEntry } from '../../states/contacts/reducer';
 import type { TabbedFormSubroutes } from '../../states/routing/types';
@@ -70,7 +70,6 @@ type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, ...props }) => {
   const methods = useForm({
-    defaultValues: contactForm,
     shouldFocusError: false,
     mode: 'onChange',
   });
@@ -84,22 +83,20 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, ...props
   const onSelectSearchResult = (searchResult: SearchContact) => {
     const selectedIsCaller = searchResult.details.callType === callTypes.caller;
     if (isCallerType && selectedIsCaller) {
-      (CallerTabDefinition as FormDefinition).forEach(e => {
-        const unNested = unNestInformation(e, searchResult.details.callerInformation);
-        const deTransformed = deTransformValue(e)(unNested);
-        methods.setValue(`callerInformation.${e.name}`, deTransformed);
-      });
-      const { callerInformation } = methods.getValues();
-      dispatch(updateForm(task.taskSid, 'callerInformation', callerInformation));
+      const deTransformed = searchResultToContactForm(
+        CallerTabDefinition as FormDefinition,
+        searchResult.details.callerInformation,
+      );
+
+      dispatch(updateForm(task.taskSid, 'callerInformation', deTransformed));
       dispatch(changeRoute({ route: 'tabbed-forms', subroute: 'callerInformation' }, taskId));
     } else {
-      (ChildTabDefinition as FormDefinition).forEach(e => {
-        const unNested = unNestInformation(e, searchResult.details.childInformation);
-        const deTransformed = deTransformValue(e)(unNested);
-        methods.setValue(`childInformation.${e.name}`, deTransformed);
-      });
-      const { childInformation } = methods.getValues();
-      dispatch(updateForm(task.taskSid, 'childInformation', childInformation));
+      const deTransformed = searchResultToContactForm(
+        ChildTabDefinition as FormDefinition,
+        searchResult.details.childInformation,
+      );
+
+      dispatch(updateForm(task.taskSid, 'childInformation', deTransformed));
       dispatch(changeRoute({ route: 'tabbed-forms', subroute: 'childInformation' }, taskId));
     }
   };
@@ -151,23 +148,31 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, ...props
             <Search currentIsCaller={isCallerType} handleSelectSearchResult={onSelectSearchResult} />
           ) : (
             <div style={{ height: '100%', overflow: 'hidden' }}>
-              {task.attributes.isContactlessTask && <ContactlessTaskTab display={subroute === 'contactlessTask'} />}
+              {task.attributes.isContactlessTask && (
+                <ContactlessTaskTab
+                  display={subroute === 'contactlessTask'}
+                  initialValues={contactForm.contactlessTask}
+                />
+              )}
               {isCallerType && (
                 <TabbedFormTab
                   tabPath="callerInformation"
                   definition={CallerTabDefinition as FormDefinition}
+                  initialValues={contactForm.callerInformation}
                   display={subroute === 'callerInformation'}
                 />
               )}
               <TabbedFormTab
                 tabPath="childInformation"
                 definition={ChildTabDefinition as FormDefinition}
+                initialValues={contactForm.childInformation}
                 display={subroute === 'childInformation'}
               />
-              <IssueCategorizationTab display={subroute === 'categories'} />
+              <IssueCategorizationTab display={subroute === 'categories'} initialValue={contactForm.categories} />
               <TabbedFormTab
                 tabPath="caseInformation"
                 definition={CaseTabDefinition as FormDefinition}
+                initialValues={contactForm.caseInformation}
                 display={subroute === 'caseInformation'}
               />
             </div>

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -7,7 +7,7 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { namespace, contactFormsBase, routingBase, RootState } from '../../states';
 import { updateCallType, updateForm } from '../../states/contacts/actions';
-import { searchResultToContactForm, deTransformValue } from '../../services/ContactService';
+import { searchResultToContactForm } from '../../services/ContactService';
 import { changeRoute } from '../../states/routing/actions';
 import type { TaskEntry } from '../../states/contacts/reducer';
 import type { TabbedFormSubroutes } from '../../states/routing/types';

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -42,7 +42,7 @@ const nestName = (information: { firstName: string; lastName: string }) => {
   return { ...rest, name: { firstName, lastName } };
 };
 
-export const unNestInforationObject = (
+const unNestInforationObject = (
   def: FormDefinition,
   obj: InformationObject,
 ): TaskEntry['childInformation'] | TaskEntry['callerInformation'] =>
@@ -91,7 +91,7 @@ const transformValues = (def: FormDefinition) => (
   values: TaskEntry['callerInformation'] | TaskEntry['caseInformation'] | TaskEntry['childInformation'],
 ) => def.reduce((acc, e) => ({ ...acc, [e.name]: transformValue(e)(values[e.name]) }), {});
 
-export const deTransformValue = (e: FormItemDefinition) => (value: string | boolean | null) => {
+const deTransformValue = (e: FormItemDefinition) => (value: string | boolean | null) => {
   // de-transform mixed checkbox null DB value to be "mixed"
   if (e.type === 'mixed-checkbox' && value === null) return 'mixed';
 

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -42,7 +42,7 @@ const nestName = (information: { firstName: string; lastName: string }) => {
   return { ...rest, name: { firstName, lastName } };
 };
 
-const unNestInforationObject = (
+const unNestInformationObject = (
   def: FormDefinition,
   obj: InformationObject,
 ): TaskEntry['childInformation'] | TaskEntry['callerInformation'] =>
@@ -99,7 +99,7 @@ const deTransformValue = (e: FormItemDefinition) => (value: string | boolean | n
 };
 
 export const searchResultToContactForm = (def: FormDefinition, obj: InformationObject) => {
-  const information = unNestInforationObject(def, obj);
+  const information = unNestInformationObject(def, obj);
 
   const deTransformed = def.reduce((acc, e) => ({ ...acc, [e.name]: deTransformValue(e)(information[e.name]) }), {});
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-438

This PR fixes the 2nd bug described in https://github.com/tech-matters/flex-plugins/pull/280#issuecomment-750327284, where dependent select & 3-way were being incorrectly initialized with redux/searchResult/transfer data.
This has been fixed by including 1 extra parameter to the `form generator` function (1st commit), which is an `initialValues` object (may be null).
If the provided `initialValues` does not contains a key for certain input, it will default to the "empty state" value associated to the input type.
Second and third commits only makes use of this new approach in tabbed forms.

TODO:
- strictness types for the `form generator` function.