### PR TITLE
Add Insights Support for Zambia

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -77,13 +77,10 @@ test('saveInsightsData for data callType', async () => {
       content: 'content',
       conversation_attribute_1: 'Unspecified/Other - Missing children;Bullying;Addictive behaviours and substance use',
       conversation_attribute_2: 'Child calling about self',
-      conversation_attribute_3: 'Boy',
-      conversation_attribute_4: '13-15',
       communication_channel: 'Call',
     },
     customers: {
       name: 'John Doe',
-      gender: 'Boy',
     },
   };
 
@@ -128,13 +125,10 @@ test('Handles contactless tasks', async () => {
     conversations: {
       conversation_attribute_1: 'Unspecified/Other - Violence',
       conversation_attribute_2: 'Child calling about self',
-      conversation_attribute_3: 'Unknown',
-      conversation_attribute_4: '3',
       communication_channel: 'SMS',
       date: getDateTime({ date, time }),
     },
     customers: {
-      gender: 'Unknown',
     },
   };
 

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -222,6 +222,155 @@ test('processHelplineConfig for three-way checkboxes', async () => {
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 });
 
+test('processHelplineConfig for case data', () => {
+  const helplineConfig = {
+    contactForm: {},
+    caseForm: {
+      topLevel: [
+        {
+          name: 'id',
+          insights: ['conversations', 'case'],
+        },
+      ],
+      perpetrator: [
+        {
+          name: 'relationshipToChild',
+          insights: ['customers', 'organization'],
+        },
+        {
+          name: 'gender',
+          insights: ['conversations', 'followed_by'],
+        },
+        {
+          name: 'age',
+          insights: ['conversations', 'preceded_by'],
+        },
+      ],
+      /*
+       * incident: [
+       *   {
+       *     name: 'durationOfIncident',
+       *     insights: ['conversations', 'in_business_hours'],
+       *   },
+       *   {
+       *     name: 'location',
+       *     insights: ['customers', 'market_segment'],
+       *   },
+       * ],
+       */
+      referral: [
+        {
+          name: 'referredTo',
+          insights: ['customers', 'manager'],
+        },
+      ],
+    },
+  };
+
+  const contactForm = {};
+
+  const caseForm = {
+    id: 102,
+    status: 'open',
+    helpline: '',
+    twilioWorkerId: 'worker',
+    info: {
+      summary: 'case summary',
+      notes: ['my note'],
+      perpetrators: [
+        {
+          perpetrator: {
+            name: {
+              firstName: 'first',
+              lastName: 'last',
+            },
+            relationshipToChild: 'Grandparent',
+            gender: 'Boy',
+            age: '>25',
+            language: 'Bemba',
+            nationality: 'Zambian',
+            ethnicity: 'Bembese',
+            location: {
+              streetAddress: '',
+              city: '',
+              stateOrCounty: '',
+              postalCode: '',
+              phone1: '',
+              phone2: '',
+            },
+          },
+          createdAt: '',
+          twilioWorkerId: '',
+        },
+      ],
+      households: [
+        {
+          household: {
+            name: {
+              firstName: 'first',
+              lastName: 'last',
+            },
+            relationshipToChild: 'Mother',
+            gender: 'Girl',
+            age: '>25',
+            language: 'Bemba',
+            nationality: 'Zambian',
+            ethnicity: 'Bembese',
+            location: {
+              streetAddress: '',
+              city: '',
+              stateOrCounty: '',
+              postalCode: '',
+              phone1: '',
+              phone2: '',
+            },
+          },
+          createdAt: '',
+          twilioWorkerId: '',
+        },
+      ],
+      referrals: [
+        {
+          date: new Date(),
+          referredTo: 'Referral Agency 1',
+          comments: 'A referral',
+        },
+        {
+          date: new Date(),
+          referredTo: 'Referral Agency 2',
+          comments: 'Another referral',
+        },
+      ],
+      incidents: [
+        {
+          durationOfIncident: '2',
+          location: 'At home',
+        },
+      ],
+      followUpDate: '2021-01-30',
+    },
+    createdAt: '',
+    updatdAt: '',
+    connectedContacts: [],
+  };
+
+  const expected = {
+    conversations: {
+      case: '102',
+      followed_by: 'Boy',
+      preceded_by: '>25',
+      // in_business_hours: '2',
+    },
+    customers: {
+      organization: 'Grandparent',
+      // market_segment: 'At home',
+      manager: 'Referral Agency 1',
+    },
+  };
+
+  expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
+});
+
 test('zambiaUpdates handles custom entries', () => {
   const contactForm = {
     callType: 'Child calling about self',

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { processHelplineConfig, saveInsightsData } from '../../services/InsightsService';
+import { processHelplineConfig, saveInsightsData, zambiaUpdates } from '../../services/InsightsService';
 import { getDateTime } from '../../utils/helpers';
 
 test('saveInsightsData for non-data callType', async () => {
@@ -16,11 +16,11 @@ test('saveInsightsData for non-data callType', async () => {
     setAttributes: jest.fn(),
   };
 
-  const task = {
+  const contactForm = {
     callType: 'Abusive',
   };
 
-  await saveInsightsData(twilioTask, task);
+  await saveInsightsData(twilioTask, contactForm);
 
   const expectedNewAttributes = {
     taskSid: 'task-sid',
@@ -53,7 +53,7 @@ test('saveInsightsData for data callType', async () => {
     setAttributes: jest.fn(),
   };
 
-  const task = {
+  const contactForm = {
     callType: 'Child calling about self',
 
     childInformation: {
@@ -68,7 +68,7 @@ test('saveInsightsData for data callType', async () => {
     ],
   };
 
-  await saveInsightsData(twilioTask, task);
+  await saveInsightsData(twilioTask, contactForm);
 
   const expectedNewAttributes = {
     taskSid: 'task-sid',
@@ -211,7 +211,6 @@ test('processHelplineConfig for three-way checkboxes', async () => {
     },
   };
 
-  // Double-check that this is what's desired!!!!!
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 
   contactForm.childInformation.hivPositive = true;
@@ -222,3 +221,19 @@ test('processHelplineConfig for three-way checkboxes', async () => {
   expected.customers.category = 0;
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 });
+
+test('zambiaUpdates handles custom entries', () => {
+  const contactForm = {
+    callType: 'Child calling about self',
+
+    childInformation: {
+      province: 'Eastern',
+      district: 'Sinda',
+    },
+    caseInformation: {},
+    categories: [],
+  };
+
+  const returnedAttributes = zambiaUpdates({}, contactForm, {});
+  expect(returnedAttributes.customers.area).toEqual('Eastern;Sinda');
+})

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -261,7 +261,7 @@ test('processHelplineConfig for case data', () => {
       referral: [
         {
           name: 'referredTo',
-          insights: ['customers', 'manager'],
+          insights: ['customers', 'customer_manager'],
         },
       ],
     },
@@ -364,7 +364,7 @@ test('processHelplineConfig for case data', () => {
     customers: {
       organization: 'Grandparent',
       // market_segment: 'At home',
-      manager: 'Referral Agency 1',
+      customer_manager: 'Referral Agency 1',
     },
   };
 

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -187,3 +187,45 @@ test('processHelplineConfig works for basic cases', async () => {
 
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 });
+
+test('processHelplineConfig for three-way checkboxes', async () => {
+  const helplineConfig = {
+    contactForm: {
+      childInformation: [
+        {
+          name: 'hivPositive',
+          insights: ['customers', 'category'],
+          type: 'mixed-checkbox',
+        },
+      ],
+    },
+  };
+
+  const contactForm = {
+    callType: 'Child calling about self',
+
+    childInformation: {
+      hivPositive: 'mixed',
+    },
+  };
+
+  const caseForm = {};
+
+  const expected = {
+    conversations: {},
+    customers: {
+      category: null,
+    },
+  };
+
+  // Double-check that this is what's desired!!!!!
+  expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
+
+  contactForm.childInformation.hivPositive = 'true';
+  expected.customers.category = '1';
+  expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
+
+  contactForm.childInformation.hivPositive = 'false';
+  expected.customers.category = '0';
+  expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
+});

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -226,6 +226,7 @@ test('zambiaUpdates handles custom entries', () => {
   const contactForm = {
     callType: 'Child calling about self',
 
+    callerInformation: {},
     childInformation: {
       province: 'Eastern',
       district: 'Sinda',
@@ -236,4 +237,4 @@ test('zambiaUpdates handles custom entries', () => {
 
   const returnedAttributes = zambiaUpdates({}, contactForm, {});
   expect(returnedAttributes.customers.area).toEqual('Eastern;Sinda');
-})
+});

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { saveInsightsData } from '../../services/InsightsService';
+import { processHelplineConfig, saveInsightsData } from '../../services/InsightsService';
 import { getDateTime } from '../../utils/helpers';
 
 test('saveInsightsData for non-data callType', async () => {
@@ -139,4 +139,53 @@ test('Handles contactless tasks', async () => {
   };
 
   expect(twilioTask.setAttributes).toHaveBeenCalledWith(expectedNewAttributes);
+});
+
+test('processHelplineConfig works for basic cases', async() => {
+  const helplineConfig = {
+    contactForm: {
+      childInformation: [
+        {
+          name: 'village',
+          insights: [ 'customers', 'city' ],
+        },
+        {
+          name: 'language',
+          insights: [ 'conversations', 'language' ] 
+        }
+      ]
+    }
+  };
+
+  const contactForm = {
+    callType: 'Child calling about self',
+
+    childInformation: {
+      village: 'Somewhere',
+      language: 'Martian',
+      age: '13-15',
+      gender: 'Boy',
+    },
+    caseInformation: {},
+    categories: [
+      'categories.Missing children.Unspecified/Other',
+      'categories.Violence.Bullying',
+      'categories.Mental Health.Addictive behaviours and substance use',
+    ],
+  };
+
+  const caseForm = {
+
+  };
+
+  const expected = {
+    conversations: {
+      language: 'Martian',
+    },
+    customers: {
+      city: 'Somewhere',
+    },
+  };
+
+  expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 });

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -249,7 +249,7 @@ test('processHelplineConfig for case data', () => {
       /*
        * incident: [
        *   {
-       *     name: 'durationOfIncident',
+       *     name: 'duration',
        *     insights: ['conversations', 'in_business_hours'],
        *   },
        *   {
@@ -343,7 +343,7 @@ test('processHelplineConfig for case data', () => {
       ],
       incidents: [
         {
-          durationOfIncident: '2',
+          duration: '2',
           location: 'At home',
         },
       ],

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -128,8 +128,7 @@ test('Handles contactless tasks', async () => {
       communication_channel: 'SMS',
       date: getDateTime({ date, time }),
     },
-    customers: {
-    },
+    customers: {},
   };
 
   expect(twilioTask.setAttributes).toHaveBeenCalledWith(expectedNewAttributes);

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -141,20 +141,20 @@ test('Handles contactless tasks', async () => {
   expect(twilioTask.setAttributes).toHaveBeenCalledWith(expectedNewAttributes);
 });
 
-test('processHelplineConfig works for basic cases', async() => {
+test('processHelplineConfig works for basic cases', async () => {
   const helplineConfig = {
     contactForm: {
       childInformation: [
         {
           name: 'village',
-          insights: [ 'customers', 'city' ],
+          insights: ['customers', 'city'],
         },
         {
           name: 'language',
-          insights: [ 'conversations', 'language' ] 
-        }
-      ]
-    }
+          insights: ['conversations', 'language'],
+        },
+      ],
+    },
   };
 
   const contactForm = {
@@ -174,9 +174,7 @@ test('processHelplineConfig works for basic cases', async() => {
     ],
   };
 
-  const caseForm = {
-
-  };
+  const caseForm = {};
 
   const expected = {
     conversations: {

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -131,7 +131,7 @@ test('Handles contactless tasks', async () => {
       conversation_attribute_3: 'Unknown',
       conversation_attribute_4: '3',
       communication_channel: 'SMS',
-      date: getDateTime({ date, time }).toString(),
+      date: getDateTime({ date, time }),
     },
     customers: {
       gender: 'Unknown',
@@ -221,11 +221,11 @@ test('processHelplineConfig for three-way checkboxes', async () => {
   // Double-check that this is what's desired!!!!!
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 
-  contactForm.childInformation.hivPositive = 'true';
-  expected.customers.category = '1';
+  contactForm.childInformation.hivPositive = true;
+  expected.customers.category = 1;
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 
-  contactForm.childInformation.hivPositive = 'false';
-  expected.customers.category = '0';
+  contactForm.childInformation.hivPositive = false;
+  expected.customers.category = 0;
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 });

--- a/plugin-hrm-form/src/formDefinitions/tabbedForms/CaseInformationTab.json
+++ b/plugin-hrm-form/src/formDefinitions/tabbedForms/CaseInformationTab.json
@@ -52,21 +52,21 @@
   {
     "name": "okForCaseWorkerToCall",
     "label": "Ok for case worker to call?",
-    "type": "checkbox"
+    "type": "mixed-checkbox"
   },
   {
     "name": "didYouDiscussRightsWithTheChild",
     "label": "Did you discuss rights with the child?",
-    "type": "checkbox"
+    "type": "mixed-checkbox"
   },
   {
     "name": "didTheChildFeelWeSolvedTheirProblem",
     "label": "Did the child feel we solved their problem?",
-    "type": "checkbox"
+    "type": "mixed-checkbox"
   },
   {
     "name": "wouldTheChildRecommendUsToAFriend",
     "label": "Would the child recommend us to a friend?",
-    "type": "checkbox"
+    "type": "mixed-checkbox"
   }
 ]

--- a/plugin-hrm-form/src/insightsConfig/types.ts
+++ b/plugin-hrm-form/src/insightsConfig/types.ts
@@ -1,0 +1,18 @@
+export enum InsightsObject {
+  Customers = 'customers',
+  Conversations = 'conversations',
+}
+export enum FieldType {
+  MixedCheckbox = 'mixed-checkbox',
+}
+export type InsightsFieldSpec = {
+  name: string;
+  insights: [InsightsObject, string];
+  type?: FieldType;
+};
+export type InsightsSubFormSpec = InsightsFieldSpec[];
+export type InsightsFormSpec = { [key: string]: InsightsSubFormSpec };
+export type InsightsConfigSpec = {
+  contactForm?: InsightsFormSpec;
+  caseForm?: InsightsFormSpec;
+};

--- a/plugin-hrm-form/src/insightsConfig/zambia.ts
+++ b/plugin-hrm-form/src/insightsConfig/zambia.ts
@@ -22,9 +22,10 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
         insights: [InsightsObject.Customers, 'city'],
       },
       /*
-       * province;district => customers.area is hard-coded
-       * Postal code TBD
-       * phone #1 TBD
+       * province;district => customers.area is hard-coded elsewhere
+       * Undecided per excel file:
+       *  Postal code
+       *  phone #1
        */
       {
         name: 'gender',
@@ -106,9 +107,10 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
         type: FieldType.MixedCheckbox,
       },
       /*
-       * How did you know about us => conversation attribute 5 ???
-       * Did we solve problem => convo.productive ???
-       * Would recommend => convo att 6 ???
+       * Undecided per excel file:
+       * How did you know about us => conversation attribute 5
+       * Did we solve problem => conversations.productive
+       * Would recommend => conversation attribute 6
        */
     ],
   },
@@ -148,7 +150,7 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
     referral: [
       {
         name: 'referredTo',
-        insights: [InsightsObject.Customers, 'manager'],
+        insights: [InsightsObject.Customers, 'customer_manager'],
       },
     ],
   },

--- a/plugin-hrm-form/src/insightsConfig/zambia.ts
+++ b/plugin-hrm-form/src/insightsConfig/zambia.ts
@@ -22,7 +22,7 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
         insights: [InsightsObject.Customers, 'city'],
       },
       /*
-       * province/district => customers.area is hard-coded
+       * province;district => customers.area is hard-coded
        * Postal code TBD
        * phone #1 TBD
        */
@@ -110,6 +110,46 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
        * Did we solve problem => convo.productive ???
        * Would recommend => convo att 6 ???
        */
+    ],
+  },
+  caseForm: {
+    topLevel: [
+      {
+        name: 'id',
+        insights: [InsightsObject.Conversations, 'case'],
+      },
+    ],
+    perpetrator: [
+      {
+        name: 'relationshipToChild',
+        insights: [InsightsObject.Customers, 'organization'],
+      },
+      {
+        name: 'gender',
+        insights: [InsightsObject.Conversations, 'followed_by'],
+      },
+      {
+        name: 'age',
+        insights: [InsightsObject.Conversations, 'preceded_by'],
+      },
+    ],
+    /*
+     * incident: [
+     *   {
+     *     name: 'durationOfIncident',
+     *     insights: [InsightsObject.Conversations, 'in_business_hours'],
+     *   },
+     *   {
+     *     name: 'location',
+     *     insights: [InsightsObject.Customers, 'market_segment'],
+     *   },
+     * ],
+     */
+    referral: [
+      {
+        name: 'referredTo',
+        insights: [InsightsObject.Customers, 'manager'],
+      },
     ],
   },
 };

--- a/plugin-hrm-form/src/insightsConfig/zambia.ts
+++ b/plugin-hrm-form/src/insightsConfig/zambia.ts
@@ -94,5 +94,22 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
         insights: [InsightsObject.Customers, 'region'],
       },
     ],
+    // Note: the Contact Summary tab is called caseInformation for legacy reasons
+    caseInformation: [
+      {
+        name: 'actionTaken',
+        insights: [InsightsObject.Conversations, 'initiative'],
+      },
+      {
+        name: 'repeatCaller',
+        insights: [InsightsObject.Conversations, 'conversation_attribute_7'],
+        type: FieldType.MixedCheckbox,
+      },
+      /*
+       * How did you know about us => conversation attribute 5 ???
+       * Did we solve problem => convo.productive ???
+       * Would recommend => convo att 6 ???
+       */
+    ],
   },
 };

--- a/plugin-hrm-form/src/insightsConfig/zambia.ts
+++ b/plugin-hrm-form/src/insightsConfig/zambia.ts
@@ -23,10 +23,11 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
       },
       /*
        * province;district => customers.area is hard-coded elsewhere
-       * Undecided per excel file:
-       *  Postal code
-       *  phone #1
        */
+      {
+        name: 'postalCode',
+        insights: [InsightsObject.Customers, 'zip'],
+      },
       {
         name: 'gender',
         insights: [InsightsObject.Customers, 'gender'],
@@ -98,20 +99,28 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
     // Note: the Contact Summary tab is called caseInformation for legacy reasons
     caseInformation: [
       {
-        name: 'actionTaken',
-        insights: [InsightsObject.Conversations, 'initiative'],
-      },
-      {
         name: 'repeatCaller',
         insights: [InsightsObject.Conversations, 'conversation_attribute_7'],
         type: FieldType.MixedCheckbox,
       },
-      /*
-       * Undecided per excel file:
-       * How did you know about us => conversation attribute 5
-       * Did we solve problem => conversations.productive
-       * Would recommend => conversation attribute 6
-       */
+      {
+        name: 'actionTaken',
+        insights: [InsightsObject.Conversations, 'initiative'],
+      },
+      {
+        name: 'howDidYouKnowAboutOurLine',
+        insights: [InsightsObject.Conversations, 'conversation_attribute_5'],
+      },
+      {
+        name: 'didTheChildFeelWeSolvedTheirProblem',
+        insights: [InsightsObject.Conversations, 'productive'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'wouldTheChildRecommendUsToAFriend',
+        insights: [InsightsObject.Conversations, 'conversation_attribute_6'],
+        type: FieldType.MixedCheckbox,
+      },
     ],
   },
   caseForm: {
@@ -138,7 +147,7 @@ export const zambiaInsightsConfig: InsightsConfigSpec = {
     /*
      * incident: [
      *   {
-     *     name: 'durationOfIncident',
+     *     name: 'duration',
      *     insights: [InsightsObject.Conversations, 'in_business_hours'],
      *   },
      *   {

--- a/plugin-hrm-form/src/insightsConfig/zambia.ts
+++ b/plugin-hrm-form/src/insightsConfig/zambia.ts
@@ -1,0 +1,98 @@
+import { FieldType, InsightsConfigSpec, InsightsObject } from './types';
+
+export const zambiaInsightsConfig: InsightsConfigSpec = {
+  contactForm: {
+    callerInformation: [
+      {
+        name: 'relationshipToChild',
+        insights: [InsightsObject.Conversations, 'initiated_by'],
+      },
+      {
+        name: 'gender',
+        insights: [InsightsObject.Conversations, 'conversation_attribute_4'],
+      },
+      {
+        name: 'age',
+        insights: [InsightsObject.Conversations, 'conversation_attribute_3'],
+      },
+    ],
+    childInformation: [
+      {
+        name: 'village',
+        insights: [InsightsObject.Customers, 'city'],
+      },
+      /*
+       * province/district => customers.area is hard-coded
+       * Postal code TBD
+       * phone #1 TBD
+       */
+      {
+        name: 'gender',
+        insights: [InsightsObject.Customers, 'gender'],
+      },
+      {
+        name: 'age',
+        insights: [InsightsObject.Customers, 'year_of_birth'],
+      },
+      {
+        name: 'language',
+        insights: [InsightsObject.Conversations, 'language'],
+      },
+      {
+        name: 'ethnicity',
+        insights: [InsightsObject.Customers, 'customer_attribute_2'],
+      },
+      {
+        name: 'gradeLevel',
+        insights: [InsightsObject.Customers, 'acquisition_date'],
+      },
+      {
+        name: 'livingSituation',
+        insights: [InsightsObject.Customers, 'customer_attribute_1'],
+      },
+      {
+        name: 'hivPositive',
+        insights: [InsightsObject.Customers, 'category'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'inConflictWithTheLaw',
+        insights: [InsightsObject.Conversations, 'conversation_measure_1'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'livingInConflictZone',
+        insights: [InsightsObject.Conversations, 'conversation_measure_2'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'livingInPoverty',
+        insights: [InsightsObject.Conversations, 'conversation_measure_3'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'memberOfAnEthnic',
+        insights: [InsightsObject.Conversations, 'conversation_measure_4'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'childOnTheMove',
+        insights: [InsightsObject.Customers, 'email'],
+      },
+      {
+        name: 'childWithDisability',
+        insights: [InsightsObject.Customers, 'customer_attribute_3'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'LGBTQI+',
+        insights: [InsightsObject.Conversations, 'conversation_measure_5'],
+        type: FieldType.MixedCheckbox,
+      },
+      {
+        name: 'region',
+        insights: [InsightsObject.Customers, 'region'],
+      },
+    ],
+  },
+};

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -57,29 +57,24 @@ const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, cas
     ? mapChannelForInsights(contactForm.contactlessTask.channel)
     : mapChannelForInsights(taskAttributes.channelType);
 
+  // First add the data we add whether or not there's contact form data
+  const coreAttributes: InsightsAttributes = {
+    conversations: {
+      conversation_attribute_2: callType.toString(),
+      communication_channel,
+    },
+  };
+
   if (!hasCustomerData) {
+    return coreAttributes;
+  } else {
     return {
       conversations: {
-        conversation_attribute_2: callType.toString(),
-        communication_channel,
+        ...coreAttributes.conversations,
+        conversation_attribute_1: getSubcategories(contactForm).toString(),
       },
     };
   }
-
-  const { childInformation } = contactForm;
-
-  return {
-    conversations: {
-      conversation_attribute_1: getSubcategories(contactForm).toString(),
-      conversation_attribute_2: callType.toString(),
-      conversation_attribute_3: childInformation.gender.toString(),
-      conversation_attribute_4: childInformation.age.toString(),
-      communication_channel,
-    },
-    customers: {
-      gender: childInformation.gender.toString(),
-    },
-  };
 };
 
 const contactlessTaskUpdates = (

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -15,8 +15,8 @@ import { formatCategories } from '../utils/formatters';
 type TaskAttributes = any;
 
 type InsightsAttributes = {
-  conversations?: { [key: string]: string };
-  customers?: { [key: string]: string };
+  conversations?: { [key: string]: string | number};
+  customers?: { [key: string]: string | number};
 };
 
 /*
@@ -71,7 +71,7 @@ const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, cas
   return {
     conversations: {
       conversation_attribute_1: getSubcategories(contactForm).toString(),
-      conversation_attribute_2: callType,
+      conversation_attribute_2: callType.toString(),
       conversation_attribute_3: childInformation.gender.toString(),
       conversation_attribute_4: childInformation.age.toString(),
       communication_channel,
@@ -95,7 +95,7 @@ const contactlessTaskUpdates = (
 
   return {
     conversations: {
-      date: dateTime.toString(),
+      date: dateTime,
     },
   };
 };
@@ -191,7 +191,8 @@ const zambiaInsightsConfig: InsightsConfigSpec = {
       },
       {
         name: 'LGBTQI+',
-        insights: [InsightsObject.Customers, 'conversation_measure_5'],
+        insights: [InsightsObject.Conversations, 'conversation_measure_5'],
+        type: FieldType.MixedCheckbox,
       },
       {
         name: 'region',
@@ -201,11 +202,11 @@ const zambiaInsightsConfig: InsightsConfigSpec = {
   },
 };
 
-const convertMixedCheckbox = (v: string): string => {
-  if (v === 'true') {
-    return '1';
-  } else if (v === 'false') {
-    return '0';
+const convertMixedCheckbox = (v: string | boolean): number => {
+  if (v === true) {
+    return 1;
+  } else if (v === false) {
+    return 0;
   } else if (v === 'mixed') {
     return null;
   }
@@ -234,12 +235,14 @@ export const processHelplineConfig = (
       insightsAtts[insightsObject][insightsField] = value;
     });
   });
+  // console.warn(`processconfig results:`);
+  // console.warn(insightsAtts);
   return insightsAtts;
 };
 
 const zambiaUpdates = (attributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
   const { callType } = contactForm;
-  if (!isNonDataCallType(callType)) return {};
+  if (isNonDataCallType(callType)) return {};
 
   return processHelplineConfig(contactForm, caseForm, zambiaInsightsConfig);
 };

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -19,6 +19,7 @@ type InsightsAttributes = {
   customers?: { [key: string]: string | number };
 };
 
+const delimiter = ';'
 /*
  * Converts an array of categories with a fully-specified path (as stored in Redux)
  * into an object where the top-level categories are the keys and the values
@@ -46,7 +47,7 @@ const getSubcategories = (contactForm: TaskEntry): string => {
   const { categories } = contactForm;
 
   const categoryMap = makeCategoryMap(categories);
-  return formatCategories(categoryMap).join(';');
+  return formatCategories(categoryMap).join(delimiter);
 };
 
 const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
@@ -121,7 +122,7 @@ const zambiaInsightsConfig: InsightsConfigSpec = {
         insights: [InsightsObject.Customers, 'city'],
       },
       /*
-       * province/municipality/district TBD
+       * province/municipality/district handled in function
        * Postal code TBD
        * phone #1 TBD
        */
@@ -236,11 +237,18 @@ export const processHelplineConfig = (
   return insightsAtts;
 };
 
-const zambiaUpdates = (attributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
+// Visible for testing
+export const zambiaUpdates = (attributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
   const { callType } = contactForm;
   if (isNonDataCallType(callType)) return {};
 
-  return processHelplineConfig(contactForm, caseForm, zambiaInsightsConfig);
+  const attsToReturn: InsightsAttributes = processHelplineConfig(contactForm, caseForm, zambiaInsightsConfig);
+
+  // Custom additions
+  // Add province and district into area
+  attsToReturn[InsightsObject.Customers]['area'] = [ contactForm.childInformation.province, contactForm.childInformation.district ].join(delimiter);
+
+  return attsToReturn;
 };
 
 const mergeAttributes = (previousAttributes: TaskAttributes, newAttributes: InsightsAttributes): TaskAttributes => {

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -15,8 +15,8 @@ import { formatCategories } from '../utils/formatters';
 type TaskAttributes = any;
 
 type InsightsAttributes = {
-  conversations?: { [key: string]: string | number};
-  customers?: { [key: string]: string | number};
+  conversations?: { [key: string]: string | number };
+  customers?: { [key: string]: string | number };
 };
 
 /*
@@ -67,14 +67,13 @@ const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, cas
 
   if (!hasCustomerData) {
     return coreAttributes;
-  } else {
-    return {
-      conversations: {
-        ...coreAttributes.conversations,
-        conversation_attribute_1: getSubcategories(contactForm).toString(),
-      },
-    };
   }
+  return {
+    conversations: {
+      ...coreAttributes.conversations,
+      conversation_attribute_1: getSubcategories(contactForm).toString(),
+    },
+  };
 };
 
 const contactlessTaskUpdates = (
@@ -230,8 +229,10 @@ export const processHelplineConfig = (
       insightsAtts[insightsObject][insightsField] = value;
     });
   });
-  // console.warn(`processconfig results:`);
-  // console.warn(insightsAtts);
+  /*
+   * console.warn(`processconfig results:`);
+   * console.warn(insightsAtts);
+   */
   return insightsAtts;
 };
 

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -49,21 +49,7 @@ const getSubcategories = (contactForm: TaskEntry): string => {
   return formatCategories(categoryMap).join(';');
 };
 
-const buildCustomersObject = (taskAttributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
-  const { callType } = contactForm;
-  const hasCustomerData = !isNonDataCallType(callType);
-
-  if (!hasCustomerData) return {};
-
-  const { childInformation } = contactForm;
-  return {
-    customers: {
-      gender: childInformation.gender.toString(),
-    },
-  };
-};
-
-const buildConversationsObject = (taskAttributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
+const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
   const { callType } = contactForm;
   const hasCustomerData = !isNonDataCallType(callType);
 
@@ -90,10 +76,13 @@ const buildConversationsObject = (taskAttributes: TaskAttributes, contactForm: T
       conversation_attribute_4: childInformation.age.toString(),
       communication_channel,
     },
+    customers: {
+      gender: childInformation.gender.toString(),
+    }
   };
 };
 
-const contactlessAttributes = (attributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
+const contactlessTaskUpdates = (attributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
   if (!attributes.isContactlessTask) {
     return {};
   }
@@ -133,9 +122,8 @@ const mergeAttributes = (previousAttributes: TaskAttributes, newAttributes: Insi
 export async function saveInsightsData(twilioTask: ITask, contactForm: TaskEntry, caseForm: Case) {
   const previousAttributes: TaskAttributes = twilioTask.attributes;
   const insightsUpdates: InsightsAttributes[] = [];
-  insightsUpdates.push(buildConversationsObject(twilioTask.attributes, contactForm, caseForm));
-  insightsUpdates.push(buildCustomersObject(twilioTask.attributes, contactForm, caseForm));
-  insightsUpdates.push(contactlessAttributes(twilioTask.attributes, contactForm, caseForm));
+  insightsUpdates.push(baseUpdates(twilioTask.attributes, contactForm, caseForm));
+  insightsUpdates.push(contactlessTaskUpdates(twilioTask.attributes, contactForm, caseForm));
   const finalAttributes: TaskAttributes = insightsUpdates.reduce(
     (acc, curr) => mergeAttributes(acc, curr),
     previousAttributes,

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -187,37 +187,26 @@ export const processHelplineConfig = (
     conversations: {},
   };
 
-  const contactFormSpec: InsightsFormSpec = configSpec.contactForm;
-  if (contactFormSpec) {
-    // make this more DRY
-    Object.keys(contactFormSpec).forEach(subform => {
-      const fields: InsightsFieldSpec[] = contactFormSpec[subform];
+  const formsToProcess: [InsightsFormSpec, TaskEntry | InsightsCaseForm][] = [];
+  if (configSpec.contactForm) {
+    formsToProcess.push([configSpec.contactForm, contactForm]);
+  }
+  if (configSpec.caseForm) {
+    formsToProcess.push([configSpec.caseForm, convertCaseFormForInsights(caseForm)]);
+  }
+  formsToProcess.forEach(([spec, form]) => {
+    Object.keys(spec).forEach(subform => {
+      const fields: InsightsFieldSpec[] = spec[subform];
       fields.forEach(field => {
         const [insightsObject, insightsField] = field.insights;
-        let value = contactForm[subform][field.name];
+        let value = form[subform][field.name];
         if (field.type === FieldType.MixedCheckbox) {
           value = convertMixedCheckbox(value);
         }
         insightsAtts[insightsObject][insightsField] = value;
       });
     });
-  }
-
-  const caseFormSpec: InsightsFormSpec = configSpec.caseForm;
-  if (caseFormSpec) {
-    const convertedCaseForm: InsightsCaseForm = convertCaseFormForInsights(caseForm);
-    Object.keys(caseFormSpec).forEach(subform => {
-      const fields: InsightsFieldSpec[] = caseFormSpec[subform];
-      fields.forEach(field => {
-        const [insightsObject, insightsField] = field.insights;
-        let value = convertedCaseForm[subform][field.name];
-        if (field.type === FieldType.MixedCheckbox) {
-          value = convertMixedCheckbox(value);
-        }
-        insightsAtts[insightsObject][insightsField] = value;
-      });
-    });
-  }
+  });
 
   /*
    * console.warn(`processconfig results:`);

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -116,6 +116,20 @@ type InsightsConfigSpec = {
 
 const zambiaInsightsConfig: InsightsConfigSpec = {
   contactForm: {
+    callerInformation: [
+      {
+        name: 'relationshipToChild',
+        insights: [InsightsObject.Conversations, 'initiated_by'],
+      },
+      {
+        name: 'gender',
+        insights: [InsightsObject.Conversations, 'conversation_attribute_4'],
+      },
+      {
+        name: 'age',
+        insights: [InsightsObject.Conversations, 'conversation_attribute_3'],
+      },
+    ],
     childInformation: [
       {
         name: 'village',

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -28,6 +28,7 @@ type InsightsAttributes = {
 };
 
 const delimiter = ';';
+
 /*
  * Converts an array of categories with a fully-specified path (as stored in Redux)
  * into an object where the top-level categories are the keys and the values
@@ -127,8 +128,6 @@ type InsightsCaseForm = {
  * for a TaskEntry (contact form) so it can be consumed in the same manner.
  * As of January 2, 2021, Case has not been moved over to use the
  * customization framework.  When it is, we will need to change this function.
- *
- * TODO: make more generalized.  It makes a lot of assumptions right now.
  */
 const convertCaseFormForInsights = (caseForm: Case): InsightsCaseForm => {
   if (!caseForm || Object.keys(caseForm).length === 0) return {};
@@ -140,6 +139,8 @@ const convertCaseFormForInsights = (caseForm: Case): InsightsCaseForm => {
     id: caseForm.id.toString(),
   };
   if (caseForm.info && caseForm.info.perpetrators && caseForm.info.perpetrators.length > 0) {
+    // Flatten out the Perpetrator object. This can be changed after this is using the 
+    // customization framework.
     const thePerp = caseForm.info.perpetrators[0];
     const untypedPerp: any = {
       ...thePerp,
@@ -208,10 +209,6 @@ export const processHelplineConfig = (
     });
   });
 
-  /*
-   * console.warn(`processconfig results:`);
-   * console.warn(insightsAtts);
-   */
   return insightsAtts;
 };
 
@@ -227,8 +224,8 @@ export const zambiaUpdates = (
   const attsToReturn: InsightsAttributes = processHelplineConfig(contactForm, caseForm, zambiaInsightsConfig);
 
   /*
-   * Custom additions
-   * Add province and district into area
+   * Custom additions:
+   *  Add province and district into area
    */
   attsToReturn[InsightsObject.Customers].area = [
     contactForm.childInformation.province,
@@ -252,7 +249,7 @@ const mergeAttributes = (previousAttributes: TaskAttributes, newAttributes: Insi
   };
 };
 
-// how do we type function return values in typescript?
+// In TS, how do we say that we are returning a function?
 const getInsightsUpdateFunctionsForConfig = (config: any): any => {
   const functionArray = [baseUpdates, contactlessTaskUpdates];
   if (config.useZambiaInsights) {
@@ -265,10 +262,6 @@ const getInsightsUpdateFunctionsForConfig = (config: any): any => {
  * The idea here is to apply a cascading series of modifications to the attributes for Insights.
  * We may have a set of core values to add, plus conditional core values (such as if this is a
  * contactless task), and then may have helpline-specific updates based on configuration.
- * At present this is just a refactoring of the existing functionality, but next we will
- * add helpline-specific configuration.
- * We may add a configuration language similar to our customization JSON files
- * into the helpline-specific update functions to express them more clearly.
  *
  * Note: config parameter tells where to go to get helpline-specific tests.  It should
  * eventually match up with getConfig().  Also useful for testing.

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -78,11 +78,15 @@ const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, cas
     },
     customers: {
       gender: childInformation.gender.toString(),
-    }
+    },
   };
 };
 
-const contactlessTaskUpdates = (attributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
+const contactlessTaskUpdates = (
+  attributes: TaskAttributes,
+  contactForm: TaskEntry,
+  caseForm: Case,
+): InsightsAttributes => {
   if (!attributes.isContactlessTask) {
     return {};
   }
@@ -99,10 +103,10 @@ const contactlessTaskUpdates = (attributes: TaskAttributes, contactForm: TaskEnt
 enum InsightsObject {
   Customers = 'customers',
   Conversations = 'conversations',
-};
+}
 type InsightsFieldSpec = {
-  name: string,
-  insights: [ InsightsObject, string ],
+  name: string;
+  insights: [InsightsObject, string];
 };
 type InsightsSubFormSpec = InsightsFieldSpec[];
 type InsightsFormSpec = { [key: string]: InsightsSubFormSpec };
@@ -111,43 +115,47 @@ type InsightsConfigSpec = {
   caseForm?: InsightsFormSpec;
 };
 
-const zambiaInsightsConfig : InsightsConfigSpec = {
+const zambiaInsightsConfig: InsightsConfigSpec = {
   contactForm: {
     childInformation: [
       {
         name: 'village',
-        insights: [ InsightsObject.Customers, 'city' ],
+        insights: [InsightsObject.Customers, 'city'],
       },
       {
         name: 'language',
-        insights: [ InsightsObject.Conversations, 'language' ] 
-      }
-    ]
-  }
+        insights: [InsightsObject.Conversations, 'language'],
+      },
+    ],
+  },
 };
 
-export const processHelplineConfig = (contactForm: TaskEntry, caseForm: Case, configSpec: InsightsConfigSpec): InsightsAttributes => {
+export const processHelplineConfig = (
+  contactForm: TaskEntry,
+  caseForm: Case,
+  configSpec: InsightsConfigSpec,
+): InsightsAttributes => {
   const insightsAtts: InsightsAttributes = {
     customers: {},
     conversations: {},
   };
   const contactFormSpec: InsightsFormSpec = configSpec.contactForm;
-  Object.keys(contactFormSpec).forEach( subform => {
+  Object.keys(contactFormSpec).forEach(subform => {
     const fields: InsightsFieldSpec[] = contactFormSpec[subform];
     fields.forEach(field => {
-      const [ insightsObject, insightsField ] = field.insights;
+      const [insightsObject, insightsField] = field.insights;
       insightsAtts[insightsObject][insightsField] = contactForm[subform][field.name];
     });
   });
   return insightsAtts;
-}
+};
 
 const zambiaUpdates = (attributes: TaskAttributes, contactForm: TaskEntry, caseForm: Case): InsightsAttributes => {
   const { callType } = contactForm;
-  if(!isNonDataCallType(callType)) return {};
+  if (!isNonDataCallType(callType)) return {};
 
   return {};
-}
+};
 
 const mergeAttributes = (previousAttributes: TaskAttributes, newAttributes: InsightsAttributes): TaskAttributes => {
   return {

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -139,8 +139,10 @@ const convertCaseFormForInsights = (caseForm: Case): InsightsCaseForm => {
     id: caseForm.id.toString(),
   };
   if (caseForm.info && caseForm.info.perpetrators && caseForm.info.perpetrators.length > 0) {
-    // Flatten out the Perpetrator object. This can be changed after this is using the 
-    // customization framework.
+    /*
+     * Flatten out the Perpetrator object. This can be changed after this is using the
+     * customization framework.
+     */
     const thePerp = caseForm.info.perpetrators[0];
     const untypedPerp: any = {
       ...thePerp,

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -275,13 +275,9 @@ const getInsightsUpdateFunctionsForConfig = (config: any): any => {
  */
 export async function saveInsightsData(twilioTask: ITask, contactForm: TaskEntry, caseForm: Case, config = {}) {
   const previousAttributes: TaskAttributes = twilioTask.attributes;
-  const insightsUpdates: InsightsAttributes[] = getInsightsUpdateFunctionsForConfig(config).map((f: any) =>
-    f(twilioTask.attributes, contactForm, caseForm),
-  );
-  const finalAttributes: TaskAttributes = insightsUpdates.reduce(
-    (acc, curr) => mergeAttributes(acc, curr),
-    previousAttributes,
-  );
+  const finalAttributes: TaskAttributes = getInsightsUpdateFunctionsForConfig(config)
+    .map((f: any) => f(twilioTask.attributes, contactForm, caseForm))
+    .reduce((acc: TaskAttributes, curr: InsightsAttributes) => mergeAttributes(acc, curr), previousAttributes);
 
   await twilioTask.setAttributes(finalAttributes);
 }

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -199,7 +199,7 @@ export const processHelplineConfig = (
       const fields: InsightsFieldSpec[] = spec[subform];
       fields.forEach(field => {
         const [insightsObject, insightsField] = field.insights;
-        let value = form[subform][field.name];
+        let value = form[subform] && form[subform][field.name];
         if (field.type === FieldType.MixedCheckbox) {
           value = convertMixedCheckbox(value);
         }

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -241,7 +241,7 @@ const saveInsights = async payload => {
   const contactForm = getStateContactForms(taskSid);
   const caseForm = getStateCaseForms(taskSid);
 
-  await saveInsightsData(payload.task, contactForm, caseForm);
+  await saveInsightsData(payload.task, contactForm, caseForm, { useZambiaInsights: true });
 };
 
 /**

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -5,7 +5,7 @@ import { Manager, TaskHelper, Actions as FlexActions, StateHelper } from '@twili
 import { DEFAULT_TRANSFER_MODE, getConfig } from '../HrmFormPlugin';
 import { saveInsightsData } from '../services/InsightsService';
 import { transferChatStart, adjustChatCapacity } from '../services/ServerlessService';
-import { namespace, contactFormsBase } from '../states';
+import { namespace, contactFormsBase, connectedCaseBase } from '../states';
 import * as Actions from '../states/contacts/actions';
 import * as GeneralActions from '../states/actions';
 import { channelTypes, transferModes } from '../states/DomainConstants';
@@ -23,6 +23,20 @@ import categoriesFormDefinition from '../formDefinitions/tabbedForms/IssueCatego
  */
 const getStateContactForms = taskSid => {
   return Manager.getInstance().store.getState()[namespace][contactFormsBase].tasks[taskSid];
+};
+
+/**
+ * Given a taskSid, retrieves the state of the connected case (stored in redux) for that task
+ * This does not include temporaryCaseInfo
+ * @param {string} taskSid
+ */
+const getStateCaseForms = taskSid => {
+  return (
+    (Manager.getInstance().store.getState()[namespace][connectedCaseBase] &&
+      Manager.getInstance().store.getState()[namespace][connectedCaseBase].tasks[taskSid] &&
+      Manager.getInstance().store.getState()[namespace][connectedCaseBase].tasks[taskSid].connectedCase) ||
+    {}
+  );
 };
 
 /**
@@ -224,9 +238,10 @@ export const wrapupTask = setupObject =>
  */
 const saveInsights = async payload => {
   const { taskSid } = payload.task;
-  const form = getStateContactForms(taskSid);
+  const contactForm = getStateContactForms(taskSid);
+  const caseForm = getStateCaseForms(taskSid);
 
-  await saveInsightsData(payload.task, form);
+  await saveInsightsData(payload.task, contactForm, caseForm);
 };
 
 /**


### PR DESCRIPTION
This adds a framework for handling insights support for helplines, and includes configuration for Zambia.

Primary reviewer: @GPaoloni 
Fulfills: [CHI-383](https://bugs.benetech.org/browse/CHI-383)

Here are the key overall design concepts:
- The `InsightsService` applies a series of cascading functions that create a final version of the insights attributes.  This allows for a base set of updates for all helplines (such as storing categories) as well as configurable updates per helpline.
- Updates for a helpline can be expressed by a configuration language very similar to the JSON for a `FormDefinition`.  This is available in `insightsConfig/zambia.ts`.  This is currently a JS object, but the idea is that it can be merged into the `FormDefinition` JSON as a future revision.
- The configuration language doesn't handle situations where two fields should be combined into one attribute, so there's a small amount of custom code written in `zambiaUpdates()` to apply those changes.

File-by-file, here are the major changes:
- `InsightsService.test.js`: Adds tests for supporting three-way checkboxes (converting to `int(1)`, `int(0)` and `null`; Adds tests for processing the configuration language; Adds test for custom Zambia additions.
- `insightsConfig/types.ts`: Adds types used in insights configuration.  Types at the bottom of the file are composed of types at the top.
- `insightsConfig/zambia.ts`: The configuration for Zambia.  Comments are added where there's a hard-coded conversion not captured here, or where there are outstanding questions about Zambia configuration (to be resolved in a future PR), or for incidents which is not yet running.  This configuration could be merged with existing `FormDefinition` files by adding the `insights` property to relevant fields.  The case definition strays from the definition of `Case` elsewhere so that it matches the pattern of the contact forms.  There is a transform function in `InsightsService.ts` for it.  
- `InsightsService.ts`: Changes the existing functions to only add base configuration, removing insights fields for gender and age that could be custom per helpline.  Adds `processHelplineConfig` and supporting functions for running through configuration like `zambia.ts`.  Adds a transform for `Case` to make the data structure better fit the model of the contact forms which have a form -> subForm pattern.
- `setupActions.js`: Adds access to the case form from Redux.  Sends the case form to `saveInsightsData()`.  Adds a config param that activates storing Zambia config in Insights: this is hard-coded for now but can made configurable using `getConfig()` or whichever method we use for specifying which `FormDefinition`s to use in different helplines.

Some notes:
- Support for incidents is written but commented out, since we don't have incidents working yet.
- I'm still a little concerned about using ints vs strings in some of the fields, and this will need to be tested.  I'm also concerned about nulls vs "".  We use "" or "Unknown" when certain values aren't filled in by the user.
- Are there any pass-by-reference dangers here?  Could we be modifying data that will be stored elsewhere, for example, saved to the HRM?
- This also fixes [CHI-450](https://bugs.benetech.org/browse/CHI-450), which I broke in #295 by making the `date` attribute a string.  It needs to be a number.
- This will only grab the first element of Perpetrators or Referrals for Insights.  Possibly in the future we may need to add one of these to Insights if and only if it was added on this contact.  This will matter when we have cases with multiple connected contacts.
