### PR TITLE
Bug fix: Only one category showing on Case View Header

### DIFF
--- a/plugin-hrm-form/src/utils/categories.ts
+++ b/plugin-hrm-form/src/utils/categories.ts
@@ -15,7 +15,9 @@ const getCategoryLabel = (category, subcategory) =>
   subcategory === 'Unspecified/Other' ? `${subcategory} - ${category}` : subcategory;
 
 export const getContactTags = (contactCategories: ContactCategories) =>
-  Object.entries(contactCategories).map(([category, [subcategory]]) => ({
-    label: getCategoryLabel(category, subcategory),
-    color: getCategoryColor(category),
-  }));
+  Object.entries(contactCategories).flatMap(([category, subcategories]) =>
+    subcategories.map(subcategory => ({
+      label: getCategoryLabel(category, subcategory),
+      color: getCategoryColor(category),
+    })),
+  );


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-443
Primary reviewer: @andvirga 

This PR fixes a bug in the Case Header: "Only one category showing on Case View Header". This happened when picking more than one subcategory from the same category.