### PR TITLE
CHI-455 - Other Case View Changes

### DIFF
--- a/plugin-hrm-form/src/___tests__/states/case/actions.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/actions.test.ts
@@ -14,15 +14,17 @@ describe('test action creators', () => {
       info: null,
       createdAt: '2020-07-31T20:39:37.408Z',
       updatedAt: '2020-07-31T20:39:37.408Z',
+      connectedContacts: null,
     };
 
     const expectedAction: types.CaseActionType = {
       type: types.SET_CONNECTED_CASE,
       connectedCase,
       taskId: task.taskSid,
+      caseHasBeenEdited: false,
     };
 
-    expect(actions.setConnectedCase(connectedCase, task.taskSid)).toStrictEqual(expectedAction);
+    expect(actions.setConnectedCase(connectedCase, task.taskSid, false)).toStrictEqual(expectedAction);
   });
 
   test('removeConnectedCase', async () => {

--- a/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
@@ -38,17 +38,19 @@ describe('test reducer', () => {
       info: null,
       createdAt: '2020-07-31T20:39:37.408Z',
       updatedAt: '2020-07-31T20:39:37.408Z',
+      connectedContacts: null,
     };
 
     const expectedAction: types.CaseActionType = {
       type: types.SET_CONNECTED_CASE,
       connectedCase,
       taskId: task.taskSid,
+      caseHasBeenEdited: false,
     };
 
-    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: null } } };
+    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: null, caseHasBeenEdited: false } } };
 
-    const result = reduce(state, actions.setConnectedCase(connectedCase, task.taskSid));
+    const result = reduce(state, actions.setConnectedCase(connectedCase, task.taskSid, false));
     expect(result).toStrictEqual(expected);
 
     state = result;
@@ -76,7 +78,9 @@ describe('test reducer', () => {
     const info = { summary: 'Some summary', notes: ['Some note'] };
 
     const { connectedCase, temporaryCaseInfo } = state.tasks.task1;
-    const expected = { tasks: { task1: { connectedCase: { ...connectedCase, info }, temporaryCaseInfo } } };
+    const expected = {
+      tasks: { task1: { connectedCase: { ...connectedCase, info }, temporaryCaseInfo, caseHasBeenEdited: true } },
+    };
 
     const result = reduce(state, actions.updateCaseInfo(info, task.taskSid));
     expect(result).toStrictEqual(expected);
@@ -85,12 +89,12 @@ describe('test reducer', () => {
   });
 
   test('should handle UPDATE_TEMP_INFO', async () => {
-    const string = 'Some random string here';
+    const randomTemp = { screen: 'add-note', info: '' };
 
     const { connectedCase } = state.tasks.task1;
-    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: string } } };
+    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: randomTemp, caseHasBeenEdited: true } } };
 
-    const result = reduce(state, actions.updateTempInfo(string, task.taskSid));
+    const result = reduce(state, actions.updateTempInfo({ screen: 'add-note', info: '' }, task.taskSid));
     expect(result).toStrictEqual(expected);
 
     state = result;

--- a/plugin-hrm-form/src/components/case/AddHousehold.tsx
+++ b/plugin-hrm-form/src/components/case/AddHousehold.tsx
@@ -60,7 +60,7 @@ const AddHousehold: React.FC<Props> = ({
     const households = info && info.households ? [...info.households, newHousehold] : [newHousehold];
     const newInfo = info ? { ...info, households } : { households };
     const updatedCase = await updateCase(id, { info: newInfo });
-    setConnectedCase(updatedCase, task.taskSid);
+    setConnectedCase(updatedCase, task.taskSid, true);
     if (shouldStayInForm) {
       updateTempInfo({ screen: 'add-household', info: newCallerFormInformation }, task.taskSid);
       changeRoute({ route, subroute: 'add-household' }, task.taskSid);

--- a/plugin-hrm-form/src/components/case/AddNote.tsx
+++ b/plugin-hrm-form/src/components/case/AddNote.tsx
@@ -43,7 +43,7 @@ const AddNote: React.FC<Props> = ({
     const notes = info && info.notes ? [...info.notes, newNote] : [newNote];
     const newInfo = info ? { ...info, notes } : { notes };
     const updatedCase = await updateCase(id, { info: newInfo });
-    setConnectedCase(updatedCase, task.taskSid);
+    setConnectedCase(updatedCase, task.taskSid, true);
     updateTempInfo({ screen: 'add-note', info: '' }, task.taskSid);
     onClickClose();
   };

--- a/plugin-hrm-form/src/components/case/AddPerpetrator.tsx
+++ b/plugin-hrm-form/src/components/case/AddPerpetrator.tsx
@@ -60,7 +60,7 @@ const AddPerpetrator: React.FC<Props> = ({
     const perpetrators = info && info.perpetrators ? [...info.perpetrators, newPerpetrator] : [newPerpetrator];
     const newInfo = info ? { ...info, perpetrators } : { perpetrators };
     const updatedCase = await updateCase(id, { info: newInfo });
-    setConnectedCase(updatedCase, task.taskSid);
+    setConnectedCase(updatedCase, task.taskSid, true);
 
     if (shouldStayInForm) {
       updateTempInfo({ screen: 'add-perpetrator', info: newCallerFormInformation }, task.taskSid);

--- a/plugin-hrm-form/src/components/case/AddReferral.tsx
+++ b/plugin-hrm-form/src/components/case/AddReferral.tsx
@@ -61,7 +61,7 @@ const AddReferral: React.FC<Props> = ({
     const referrals = info && info.referrals ? [...info.referrals, newReferral] : [newReferral];
     const newInfo = info ? { ...info, referrals } : { referrals };
     const updatedCase = await updateCase(id, { info: newInfo });
-    setConnectedCase(updatedCase, task.taskSid);
+    setConnectedCase(updatedCase, task.taskSid, true);
     updateTempInfo({ screen: 'add-referral', info: blankReferral }, task.taskSid);
     onClickClose();
   };

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -53,13 +53,19 @@ type OwnProps = {
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const getNameFromContact = contact => {
-  const { firstName, lastName } = contact.rawJson.childInformation.name;
-  return formatName(`${firstName} ${lastName}`);
+  if (contact?.rawJson?.childInformation?.name) {
+    const { firstName, lastName } = contact.rawJson.childInformation.name;
+    return formatName(`${firstName} ${lastName}`);
+  }
+  return 'Unknown';
 };
 
 const getNameFromForm = form => {
-  const { firstName, lastName } = form.childInformation;
-  return formatName(`${firstName} ${lastName}`);
+  if (form?.childInformation) {
+    const { firstName, lastName } = form.childInformation;
+    return formatName(`${firstName} ${lastName}`);
+  }
+  return 'Unknown';
 };
 
 // eslint-disable-next-line complexity
@@ -166,14 +172,17 @@ const Case: React.FC<Props> = props => {
 
   const { task, form, counselorsHash } = props;
 
-  const { connectedCase } = props.connectedCaseState;
+  const { connectedCase, caseHasBeenEdited } = props.connectedCaseState;
 
   const getCategories = firstConnectedContact => {
     if (firstConnectedContact?.rawJson?.caseInformation) {
       return firstConnectedContact.rawJson.caseInformation.categories;
     }
-    const transformedCategories = transformCategories(form.categories);
-    return transformedCategories;
+    if (form?.categories) {
+      const transformedCategories = transformCategories(form.categories);
+      return transformedCategories;
+    }
+    return null;
   };
 
   const handleUpdate = async () => {
@@ -272,7 +281,7 @@ const Case: React.FC<Props> = props => {
               />
             </Box>
             <Box marginLeft="25px" marginTop="25px">
-              <CaseSummary task={props.task} readonly={props.isCreating || status === 'closed'} />
+              <CaseSummary task={props.task} readonly={status === 'closed'} />
             </Box>
             <Dialog onClose={closeMockedMessage} open={isMockedMessageOpen}>
               <DialogContent>{mockedMessage}</DialogContent>
@@ -307,12 +316,12 @@ const Case: React.FC<Props> = props => {
             {!props.isCreating && (
               <>
                 <Box marginRight="15px">
-                  <StyledNextStepButton roundCorners onClick={props.handleClose}>
+                  <StyledNextStepButton secondary roundCorners onClick={props.handleClose}>
                     <Template code="BottomBar-Close" />
                   </StyledNextStepButton>
                 </Box>
                 {isEditing && (
-                  <StyledNextStepButton roundCorners onClick={handleUpdate}>
+                  <StyledNextStepButton disabled={!caseHasBeenEdited} roundCorners onClick={handleUpdate}>
                     <Template code="BottomBar-Update" />
                   </StyledNextStepButton>
                 )}

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -49,7 +49,7 @@ const CaseDetails = ({
 
   return (
     <>
-      <CaseDetailsHeader caseId={caseId} childName={name} />
+      <CaseDetailsHeader caseId={caseId} childName={name} counselor={counselor} />
       <DetailsContainer tabIndex={0} aria-labelledby="Case-CaseId-label">
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <div style={{ paddingRight: '20px' }}>

--- a/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
+++ b/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
@@ -9,16 +9,18 @@ import {
   DetailsHeaderCaseContainer,
   DetailsHeaderCaseId,
   DetailsHeaderOfficeName,
+  DetailsHeaderCounselor,
 } from '../../../styles/case';
 
 type OwnProps = {
   caseId: string;
   childName: string;
   officeName: string;
+  counselor: string;
   onClickView: () => void;
 };
 
-const CaseDetailsHeader: React.FC<OwnProps> = ({ caseId, childName, officeName, onClickView }) => {
+const CaseDetailsHeader: React.FC<OwnProps> = ({ caseId, childName, officeName, counselor, onClickView }) => {
   return (
     <DetailsHeaderContainer>
       <DetailsHeaderChildName variant="h6">{childName}</DetailsHeaderChildName>
@@ -29,6 +31,9 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({ caseId, childName, officeName, 
         </DetailsHeaderCaseId>
         {officeName && <DetailsHeaderOfficeName>{officeName}</DetailsHeaderOfficeName>}
       </DetailsHeaderCaseContainer>
+      <DetailsHeaderCounselor>
+        <Template code="Case-Counsellor" />: {counselor}
+      </DetailsHeaderCounselor>
     </DetailsHeaderContainer>
   );
 };

--- a/plugin-hrm-form/src/components/search/SearchResults/index.tsx
+++ b/plugin-hrm-form/src/components/search/SearchResults/index.tsx
@@ -124,7 +124,7 @@ const SearchResults: React.FC<Props> = ({
   };
 
   const handleClickViewCase = currentCase => () => {
-    setConnectedCase(currentCase, task.taskSid);
+    setConnectedCase(currentCase, task.taskSid, false);
     changeSearchPage(SearchPages.case);
   };
 

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
@@ -73,7 +73,7 @@ class BottomBar extends Component {
     try {
       const caseFromDB = await createCase(caseRecord);
       this.props.changeRoute({ route: 'new-case' }, taskSid);
-      this.props.setConnectedCase(caseFromDB, taskSid);
+      this.props.setConnectedCase(caseFromDB, taskSid, false);
     } catch (error) {
       window.alert(strings['Error-Backend']);
     }

--- a/plugin-hrm-form/src/states/case/actions.ts
+++ b/plugin-hrm-form/src/states/case/actions.ts
@@ -10,10 +10,11 @@ import {
 } from './types';
 
 // Action creators
-export const setConnectedCase = (connectedCase: Case, taskId: string): CaseActionType => ({
+export const setConnectedCase = (connectedCase: Case, taskId: string, caseHasBeenEdited: Boolean): CaseActionType => ({
   type: SET_CONNECTED_CASE,
   connectedCase,
   taskId,
+  caseHasBeenEdited,
 });
 
 export const removeConnectedCase = (taskId: string): CaseActionType => ({

--- a/plugin-hrm-form/src/states/case/reducer.ts
+++ b/plugin-hrm-form/src/states/case/reducer.ts
@@ -14,7 +14,7 @@ import { GeneralActionType, REMOVE_CONTACT_STATE } from '../types';
 
 export type CaseState = {
   tasks: {
-    [taskId: string]: { connectedCase: Case; temporaryCaseInfo?: TemporaryCaseInfo };
+    [taskId: string]: { connectedCase: Case; temporaryCaseInfo?: TemporaryCaseInfo; caseHasBeenEdited: Boolean };
   };
 };
 
@@ -32,6 +32,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
           [action.taskId]: {
             connectedCase: action.connectedCase,
             temporaryCaseInfo: null,
+            caseHasBeenEdited: action.caseHasBeenEdited,
           },
         },
       };
@@ -55,6 +56,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
           [action.taskId]: {
             connectedCase: updatedCase,
             temporaryCaseInfo: null,
+            caseHasBeenEdited: true,
           },
         },
       };
@@ -79,6 +81,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
           ...state.tasks,
           [action.taskId]: {
             connectedCase: updatedCase,
+            caseHasBeenEdited: true,
           },
         },
       };

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -44,6 +44,7 @@ type SetConnectedCaseAction = {
   type: typeof SET_CONNECTED_CASE;
   connectedCase: Case;
   taskId: string;
+  caseHasBeenEdited: Boolean;
 };
 
 type RemoveConnectedCaseAction = {

--- a/plugin-hrm-form/src/styles/case/index.tsx
+++ b/plugin-hrm-form/src/styles/case/index.tsx
@@ -236,6 +236,13 @@ export const DetailsHeaderCaseContainer = styled('div')`
 
 DetailsHeaderCaseContainer.displayName = 'DetailsHeaderCaseContainer';
 
+export const DetailsHeaderCounselor = styled('div')`
+  font-style: italic;
+  margin-top: 5px;
+`;
+
+DetailsHeaderCounselor.displayName = 'DetailsHeaderCounselor';
+
 export const DetailsHeaderCaseId = styled(Typography)`
   font-weight: 600 !important;
 `;

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -168,6 +168,7 @@
   "Case-ReferralDate": "Date",
   "Case-ReferralReferredTo": "Referred To...",
   "Case-ReferralComments": "Comments",
+  "Case-Counsellor": "Counsellor",
 
   "SideNavCaseList": "Case List",
   


### PR DESCRIPTION
Jira related:
https://bugs.benetech.org/browse/CHI-455

Primary reviewer: @GPaoloni 

Changes description:
- Added Counsellor back to Case Header,
- Disable Update button if a case has not been edited.
- Fixed a blank screen bug when open any VOIDED case (voided cases don't have child name or categories info).
- Fixed a bug that prevented the user to enter a Case summary when the case has just been created.
- Fixed styling of Close button (secondary).