### PR TITLE
Show Contact Info Tab for Offline Non-Data Contacts

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/ContactService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/ContactService.test.js
@@ -180,11 +180,9 @@ describe('saveToHrm() (isContactlessTask)', () => {
     mockedFetch.mockClear();
   });
 
-  test('non-data calltype do not save form data (nor it does captures contactlessTask info)', async () => {
-    const form = createForm(
-      { callType: callTypes.hangup, childFirstName: 'Jill' },
-      { channel: '', date: '2020-11-24', time: '12:00' },
-    );
+  test('non-data calltype do not save form data (but captures contactlessTask info)', async () => {
+    const contactlessTask = { channel: 'web', date: '2020-11-24', time: '12:00' };
+    const form = createForm({ callType: callTypes.hangup, childFirstName: 'Jill' }, contactlessTask);
     const mockedFetch = jest.spyOn(global, 'fetch').mockImplementation(() => fetchSuccess);
 
     await saveToHrm(task, form, hrmBaseUrl, workerSid, helpline);
@@ -192,7 +190,8 @@ describe('saveToHrm() (isContactlessTask)', () => {
     const formFromPOST = getFormFromPOST(mockedFetch);
     expect(formFromPOST.callType).toEqual(callTypes.hangup);
     expect(formFromPOST.childInformation.name.firstName).toEqual('');
-    expect(getTimeOfContactFromPOST(mockedFetch)).not.toEqual(new Date(2020, 10, 24, 12, 0).getTime());
+    expect(formFromPOST.contactlessTask).toStrictEqual(contactlessTask);
+    expect(getTimeOfContactFromPOST(mockedFetch)).toEqual(new Date(2020, 10, 24, 12, 0).getTime());
 
     mockedFetch.mockClear();
   });

--- a/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.jsx
+++ b/plugin-hrm-form/src/components/callTypeButtons/CallTypeButtons.jsx
@@ -47,6 +47,14 @@ const CallTypeButtons = props => {
     props.dispatch(changeRoute({ route: 'tabbed-forms', subroute }, taskSid));
   };
 
+  const handleNonDataClick = (taskSid, callType) => {
+    if (task.attributes.isContactlessTask) {
+      handleClickAndRedirect(taskSid, callType);
+    } else {
+      handleClick(taskSid, callType);
+    }
+  };
+
   const handleConfirmNonDataCallType = async () => {
     if (!hasTaskControl(task)) return;
 
@@ -92,7 +100,7 @@ const CallTypeButtons = props => {
             .map((callType, i) => (
               <NonDataCallTypeButton
                 key={callType}
-                onClick={() => handleClick(task.taskSid, callTypes[callType])}
+                onClick={() => handleNonDataClick(task.taskSid, callTypes[callType])}
                 marginRight={i % 2 === 0}
               >
                 <Template code={`CallType-${callType}`} />

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
@@ -19,6 +19,8 @@ import { createCase } from '../../services/CaseService';
 import { saveToHrm } from '../../services/ContactService';
 import { hasTaskControl } from '../../utils/transfer';
 import { namespace, contactFormsBase } from '../../states';
+import { isNonDataCallType } from '../../states/ValidationRules';
+import callTypes from '../../states/DomainConstants';
 
 class BottomBar extends Component {
   static displayName = 'BottomBar';
@@ -33,7 +35,7 @@ class BottomBar extends Component {
     task: taskType.isRequired,
     changeRoute: PropTypes.func.isRequired,
     setConnectedCase: PropTypes.func.isRequired,
-    contactForm: PropTypes.shape({}).isRequired,
+    contactForm: PropTypes.shape({ callType: PropTypes.oneOf(Object.keys(callTypes)) }).isRequired,
   };
 
   static defaultProps = {
@@ -101,7 +103,7 @@ class BottomBar extends Component {
   };
 
   render() {
-    const { showNextButton, showSubmitButton, handleSubmitIfValid, optionalButtons } = this.props;
+    const { showNextButton, showSubmitButton, handleSubmitIfValid, optionalButtons, contactForm } = this.props;
     const { isMenuOpen, anchorEl, mockedMessage } = this.state;
 
     const showBottomBar = showNextButton || showSubmitButton;
@@ -145,7 +147,7 @@ class BottomBar extends Component {
           )}
           {showSubmitButton && (
             <>
-              {featureFlags.enable_case_management && (
+              {featureFlags.enable_case_management && !isNonDataCallType(contactForm.callType) && (
                 <Box marginRight="15px">
                   <StyledNextStepButton type="button" roundCorners secondary onClick={this.toggleCaseMenu}>
                     <FolderIcon style={{ fontSize: '16px', marginRight: '10px' }} />

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -29,6 +29,7 @@ import { hasTaskControl } from '../../utils/transfer';
 import CallerTabDefinition from '../../formDefinitions/tabbedForms/CallerInformationTab.json';
 import CaseTabDefinition from '../../formDefinitions/tabbedForms/CaseInformationTab.json';
 import ChildTabDefinition from '../../formDefinitions/tabbedForms/ChildInformationTab.json';
+import { isNonDataCallType } from '../../states/ValidationRules';
 
 // eslint-disable-next-line react/display-name
 const mapTabsComponents = (errors: any) => (t: TabbedFormSubroutes) => {
@@ -54,6 +55,8 @@ const mapTabsToIndex = (task: ITask, contactForm: TaskEntry): TabbedFormSubroute
   const isCallerType = contactForm.callType === callTypes.caller;
 
   if (task.attributes.isContactlessTask) {
+    if (isNonDataCallType(contactForm.callType)) return ['contactlessTask'];
+
     return isCallerType
       ? ['search', 'contactlessTask', 'callerInformation', 'childInformation', 'categories', 'caseInformation']
       : ['search', 'contactlessTask', 'childInformation', 'categories', 'caseInformation'];

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -151,6 +151,8 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, ...props
         ]
       : undefined;
 
+  const isDataCallType = !isNonDataCallType(contactForm.callType);
+
   return (
     <FormProvider {...methods}>
       <div role="form" style={{ height: '100%' }}>
@@ -179,19 +181,23 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, ...props
                   display={subroute === 'callerInformation'}
                 />
               )}
-              <TabbedFormTab
-                tabPath="childInformation"
-                definition={ChildTabDefinition as FormDefinition}
-                initialValues={contactForm.childInformation}
-                display={subroute === 'childInformation'}
-              />
-              <IssueCategorizationTab display={subroute === 'categories'} initialValue={contactForm.categories} />
-              <TabbedFormTab
-                tabPath="caseInformation"
-                definition={CaseTabDefinition as FormDefinition}
-                initialValues={contactForm.caseInformation}
-                display={subroute === 'caseInformation'}
-              />
+              {isDataCallType && (
+                <>
+                  <TabbedFormTab
+                    tabPath="childInformation"
+                    definition={ChildTabDefinition as FormDefinition}
+                    initialValues={contactForm.childInformation}
+                    display={subroute === 'childInformation'}
+                  />
+                  <IssueCategorizationTab display={subroute === 'categories'} initialValue={contactForm.categories} />
+                  <TabbedFormTab
+                    tabPath="caseInformation"
+                    definition={CaseTabDefinition as FormDefinition}
+                    initialValues={contactForm.caseInformation}
+                    display={subroute === 'caseInformation'}
+                  />
+                </>
+              )}
             </div>
           )}
           <BottomBar

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -177,6 +177,7 @@ export async function saveToHrm(task, form, hrmBaseUrl, workerSid, helpline, sho
       ...createNewTaskEntry(definitions)(false),
       callType: form.callType,
       metadata: form.metadata,
+      ...(task.attributes.isContactlessTask && { contactlessTask: form.contactlessTask }),
     };
   }
 


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-425

Primary reviewer: @GPaoloni 

When creating an offline contact, and marking the contact as a non-data call, instead of showing up the close dialog it should display the tabbed form with one tab only (Contact Info)

<img width="722" alt="Screen Shot 2021-01-06 at 13 30 35" src="https://user-images.githubusercontent.com/1504544/103794358-6431e100-5023-11eb-952d-54d5d31e9087.png">
