### PR TITLE
More timeline date fixes

### DIFF
--- a/plugin-hrm-form/src/components/case/ContactDetailsAdapter.js
+++ b/plugin-hrm-form/src/components/case/ContactDetailsAdapter.js
@@ -35,7 +35,7 @@ export const retrieveCategories = categories => {
 };
 
 export const adaptContactToDetailsScreen = (contact, counselorName) => {
-  const dateTime = contact.createdAt;
+  const dateTime = contact.timeOfContact;
   const name = `${contact.rawJson.childInformation.name.firstName} ${contact.rawJson.childInformation.name.lastName}`;
   const customerNumber = contact.number;
   const { callType, caseInformation } = contact.rawJson;

--- a/plugin-hrm-form/src/components/case/Timeline.jsx
+++ b/plugin-hrm-form/src/components/case/Timeline.jsx
@@ -90,7 +90,7 @@ const Timeline = ({ status, task, form, caseObj, changeRoute, updateTempInfo, ro
       const info = {
         referral: activity.referral,
         counselor: twilioWorkerId,
-        date: parseISO(activity.added).toLocaleDateString(navigator.language),
+        date: parseISO(activity.createdAt).toLocaleDateString(navigator.language),
       };
       updateTempInfo({ screen: 'view-referral', info }, task.taskSid);
       changeRoute({ route, subroute: 'view-referral' }, task.taskSid);
@@ -103,7 +103,7 @@ const Timeline = ({ status, task, form, caseObj, changeRoute, updateTempInfo, ro
         [ContactDetailsSections.CONTACT_SUMMARY]: false,
       };
       const contact = caseObj.connectedContacts.find(c => c.id === activity.contactId);
-      const tempInfo = { detailsExpanded, contact, date: activity.date, counselor: twilioWorkerId };
+      const tempInfo = { detailsExpanded, contact, date: activity.createdAt, counselor: twilioWorkerId };
       updateTempInfo({ screen: 'view-contact', info: tempInfo }, task.taskSid);
       changeRoute({ route, subroute: 'view-contact' }, task.taskSid);
     } else {

--- a/plugin-hrm-form/src/components/case/Timeline.jsx
+++ b/plugin-hrm-form/src/components/case/Timeline.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { Template } from '@twilio/flex-ui';
 import PropTypes from 'prop-types';
 import Dialog from '@material-ui/core/Dialog';
@@ -82,7 +82,7 @@ const Timeline = ({ status, task, form, caseObj, changeRoute, updateTempInfo, ro
       const info = {
         note: activity.text,
         counselor: twilioWorkerId,
-        date: new Date(activity.date).toLocaleDateString(navigator.language),
+        date: parseISO(activity.date).toLocaleDateString(navigator.language),
       };
       updateTempInfo({ screen: 'view-note', info }, task.taskSid);
       changeRoute({ route, subroute: 'view-note' }, task.taskSid);
@@ -90,7 +90,7 @@ const Timeline = ({ status, task, form, caseObj, changeRoute, updateTempInfo, ro
       const info = {
         referral: activity.referral,
         counselor: twilioWorkerId,
-        date: new Date(activity.date).toLocaleDateString(navigator.language),
+        date: parseISO(activity.added).toLocaleDateString(navigator.language),
       };
       updateTempInfo({ screen: 'view-referral', info }, task.taskSid);
       changeRoute({ route, subroute: 'view-referral' }, task.taskSid);
@@ -146,7 +146,7 @@ const Timeline = ({ status, task, form, caseObj, changeRoute, updateTempInfo, ro
       {timeline &&
         timeline.length > 0 &&
         timeline.map((activity, index) => {
-          const date = new Date(activity.date).toLocaleDateString(navigator.language);
+          const date = parseISO(activity.date).toLocaleDateString(navigator.language);
           return (
             <TimelineRow key={index}>
               <TimelineDate>{date}</TimelineDate>


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-433 and https://bugs.benetech.org/browse/CHI-461
Backed PR: https://github.com/tech-matters/hrm/pull/84 (merged)

Primary reviewer: @GPaoloni 

This PR fixes point **5** from **CHI-433**:
> When creating an offline contact and creating a new case from it, multiple issues related to dates:
> 2. The date of the contact in the Timeline is the current date. But it should be the date entered into the contact in the "Contact Info" screen.
> 3. After clicking on "View" next to the contact in the Timeline, the contact detail shows the current date and time. But it should be the date entered into the contact in the "Contact Info" screen.
> 5. After going into the detail of a search result, same issues as #2 and #3 above. The detail view for a Contact search result works correctly, but viewing the contact detail when coming through Case search shows the wrong date.

**CHI-433** has also some notes on the search feature, that is not addresed in this PR.
**CHI-461** (referral's date) is fully addressed in this PR.

PS: you may notice the use of **parseISO** instead of using the **Date constructor** in order to avoid timezone issues when converting strings to date.