### PR TITLE
Fix 12am

### DIFF
--- a/plugin-hrm-form/src/components/case/Timeline.jsx
+++ b/plugin-hrm-form/src/components/case/Timeline.jsx
@@ -82,7 +82,7 @@ const Timeline = ({ status, task, form, caseObj, changeRoute, updateTempInfo, ro
       const info = {
         note: activity.text,
         counselor: twilioWorkerId,
-        date: parseISO(activity.date).toLocaleDateString(navigator.language),
+        date: parseISO(activity.date).toISOString(navigator.language),
       };
       updateTempInfo({ screen: 'view-note', info }, task.taskSid);
       changeRoute({ route, subroute: 'view-note' }, task.taskSid);
@@ -90,7 +90,7 @@ const Timeline = ({ status, task, form, caseObj, changeRoute, updateTempInfo, ro
       const info = {
         referral: activity.referral,
         counselor: twilioWorkerId,
-        date: parseISO(activity.createdAt).toLocaleDateString(navigator.language),
+        date: parseISO(activity.createdAt).toISOString(navigator.language),
       };
       updateTempInfo({ screen: 'view-referral', info }, task.taskSid);
       changeRoute({ route, subroute: 'view-referral' }, task.taskSid);


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-466

Primary reviewer: @nickhurlburt 

It was always 12am because at some point we used `date.toLocaleDateString()`, and this function ignores the **time** part of the **dateTime**. Replacing it with `date.toISOString()` solves this problem.

<img width="767" alt="Screen Shot 2021-01-08 at 18 54 56" src="https://user-images.githubusercontent.com/1504544/104068060-0815bb00-51e3-11eb-8e72-823c4c7f1272.png">
