### PR TITLE
Omnibus insights fixes

### DIFF
--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -369,6 +369,48 @@ test('processHelplineConfig for case data', () => {
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
 });
 
+test('processHelplineConfig does not add caller fields for child call types', async () => {
+  const helplineConfig = {
+    contactForm: {
+      callerInformation: [
+        {
+          name: 'gender',
+          insights: ['conversations', 'conversation_attribute_4'],
+        },
+      ],
+      childInformation: [
+        {
+          name: 'language',
+          insights: ['conversations', 'language'],
+        },
+      ],
+    },
+  };
+
+  const contactForm = {
+    callType: 'Child calling about self',
+
+    callerInformation: {
+      gender: 'Boy',
+    },
+    childInformation: {
+      language: 'English',
+    },
+  };
+
+  const caseForm = {};
+
+  const expected = {
+    conversations: {
+      language: 'English',
+    },
+    customers: {
+    },
+  };
+
+  expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);
+});
+
 test('zambiaUpdates handles custom entries', () => {
   const contactForm = {
     callType: 'Child calling about self',

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -407,8 +407,7 @@ test('processHelplineConfig does not add caller fields for child call types', as
     conversations: {
       language: 'English',
     },
-    customers: {
-    },
+    customers: {},
   };
 
   expect(processHelplineConfig(contactForm, caseForm, helplineConfig)).toEqual(expected);

--- a/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
+++ b/plugin-hrm-form/src/___tests__/services/InsightsService.test.js
@@ -28,6 +28,7 @@ test('saveInsightsData for non-data callType', async () => {
     conversations: {
       content: 'content',
       conversation_attribute_2: 'Abusive',
+      conversation_attribute_5: null,
       communication_channel: 'SMS',
     },
     customers: {},
@@ -77,6 +78,7 @@ test('saveInsightsData for data callType', async () => {
       content: 'content',
       conversation_attribute_1: 'Unspecified/Other - Missing children;Bullying;Addictive behaviours and substance use',
       conversation_attribute_2: 'Child calling about self',
+      conversation_attribute_5: null,
       communication_channel: 'Call',
     },
     customers: {
@@ -125,6 +127,7 @@ test('Handles contactless tasks', async () => {
     conversations: {
       conversation_attribute_1: 'Unspecified/Other - Violence',
       conversation_attribute_2: 'Child calling about self',
+      conversation_attribute_5: null,
       communication_channel: 'SMS',
       date: getDateTime({ date, time }),
     },

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -144,8 +144,20 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, ...props
           {
             label: 'CancelOfflineContact',
             onClick: async () => {
-              const { isContactlessTask, ...rest } = task.attributes;
-              await task.setAttributes(rest); // skip insights override
+              const { attributes } = task;
+              /*
+               * Don't record insights for this task,
+               * but null out the Task ID so the Insights record is clean.
+               */
+              const newAttributes = {
+                ...attributes,
+                skipInsights: true,
+                conversations: {
+                  /* eslint-disable-next-line camelcase */
+                  conversation_attribute_5: null,
+                },
+              };
+              await task.setAttributes(newAttributes);
               Actions.invokeAction('CompleteTask', { task });
             },
           },

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -73,6 +73,11 @@ const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, cas
   const coreAttributes: InsightsAttributes = {
     conversations: {
       conversation_attribute_2: callType.toString(),
+      // By default, Twilio populates attribute 5 with the Task ID, but we
+      // overwrite it for data contacts so we want it null for non-data contacts.
+      // We'll set it to null in case this is a non-data contact,
+      // and then let other updates overwrite again later for data contacts.
+      conversation_attribute_5: null,
       communication_channel,
     },
   };

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -73,10 +73,12 @@ const baseUpdates = (taskAttributes: TaskAttributes, contactForm: TaskEntry, cas
   const coreAttributes: InsightsAttributes = {
     conversations: {
       conversation_attribute_2: callType.toString(),
-      // By default, Twilio populates attribute 5 with the Task ID, but we
-      // overwrite it for data contacts so we want it null for non-data contacts.
-      // We'll set it to null in case this is a non-data contact,
-      // and then let other updates overwrite again later for data contacts.
+      /*
+       * By default, Twilio populates attribute 5 with the Task ID, but we
+       * overwrite it for data contacts so we want it null for non-data contacts.
+       * We'll set it to null in case this is a non-data contact,
+       * and then let other updates overwrite again later for data contacts.
+       */
       conversation_attribute_5: null,
       communication_channel,
     },

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { ITask } from '@twilio/flex-ui';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { isNonDataCallType } from '../states/ValidationRules';
 import { mapChannelForInsights } from '../utils/mappers';
@@ -7,6 +8,7 @@ import { getDateTime } from '../utils/helpers';
 import { TaskEntry } from '../states/contacts/reducer';
 import { Case } from '../types/types';
 import { formatCategories } from '../utils/formatters';
+import callTypes from '../states/DomainConstants';
 import { zambiaInsightsConfig } from '../insightsConfig/zambia';
 import {
   InsightsObject,
@@ -17,7 +19,7 @@ import {
 } from '../insightsConfig/types';
 
 /*
- * 'Any'' is the best we can do, since we're limited by Twilio here.
+ * 'Any' is the best we can do, since we're limited by Twilio here.
  * See https://assets.flex.twilio.com/releases/flex-ui/1.18.0/docs/ITask.html
  */
 type TaskAttributes = any;
@@ -196,7 +198,13 @@ export const processHelplineConfig = (
 
   const formsToProcess: [InsightsFormSpec, TaskEntry | InsightsCaseForm][] = [];
   if (configSpec.contactForm) {
-    formsToProcess.push([configSpec.contactForm, contactForm]);
+    // Clone the whole object to avoid modifying the real spec. May not be needed.
+    const contactSpec = cloneDeep(configSpec.contactForm);
+    if (contactForm.callType !== callTypes.caller) {
+      // If this isn't a caller type, don't save the caller form data
+      contactSpec.callerInformation = [];
+    }
+    formsToProcess.push([contactSpec, contactForm]);
   }
   if (configSpec.caseForm) {
     formsToProcess.push([configSpec.caseForm, convertCaseFormForInsights(caseForm)]);

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -252,9 +252,11 @@ const saveInsights = async payload => {
 const sendInsightsData = setupObject => async payload => {
   const { featureFlags } = setupObject;
 
-  if (!featureFlags.enable_transfers || TransferHelpers.hasTaskControl(payload.task)) {
-    if (featureFlags.enable_save_insights) {
-      await saveInsights(payload);
+  if (!payload.task?.attributes?.skipInsights) {
+    if (!featureFlags.enable_transfers || TransferHelpers.hasTaskControl(payload.task)) {
+      if (featureFlags.enable_save_insights) {
+        await saveInsights(payload);
+      }
     }
   }
 };


### PR DESCRIPTION
Primary reviewer: @GPaoloni, though I'm going to merge and deploy this now so that Joan can start testing.  Please review afterward.

Addresses most of [CHI-462](https://bugs.benetech.org/browse/CHI-462):
- Does not record caller form values if not a caller callType.  Previously, 'Unknown' could be populated even if no data was filled in.
- `null`s out `conversation_attribute_5` by default.  Twilio auto-fills it to be the Task ID, but we are overriding it to hold the Child: LGBTQI+ value.  For situations where this value is not populated, such as canceled offline contacts or non-data contacts, this will be null so the Task ID isn't polluting the data.
- Does not save any data for a canceled offline contact, except for nulling `conversation_attribute_5`.  The communication channel will be 'default', by default.  In future work, we'll wait until an offline contact is submitted to create the Twilio task for it, and then this will no longer be necessary.

This will be easier to read by commit, though should be understandable all at once.
