### PR TITLE
Duplicate key warning

### DIFF
--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -186,7 +186,7 @@ const getInputType = (parents: string[], updateCallback: () => void) => (def: Fo
                     defaultValue={initialValue}
                   >
                     {def.options.map(o => (
-                      <FormOption key={`${path}-${o.value}`} value={o.value} isEmptyValue={o.value === ''}>
+                      <FormOption key={`${path}-${o.label}`} value={o.value} isEmptyValue={o.value === ''}>
                         {o.label}
                       </FormOption>
                     ))}

--- a/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
+++ b/plugin-hrm-form/src/components/tabbedForms/BottomBar.jsx
@@ -35,7 +35,7 @@ class BottomBar extends Component {
     task: taskType.isRequired,
     changeRoute: PropTypes.func.isRequired,
     setConnectedCase: PropTypes.func.isRequired,
-    contactForm: PropTypes.shape({ callType: PropTypes.oneOf(Object.keys(callTypes)) }).isRequired,
+    contactForm: PropTypes.shape({ callType: PropTypes.oneOf(Object.values(callTypes)) }).isRequired,
   };
 
   static defaultProps = {

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -71,7 +71,13 @@ export const TabbedFormsContainer = styled('div')`
 `;
 TabbedFormsContainer.displayName = 'TabbedFormsContainer';
 
-export const TabbedFormTabContainer = styled('div')<{ display: boolean }>`
+type TabbedFormTabContainerProps = {
+  display: boolean;
+};
+
+export const TabbedFormTabContainer = styled(({ display, ...rest }: TabbedFormTabContainerProps) => <Box {...rest} />)<
+  TabbedFormTabContainerProps
+>`
   display: ${({ display }) => (display ? 'block' : 'none')};
   height: ${({ display }) => (display ? '100%' : '0px')};
 `;


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-467

Primary reviewer: @GPaoloni 

This PR removes 3 warnings that were happening when selecting `Child calling about self` or `Someone calling about a child`:
- Duplicate key warning (as described in the Jira card)
- contactForm.callType warning
- display attribute warning