### PR TITLE
Child is at risk should be disabled when case is closed

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -56,6 +56,7 @@ const CaseDetails = ({
         childName={name}
         counselor={counselor}
         childIsAtRisk={childIsAtRisk}
+        status={status}
         handleClickChildIsAtRisk={handleClickChildIsAtRisk}
       />
       <DetailsContainer tabIndex={0} aria-labelledby="Case-CaseId-label">

--- a/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
+++ b/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
@@ -11,6 +11,7 @@ import {
   DetailsHeaderCounselor,
 } from '../../../styles/case';
 import { Flex, Box, FormCheckbox, FormLabel, FormCheckBoxWrapper } from '../../../styles/HrmStyles';
+import { CaseStatus } from '../../../types/types';
 
 type OwnProps = {
   caseId: string;
@@ -18,6 +19,7 @@ type OwnProps = {
   officeName: string;
   counselor: string;
   childIsAtRisk: boolean;
+  status: CaseStatus;
   handleClickChildIsAtRisk: () => void;
 };
 
@@ -27,6 +29,7 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({
   officeName,
   counselor,
   childIsAtRisk,
+  status,
   handleClickChildIsAtRisk,
 }) => {
   return (
@@ -54,6 +57,7 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({
               type="checkbox"
               onChange={handleClickChildIsAtRisk}
               defaultChecked={Boolean(childIsAtRisk)}
+              disabled={status === 'closed'}
             />
           </Box>
           <Template code="Case-ChildIsAtRisk" />


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-482#

Primary reviewer: @andvirga 

This PR fixes the issue where child is at risk checkbox was still editable after case status was closed.