### PR TITLE
Bug fix: Bug(s) with transferring

### DIFF
--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -1,4 +1,4 @@
-const callTypes = {
+export const callTypes = {
   child: 'Child calling about self',
   caller: 'Someone calling about a child',
   silent: 'Silent',

--- a/plugin-hrm-form/src/states/DomainConstants.ts
+++ b/plugin-hrm-form/src/states/DomainConstants.ts
@@ -1,4 +1,4 @@
-export const callTypes = {
+const callTypes = {
   child: 'Child calling about self',
   caller: 'Someone calling about a child',
   silent: 'Silent',

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -9,7 +9,7 @@ import { namespace, contactFormsBase, connectedCaseBase } from '../states';
 import * as Actions from '../states/contacts/actions';
 import { changeRoute } from '../states/routing/actions';
 import * as GeneralActions from '../states/actions';
-import { callTypes, channelTypes, transferModes } from '../states/DomainConstants';
+import callTypes, { channelTypes, transferModes } from '../states/DomainConstants';
 import * as TransferHelpers from './transfer';
 import { saveFormSharedState, loadFormSharedState } from './sharedState';
 import { prepopulateForm } from './prepopulateForm';


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-309

This PR:
> The automated message “Hi, this is the counselor. How can I help you?” was sent again which we definitely do not want. Many of the helplines will transfer a text to a new counselor without letting the child know.

Fixed by only sending the welcome message if the accepted task was NOT transferred.

> It came through to the new counselor back at the Call Type screen rather than on the Child Info screen. (The data is still in the form though.)

Fixed by dispatching the proper route-subroute depending on the selected call type.

