### PR TITLE
Make the "Counselor has left the chat" message consistent across all text-based channels

### DIFF
--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { Notifications } from '@twilio/flex-ui';
+import { ITask, Notifications } from '@twilio/flex-ui';
 
 import fetchProtectedApi from './fetchProtectedApi';
 import { getConfig } from '../HrmFormPlugin';
@@ -88,6 +88,15 @@ export const assignMeContactlessTask = async () => {
   };
 
   const response = await fetchProtectedApi('/createContactlessTask', body);
+
+  return response;
+};
+
+/**
+ * Sends a new message to the channel bounded to the provided taskSid. Optionally you can change the "from" value (defaul is "system").
+ */
+export const sendSystemMessage = async (body: { taskSid: ITask['taskSid']; message: string; from?: string }) => {
+  const response = await fetchProtectedApi('/sendSystemMessage', body);
 
   return response;
 };

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -9,7 +9,7 @@ import { namespace, contactFormsBase, connectedCaseBase } from '../states';
 import * as Actions from '../states/contacts/actions';
 import { changeRoute } from '../states/routing/actions';
 import * as GeneralActions from '../states/actions';
-import callTypes, { channelTypes, transferModes } from '../states/DomainConstants';
+import callTypes, { transferModes } from '../states/DomainConstants';
 import * as TransferHelpers from './transfer';
 import { saveFormSharedState, loadFormSharedState } from './sharedState';
 import { prepopulateForm } from './prepopulateForm';
@@ -226,19 +226,12 @@ export const afterCancelTransfer = payload => {
 export const hangupCall = fromActionFunction(saveEndMillis);
 
 /**
- * Helper to determine if the counselor should send a message before leaving the chat
- * @param {string} channel
- */
-const shouldSayGoodbye = channel =>
-  channel === channelTypes.facebook || channel === channelTypes.sms || channel === channelTypes.whatsapp;
-
-/**
  * Override for WrapupTask action. Sends a message before leaving (if it should) and saves the end time of the conversation
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  */
 export const wrapupTask = setupObject =>
   fromActionFunction(async payload => {
-    if (shouldSayGoodbye(payload.task.channelType)) {
+    if (TaskHelper.isChatBasedTask(payload.task)) {
       await sendGoodbyeMessage(setupObject)(payload);
     }
     await saveEndMillis(payload);

--- a/plugin-hrm-form/src/utils/setUpActions.js
+++ b/plugin-hrm-form/src/utils/setUpActions.js
@@ -4,7 +4,7 @@ import { Manager, TaskHelper, Actions as FlexActions, StateHelper } from '@twili
 // eslint-disable-next-line no-unused-vars
 import { DEFAULT_TRANSFER_MODE, getConfig } from '../HrmFormPlugin';
 import { saveInsightsData } from '../services/InsightsService';
-import { transferChatStart, adjustChatCapacity } from '../services/ServerlessService';
+import { transferChatStart, adjustChatCapacity, sendSystemMessage } from '../services/ServerlessService';
 import { namespace, contactFormsBase, connectedCaseBase } from '../states';
 import * as Actions from '../states/contacts/actions';
 import { changeRoute } from '../states/routing/actions';
@@ -129,8 +129,19 @@ const sendMessageOfKey = messageKey => setupObject => async payload => {
   });
 };
 
+/**
+ * @param {string} messageKey
+ * @returns {(setupObject: ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }) => import('@twilio/flex-ui').ActionFunction}
+ */
+const sendSystemMessageOfKey = messageKey => setupObject => async payload => {
+  const { getMessage } = setupObject;
+  const taskLanguage = getTaskLanguage(setupObject)(payload);
+  const message = await getMessage(messageKey)(taskLanguage);
+  await sendSystemMessage({ taskSid: payload.task.taskSid, message, from: 'Bot' });
+};
+
 const sendWelcomeMessage = sendMessageOfKey('WelcomeMsg');
-const sendGoodbyeMessage = sendMessageOfKey('GoodbyeMsg');
+const sendGoodbyeMessage = sendSystemMessageOfKey('GoodbyeMsg');
 
 /**
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-314
This PR is related to
- https://github.com/tech-matters/serverless/pull/29
- https://github.com/tech-matters/webchat/pull/15

This PR changes the way the "good bye message" is sent (in behalf of the Bot instead of the counselor), and adds it to the webchat channels (now is sent to all chat based tasks).

Note: to test this you can point to the development environment of serverless staging.