### PR TITLE
[Prototype] Add Counselor Name to Contact Info tab for Offline Contact

### DIFF
--- a/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.js
+++ b/plugin-hrm-form/src/___tests__/callTypeButtons/CallTypeButtons.test.js
@@ -12,17 +12,24 @@ import CallTypeButtons from '../../components/callTypeButtons';
 import { DataCallTypeButton, NonDataCallTypeButton, ConfirmButton, CancelButton } from '../../styles/callTypeButtons';
 import LocalizationContext from '../../contexts/LocalizationContext';
 import callTypes from '../../states/DomainConstants';
-import { namespace, contactFormsBase } from '../../states';
+import { namespace, contactFormsBase, connectedCaseBase } from '../../states';
 import { changeRoute } from '../../states/routing/actions';
 import { updateCallType } from '../../states/contacts/actions';
+import { completeTask, submitContactForm } from '../../services/formSumbissionHelpers';
 
 jest.mock('../../services/ContactService', () => ({
   saveToHrm: jest.fn(),
 }));
 
+jest.mock('../../services/formSumbissionHelpers', () => ({
+  completeTask: jest.fn(),
+  submitContactForm: jest.fn(),
+}));
+
 const mockStore = configureMockStore([]);
 
 const task = {
+  sid: 'reservation-task-sid',
   taskSid: 'task-sid',
   attributes: {},
 };
@@ -53,6 +60,7 @@ test('<CallTypeButtons> inital render (no dialog)', () => {
           },
         },
       },
+      [connectedCaseBase]: { tasks: {} },
     },
   };
   const store = mockStore(initialState);
@@ -62,7 +70,7 @@ test('<CallTypeButtons> inital render (no dialog)', () => {
   const component = renderer.create(
     <LocalizationContext.Provider value={{ strings, isCallTask }}>
       <Provider store={store}>
-        <CallTypeButtons task={task} handleCompleteTask={jest.fn()} dispatch={jest.fn()} />
+        <CallTypeButtons task={task} dispatch={jest.fn()} />
       </Provider>
     </LocalizationContext.Provider>,
   ).root;
@@ -84,6 +92,7 @@ test('<CallTypeButtons> renders dialog with END CHAT button', () => {
           },
         },
       },
+      [connectedCaseBase]: { tasks: {} },
     },
   };
   const store = mockStore(initialState);
@@ -93,7 +102,7 @@ test('<CallTypeButtons> renders dialog with END CHAT button', () => {
   const component = renderer.create(
     <LocalizationContext.Provider value={{ strings, isCallTask }}>
       <Provider store={store}>
-        <CallTypeButtons task={task} handleCompleteTask={jest.fn()} dispatch={jest.fn()} />
+        <CallTypeButtons task={task} dispatch={jest.fn()} />
       </Provider>
     </LocalizationContext.Provider>,
   ).root;
@@ -114,6 +123,7 @@ test('<CallTypeButtons> renders dialog with HANG UP button', () => {
           },
         },
       },
+      [connectedCaseBase]: { tasks: {} },
     },
   };
   const store = mockStore(initialState);
@@ -123,7 +133,7 @@ test('<CallTypeButtons> renders dialog with HANG UP button', () => {
   const component = renderer.create(
     <LocalizationContext.Provider value={{ strings, isCallTask }}>
       <Provider store={store}>
-        <CallTypeButtons task={task} handleCompleteTask={jest.fn()} dispatch={jest.fn()} />
+        <CallTypeButtons task={task} dispatch={jest.fn()} />
       </Provider>
     </LocalizationContext.Provider>,
   ).root;
@@ -144,6 +154,7 @@ test('<CallTypeButtons> click on CallType button', () => {
           },
         },
       },
+      [connectedCaseBase]: { tasks: {} },
     },
   };
   const store = mockStore(initialState);
@@ -154,7 +165,7 @@ test('<CallTypeButtons> click on CallType button', () => {
   render(
     <LocalizationContext.Provider value={{ strings, isCallTask }}>
       <Provider store={store}>
-        <CallTypeButtons task={task} handleCompleteTask={jest.fn()} />
+        <CallTypeButtons task={task} />
       </Provider>
     </LocalizationContext.Provider>,
   );
@@ -178,6 +189,7 @@ test('<CallTypeButtons> click on END CHAT button', async () => {
           },
         },
       },
+      [connectedCaseBase]: { tasks: {} },
     },
   };
   const store = mockStore(initialState);
@@ -185,12 +197,10 @@ test('<CallTypeButtons> click on END CHAT button', async () => {
 
   const isCallTask = () => false;
 
-  const handleCompleteTask = jest.fn();
-
   render(
     <LocalizationContext.Provider value={{ strings, isCallTask }}>
       <Provider store={store}>
-        <CallTypeButtons task={task} handleCompleteTask={jest.fn()} />
+        <CallTypeButtons task={task} />
       </Provider>
     </LocalizationContext.Provider>,
   );
@@ -198,7 +208,8 @@ test('<CallTypeButtons> click on END CHAT button', async () => {
   expect(screen.getByText('TaskHeaderEndChat')).toBeInTheDocument();
   screen.getByText('TaskHeaderEndChat').click();
 
-  waitFor(() => expect(handleCompleteTask).toHaveBeenCalledWith(task.taskSid, task));
+  waitFor(() => expect(submitContactForm).toHaveBeenCalled());
+  waitFor(() => expect(completeTask).toHaveBeenCalledWith(task));
 });
 
 test('<CallTypeButtons> click on CANCEL button', () => {
@@ -211,6 +222,7 @@ test('<CallTypeButtons> click on CANCEL button', () => {
           },
         },
       },
+      [connectedCaseBase]: { tasks: {} },
     },
   };
   const store = mockStore(initialState);
@@ -218,12 +230,10 @@ test('<CallTypeButtons> click on CANCEL button', () => {
 
   const isCallTask = () => false;
 
-  const handleCompleteTask = jest.fn();
-
   render(
     <LocalizationContext.Provider value={{ strings, isCallTask }}>
       <Provider store={store}>
-        <CallTypeButtons task={task} handleCompleteTask={jest.fn()} />
+        <CallTypeButtons task={task} />
       </Provider>
     </LocalizationContext.Provider>,
   );
@@ -231,5 +241,6 @@ test('<CallTypeButtons> click on CANCEL button', () => {
   expect(screen.getByText('CancelButton')).toBeInTheDocument();
   screen.getByText('CancelButton').click();
 
-  waitFor(() => expect(handleCompleteTask).not.toHaveBeenCalledWith(task.taskSid, task));
+  waitFor(() => expect(completeTask).not.toHaveBeenCalled());
+  waitFor(() => expect(submitContactForm).not.toHaveBeenCalled());
 });

--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.js
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.js
@@ -80,7 +80,6 @@ const ownProps = {
       isContactlessTask: false,
     },
   },
-  handleCompleteTask: jest.fn(),
 };
 
 describe('useState mocked', () => {
@@ -241,7 +240,6 @@ describe('useState mocked', () => {
    *    task: {
    *      taskSid: 'task1',
    *    },
-   *    handleCompleteTask: jest.fn(),
    *  };
    *
    *  const store = mockStore(initialState);

--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -9,12 +9,12 @@ import { populateCounselors } from '../services/ServerlessService';
 import { populateCounselorsState } from '../states/configuration/actions';
 import type { RootState } from '../states';
 
-type OwnProps = { handleCompleteTask: (sid: string, task: ITask) => Promise<void> };
+type OwnProps = {};
 
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const CustomCRMContainer: React.FC<Props> = ({ tasks, handleCompleteTask, dispatch }) => {
+const CustomCRMContainer: React.FC<Props> = ({ tasks, dispatch }) => {
   useEffect(() => {
     const fetchPopulateCounselors = async () => {
       try {
@@ -32,7 +32,7 @@ const CustomCRMContainer: React.FC<Props> = ({ tasks, handleCompleteTask, dispat
   return (
     <Absolute top="0" bottom="0" left="0" right="0">
       {Array.from(tasks.values()).map(item => (
-        <TaskView thisTask={item} key={`controller-${item.taskSid}`} handleCompleteTask={handleCompleteTask} />
+        <TaskView thisTask={item} key={`controller-${item.taskSid}`} />
       ))}
     </Absolute>
   );

--- a/plugin-hrm-form/src/components/CustomCRMContainer.tsx
+++ b/plugin-hrm-form/src/components/CustomCRMContainer.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import type { ITask } from '@twilio/flex-ui';
 
 import TaskView from './TaskView';
 import { Absolute } from '../styles/HrmStyles';

--- a/plugin-hrm-form/src/components/HrmForm.tsx
+++ b/plugin-hrm-form/src/components/HrmForm.tsx
@@ -7,13 +7,11 @@ import { CaseLayout } from '../styles/case';
 import CallTypeButtons from './callTypeButtons';
 import TabbedForms from './tabbedForms';
 import Case from './case';
-import { namespace, routingBase } from '../states';
+import { namespace, RootState, routingBase } from '../states';
 import * as RoutingActions from '../states/routing/actions';
-import { RoutingState } from '../states/routing/reducer';
 
 type OwnProps = {
   task: ITask;
-  handleCompleteTask: any;
   changeRoute: any;
 };
 
@@ -28,25 +26,25 @@ const HrmForm: React.FC<Props> = props => {
 
   switch (route) {
     case 'tabbed-forms':
-      return <TabbedForms handleCompleteTask={props.handleCompleteTask} />;
+      return <TabbedForms />;
 
     case 'new-case':
       return (
         <CaseLayout>
-          <Case task={props.task} handleCompleteTask={props.handleCompleteTask} isCreating={true} />
+          <Case task={props.task} isCreating={true} />
         </CaseLayout>
       );
 
     case 'select-call-type':
     default:
-      return <CallTypeButtons handleCompleteTask={props.handleCompleteTask} />;
+      return <CallTypeButtons />;
   }
 };
 
 HrmForm.displayName = 'HrmForm';
 
-const mapStateToProps = (state, ownProps: OwnProps) => {
-  const routingState: RoutingState = state[namespace][routingBase];
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => {
+  const routingState = state[namespace][routingBase];
 
   return { routing: routingState.tasks[ownProps.task.taskSid] };
 };

--- a/plugin-hrm-form/src/components/TaskView.jsx
+++ b/plugin-hrm-form/src/components/TaskView.jsx
@@ -19,7 +19,6 @@ class TaskView extends Component {
     contactFormStateExists: PropTypes.bool.isRequired,
     routingStateExists: PropTypes.bool.isRequired,
     searchStateExists: PropTypes.bool.isRequired,
-    handleCompleteTask: PropTypes.func.isRequired,
     dispatch: PropTypes.func.isRequired,
     currentDefinitionVersion: PropTypes.shape({ tabbedForms: PropTypes.shape({}) }).isRequired,
   };
@@ -51,7 +50,7 @@ class TaskView extends Component {
     return (
       <div style={{ height: '100%' }}>
         {!hasTaskControl(thisTask) && <FormNotEditable />}
-        <HrmForm handleCompleteTask={this.props.handleCompleteTask} />
+        <HrmForm />
       </div>
     );
   }

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -180,7 +180,7 @@ const Case: React.FC<Props> = props => {
 
     const { task, form } = props;
     const { connectedCase } = props.connectedCaseState;
-    const { hrmBaseUrl, strings } = getConfig();
+    const { strings } = getConfig();
 
     // Validating that task isn't a StandaloneITask.
     if (isStandaloneITask(task)) return;

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -19,8 +19,9 @@ import {
   RootState,
 } from '../../states';
 import { getConfig } from '../../HrmFormPlugin';
-import { saveToHrm, connectToCase, transformCategories } from '../../services/ContactService';
+import { connectToCase, transformCategories } from '../../services/ContactService';
 import { cancelCase, updateCase, getActivities } from '../../services/CaseService';
+import { submitContactForm, completeTask } from '../../services/formSumbissionHelpers';
 import { getDefinitionVersion } from '../../services/ServerlessService';
 import { isConnectedCaseActivity, getDateFromNotSavedContact, sortActivities } from './caseHelpers';
 import { Box, BottomButtonBar, StyledNextStepButton } from '../../styles/HrmStyles';
@@ -58,7 +59,6 @@ type OwnProps = {
   task: ITask | StandaloneITask;
   isCreating?: boolean;
   handleClose?: () => void;
-  handleCompleteTask?: (taskSid: string, task: ITask) => void;
   updateAllCasesView?: (updatedCase: CaseType) => void;
 };
 
@@ -180,17 +180,17 @@ const Case: React.FC<Props> = props => {
 
     const { task, form } = props;
     const { connectedCase } = props.connectedCaseState;
-    const { hrmBaseUrl, workerSid, helpline, strings } = getConfig();
+    const { hrmBaseUrl, strings } = getConfig();
 
     // Validating that task isn't a StandaloneITask.
     if (isStandaloneITask(task)) return;
 
     try {
-      const contact = await saveToHrm(task, form, hrmBaseUrl, workerSid, helpline);
+      const contact = await submitContactForm(task, form, connectedCase);
       await updateCase(connectedCase.id, { ...connectedCase });
-      await connectToCase(hrmBaseUrl, contact.id, connectedCase.id);
+      await connectToCase(contact.id, connectedCase.id);
       props.markCaseAsUpdated(task.taskSid);
-      props.handleCompleteTask(task.taskSid, task);
+      await completeTask(task);
     } catch (error) {
       console.error(error);
       window.alert(strings['Error-Backend']);

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTab.tsx
@@ -9,9 +9,9 @@ import { get } from 'lodash';
 import { createFormFromDefinition, disperseInputs } from '../common/forms/formGenerators';
 import { updateForm } from '../../states/contacts/actions';
 import { Container, ColumnarBlock, TwoColumnLayout, TabbedFormTabContainer } from '../../styles/HrmStyles';
-import type { RootState } from '../../states';
+import { configurationBase, namespace, RootState } from '../../states';
 import type { TaskEntry } from '../../states/contacts/reducer';
-import { formDefinition } from './ContactlessTaskTabDefinition';
+import { createFormDefinition } from './ContactlessTaskTabDefinition';
 import { splitDate, splitTime } from '../../utils/helpers';
 
 type OwnProps = {
@@ -23,7 +23,7 @@ type OwnProps = {
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task, initialValues }) => {
+const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task, initialValues, counselorsList }) => {
   const [initialForm] = React.useState(initialValues); // grab initial values in first render only. This value should never change or will ruin the memoization below
 
   const { getValues, register, setError, setValue, watch, errors } = useFormContext();
@@ -34,10 +34,12 @@ const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task, initialV
       dispatch(updateForm(task.taskSid, 'contactlessTask', rest));
     };
 
+    const formDefinition = createFormDefinition(counselorsList);
+
     const tab = createFormFromDefinition(formDefinition)(['contactlessTask'])(initialForm)(updateCallBack);
 
     return disperseInputs(5)(tab);
-  }, [dispatch, getValues, initialForm, task.taskSid]);
+  }, [counselorsList, dispatch, getValues, initialForm, task.taskSid]);
 
   // Add invisible field that errors if date + time are future (triggered by validaiton)
   React.useEffect(() => {
@@ -84,7 +86,9 @@ const ContactlessTaskTab: React.FC<Props> = ({ dispatch, display, task, initialV
 
 ContactlessTaskTab.displayName = 'ContactlessTaskTab';
 
-const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({});
+const mapStateToProps = (state: RootState, ownProps: OwnProps) => ({
+  counselorsList: state[namespace][configurationBase].counselors.list,
+});
 
 const connector = connect(mapStateToProps);
 const connected = connector(ContactlessTaskTab);

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -4,6 +4,7 @@ import { channelTypes, otherContactChannels } from '../../states/DomainConstants
 import type { FormDefinition } from '../common/forms/types';
 import { mapChannelForInsights } from '../../utils/mappers';
 import { splitDate } from '../../utils/helpers';
+import type { CounselorsList } from '../../states/configuration/types';
 
 const channelOptions = [{ value: '', label: '' }].concat(
   [...Object.values(channelTypes), ...Object.values(otherContactChannels)].map(s => ({
@@ -12,28 +13,42 @@ const channelOptions = [{ value: '', label: '' }].concat(
   })),
 );
 
-export const formDefinition: FormDefinition = [
-  {
-    name: 'channel',
-    type: 'select',
-    label: 'Channel',
-    options: channelOptions,
-    required: { value: true, message: 'RequiredFieldError' },
-  },
-  {
-    name: 'date',
-    type: 'date-input',
-    label: 'Date of Contact',
-    required: { value: true, message: 'RequiredFieldError' },
-    validate: date => {
-      const [y, m, d] = splitDate(date);
-      return isFuture(new Date(y, m - 1, d)) ? 'DateCantBeGreaterThanToday' : null;
+export const createFormDefinition = (counselorsList: CounselorsList): FormDefinition => {
+  const counsellorOptions = [
+    { label: '', value: '' },
+    ...counselorsList.map(c => ({ label: c.fullName, value: c.sid })),
+  ];
+
+  return [
+    {
+      name: 'channel',
+      type: 'select',
+      label: 'Channel',
+      options: channelOptions,
+      required: { value: true, message: 'RequiredFieldError' },
     },
-  },
-  {
-    name: 'time',
-    type: 'time-input',
-    label: 'Time of Contact',
-    required: { value: true, message: 'RequiredFieldError' },
-  },
-];
+    {
+      name: 'createdOnBehalfOf',
+      type: 'select',
+      label: 'Counsellor',
+      options: counsellorOptions,
+      required: { value: true, message: 'RequiredFieldError' },
+    },
+    {
+      name: 'date',
+      type: 'date-input',
+      label: 'Date of Contact',
+      required: { value: true, message: 'RequiredFieldError' },
+      validate: date => {
+        const [y, m, d] = splitDate(date);
+        return isFuture(new Date(y, m - 1, d)) ? 'DateCantBeGreaterThanToday' : null;
+      },
+    },
+    {
+      name: 'time',
+      type: 'time-input',
+      label: 'Time of Contact',
+      required: { value: true, message: 'RequiredFieldError' },
+    },
+  ];
+};

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -209,7 +209,7 @@ export async function saveToHrm(task, form, hrmBaseUrl, workerSid, helpline, sho
   return responseJson;
 }
 
-export async function connectToCase(hrmBaseUrl, contactId, caseId) {
+export async function connectToCase(contactId, caseId) {
   const body = { caseId };
 
   const options = {

--- a/plugin-hrm-form/src/services/ContactService.ts
+++ b/plugin-hrm-form/src/services/ContactService.ts
@@ -158,7 +158,7 @@ export function transformForm(form: TaskEntry): ContactRawJson {
  * @param helpline
  * @param shouldFillEndMillis
  */
-export async function saveToHrm(task, form, hrmBaseUrl, workerSid, helpline, shouldFillEndMillis = true) {
+export async function saveToHrm(task, form, workerSid, helpline, shouldFillEndMillis = true) {
   // if we got this far, we assume the form is valid and ready to submit
   const metadata = shouldFillEndMillis ? fillEndMillis(form.metadata) : form.metadata;
   const conversationDuration = getConversationDuration(task, metadata);

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -289,11 +289,20 @@ const getInsightsUpdateFunctionsForConfig = (config: any): any => {
  * Note: config parameter tells where to go to get helpline-specific tests.  It should
  * eventually match up with getConfig().  Also useful for testing.
  */
-export async function saveInsightsData(twilioTask: ITask, contactForm: TaskEntry, caseForm: Case, config = {}) {
-  const previousAttributes: TaskAttributes = twilioTask.attributes;
+export const buildInsightsData = (
+  previousAttributes: ITask['attributes'],
+  contactForm: TaskEntry,
+  caseForm: Case,
+  config = {},
+) => {
   const finalAttributes: TaskAttributes = getInsightsUpdateFunctionsForConfig(config)
-    .map((f: any) => f(twilioTask.attributes, contactForm, caseForm))
+    .map((f: any) => f(previousAttributes, contactForm, caseForm))
     .reduce((acc: TaskAttributes, curr: InsightsAttributes) => mergeAttributes(acc, curr), previousAttributes);
 
+  return finalAttributes;
+};
+
+export async function saveInsightsData(twilioTask: ITask, contactForm: TaskEntry, caseForm: Case, config = {}) {
+  const finalAttributes = buildInsightsData(twilioTask.attributes, contactForm, caseForm, config);
   await twilioTask.setAttributes(finalAttributes);
 }

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -116,3 +116,14 @@ export const getDefinitionVersionsList = async (missingDefinitionVersions: strin
       return { version, definition };
     }),
   );
+
+export const assignOfflineContact = async (targetSid: string, finalTaskAttributes: ITask['attributes']) => {
+
+  const body = {
+    targetSid,
+    finalTaskAttributes: JSON.stringify(finalTaskAttributes),
+  };
+
+  const response = await fetchProtectedApi('/assignOfflineContact', body);
+  return response;
+};

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -118,7 +118,6 @@ export const getDefinitionVersionsList = async (missingDefinitionVersions: strin
   );
 
 export const assignOfflineContact = async (targetSid: string, finalTaskAttributes: ITask['attributes']) => {
-
   const body = {
     targetSid,
     finalTaskAttributes: JSON.stringify(finalTaskAttributes),

--- a/plugin-hrm-form/src/services/formSumbissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSumbissionHelpers.ts
@@ -48,17 +48,15 @@ export const completeTask = (task: ITask) =>
   task.attributes.isContactlessTask ? completeContactlessTask(task) : completeContactTask(task);
 
 export const submitContactForm = async (task: ITask, contactForm: Contact, caseForm: Case) => {
-  const { hrmBaseUrl, workerSid, helpline } = getConfig();
+  const { workerSid, helpline } = getConfig();
 
   if (task.attributes.isContactlessTask) {
-    const targetSid = 'WK76971332a884bf79ec378f98879d23c2';
+    const targetSid = contactForm.contactlessTask.createdOnBehalfOf as string;
     const initialAttributes = { helpline, channelType: 'default', isContactlessTask: true, isInMyBehalf: true };
     const finalAttributes = buildInsightsData(initialAttributes, contactForm, caseForm, {});
-    const contact = await saveToHrm(task, contactForm, hrmBaseUrl, workerSid, helpline);
-    const _newTask = await assignOfflineContact(targetSid, finalAttributes);
-    return contact;
+    await assignOfflineContact(targetSid, finalAttributes);
   }
 
-  const contact = await saveToHrm(task, contactForm, hrmBaseUrl, workerSid, helpline);
+  const contact = await saveToHrm(task, contactForm, workerSid, helpline);
   return contact;
 };

--- a/plugin-hrm-form/src/services/formSumbissionHelpers.ts
+++ b/plugin-hrm-form/src/services/formSumbissionHelpers.ts
@@ -1,0 +1,64 @@
+/* eslint-disable import/no-unused-modules */
+import { Actions, ITask } from '@twilio/flex-ui';
+
+import { getConfig } from '../HrmFormPlugin';
+import { TaskEntry as Contact } from '../states/contacts/reducer';
+import { Case } from '../types/types';
+import { channelTypes } from '../states/DomainConstants';
+import { buildInsightsData } from './InsightsService';
+import { saveToHrm } from './ContactService';
+import { assignOfflineContact } from './ServerlessService';
+
+/**
+ * Function used to manually complete a task (making sure it transitions to wrapping state first).
+ */
+export const completeContactTask = async (task: ITask) => {
+  const { sid } = task;
+
+  if (task.status !== 'wrapping') {
+    if (task.channelType === channelTypes.voice) {
+      await Actions.invokeAction('HangupCall', { sid, task });
+    } else {
+      await Actions.invokeAction('WrapupTask', { sid, task });
+    }
+  }
+
+  await Actions.invokeAction('CompleteTask', { sid, task });
+};
+
+export const completeContactlessTask = async (task: ITask) => {
+  const { attributes } = task;
+  /*
+   * Don't record insights for this task,
+   * but null out the Task ID so the Insights record is clean.
+   */
+  const newAttributes = {
+    ...attributes,
+    skipInsights: true,
+    conversations: {
+      /* eslint-disable-next-line camelcase */
+      conversation_attribute_5: null,
+    },
+  };
+  await task.setAttributes(newAttributes);
+  await Actions.invokeAction('CompleteTask', { task });
+};
+
+export const completeTask = (task: ITask) =>
+  task.attributes.isContactlessTask ? completeContactlessTask(task) : completeContactTask(task);
+
+export const submitContactForm = async (task: ITask, contactForm: Contact, caseForm: Case) => {
+  const { hrmBaseUrl, workerSid, helpline } = getConfig();
+
+  if (task.attributes.isContactlessTask) {
+    const targetSid = 'WK76971332a884bf79ec378f98879d23c2';
+    const initialAttributes = { helpline, channelType: 'default', isContactlessTask: true, isInMyBehalf: true };
+    const finalAttributes = buildInsightsData(initialAttributes, contactForm, caseForm, {});
+    const contact = await saveToHrm(task, contactForm, hrmBaseUrl, workerSid, helpline);
+    const _newTask = await assignOfflineContact(targetSid, finalAttributes);
+    return contact;
+  }
+
+  const contact = await saveToHrm(task, contactForm, hrmBaseUrl, workerSid, helpline);
+  return contact;
+};

--- a/plugin-hrm-form/src/states/ContactFormStateFactory.js
+++ b/plugin-hrm-form/src/states/ContactFormStateFactory.js
@@ -1,5 +1,5 @@
 import { createStateItem } from '../components/common/forms/formGenerators';
-import { formDefinition as contactlessTaskTabDefinition } from '../components/tabbedForms/ContactlessTaskTabDefinition';
+import { createFormDefinition as createContactlessTaskTabDefinition } from '../components/tabbedForms/ContactlessTaskTabDefinition';
 
 export const ValidationType = {
   REQUIRED: 'REQUIRED', // Will not be applied if in the callerInformation tab and callType is not caller.  Will not be applied when callType is standalone.
@@ -617,7 +617,8 @@ export const createBlankForm = (formDef = defaultFormDefinition, recreated = fal
     categories: createCategoriesMetadata(formDef),
   };
 
-  const contactlessTask = contactlessTaskTabDefinition.reduce(createStateItem, {});
+  const initialContactlessTaskTabDefinition = createContactlessTaskTabDefinition([]);
+  const contactlessTask = initialContactlessTaskTabDefinition.reduce(createStateItem, {});
 
   const generatedForm = { ...initialState, metadata, contactlessTask };
 

--- a/plugin-hrm-form/src/states/contacts/reducer.ts
+++ b/plugin-hrm-form/src/states/contacts/reducer.ts
@@ -9,7 +9,7 @@ import {
   ContactFormDefinition,
 } from '../types';
 import { createStateItem } from '../../components/common/forms/formGenerators';
-import { formDefinition as contactlessTaskTabDefinition } from '../../components/tabbedForms/ContactlessTaskTabDefinition';
+import { createFormDefinition as createContactlessTaskTabDefinition } from '../../components/tabbedForms/ContactlessTaskTabDefinition';
 import callTypes, { CallTypes } from '../DomainConstants';
 
 export type TaskEntry = {
@@ -58,7 +58,8 @@ export const createNewTaskEntry = (definitions: ContactFormDefinition) => (recre
     categories: categoriesMeta,
   };
 
-  const contactlessTask = contactlessTaskTabDefinition.reduce(createStateItem, {});
+  const initialContactlessTaskTabDefinition = createContactlessTaskTabDefinition([]);
+  const contactlessTask = initialContactlessTaskTabDefinition.reduce(createStateItem, {});
 
   return {
     callType: '',

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -10,7 +10,6 @@ import QueuesStatusWriter from '../components/queuesStatus/QueuesStatusWriter';
 import QueuesStatus from '../components/queuesStatus';
 import CustomCRMContainer from '../components/CustomCRMContainer';
 import LocalizationContext from '../contexts/LocalizationContext';
-import { channelTypes } from '../states/DomainConstants';
 import Translator from '../components/translator';
 import CaseList from '../components/caseList';
 import StandaloneSearch from '../components/StandaloneSearch';
@@ -218,23 +217,6 @@ export const setUpNoTasksUI = setupObject => {
 };
 
 /**
- * Function used to manually complete a task (making sure it transitions to wrapping state first).
- * @param {string} sid
- * @param {import('@twilio/flex-ui').ITask} task
- */
-const onCompleteTask = async (sid, task) => {
-  if (task.status !== 'wrapping') {
-    if (task.channelType === channelTypes.voice) {
-      await Flex.Actions.invokeAction('HangupCall', { sid, task });
-    } else {
-      await Flex.Actions.invokeAction('WrapupTask', { sid, task });
-    }
-  }
-
-  Flex.Actions.invokeAction('CompleteTask', { sid, task });
-};
-
-/**
  * Add the custom CRM to the agent panel
  */
 export const setUpCustomCRMContainer = () => {
@@ -247,7 +229,7 @@ export const setUpCustomCRMContainer = () => {
       value={{ manager, isCallTask: Flex.TaskHelper.isCallTask }}
       key="custom-crm-container"
     >
-      <CustomCRMContainer handleCompleteTask={onCompleteTask} />
+      <CustomCRMContainer />
     </LocalizationContext.Provider>,
     options,
   );


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-500
This PR is related to https://github.com/tech-matters/serverless/pull/32

Notes:
- You can point to dev env for serverless in order to test this.
- This PR is better reviewed commit by commit.

This PR:
- Groups functions used to submit contact forms and finish tasks.
- Adds counselor dropdown to offline contact tab, in order to select in behalf of who is being submitted the contact.
- When an offline contact is submitted, a new serverless function (`assignOfflineContact`) is called. The purpose of this function is to create-assign-accept-complete a new Twilio task to the target counselor in order to create the insights for this record. 

The current behavior have some caveats/open questions:
  - The first task created (for the counselor submiting the contact form) also creates some insights. They are "cleaned up" as much as we can but they are still there.
  - The `twilioWorkerId` column of contact stored in the backend is the one of the issuer, not the target counselor. This causes the contact to appear in behalf of the issuer and not the target counselor. For this to be fixed we can either use the target counselor's sid in `twilioWorkerId` (but then the information that this task was submitted by issuer is lost, unless saved inside the raw json or a new column) or change the search query when contacts are offline contacts (this may slow down the query and increase it's complexity). Same happens for cases.

State of insights before and after an offline contact submission with Twitter channel (left is target counselor, right is issuer):
![Screenshot from 2021-02-19 15-31-36](https://user-images.githubusercontent.com/15805319/108553028-e115d300-72d0-11eb-983e-305d8cb50976.png)
![Screenshot from 2021-02-19 15-42-58](https://user-images.githubusercontent.com/15805319/108553037-e410c380-72d0-11eb-9043-7a32ce17963c.png)