### PR TITLE
Fixed Non-data contacts dialog size is too small

### DIFF
--- a/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
+++ b/plugin-hrm-form/src/styles/callTypeButtons/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'react-emotion';
-import Dialog from '@material-ui/core/Dialog';
+import Dialog, { DialogProps } from '@material-ui/core/Dialog';
 import ClearIcon from '@material-ui/icons/Clear';
 import { IconButton } from '@material-ui/core';
 import { Button, getBackgroundWithHoverCSS } from '@twilio/flex-ui';
@@ -66,11 +66,7 @@ export const NonDataCallTypeButton = styled(Button)<NonDataCallTypeButtonProps>`
   }
 `;
 
-type OwnCloseTaskDialogProps = {
-  classes: any;
-};
-
-export const CloseTaskDialog = styled(Dialog)<OwnCloseTaskDialogProps>`
+export const CloseTaskDialog = styled<DialogProps>(props => <Dialog {...props} classes={{ paper: 'paper' }} />)`
   && .paper {
     width: 350px;
   }


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-544

Primary reviewer: @GPaoloni 

Description:
Added `classes = { paper: 'paper' }` to CloseTaskDialog, with proper ts typing.

CloseTaskDialog now looks like the previous version:

![image](https://user-images.githubusercontent.com/12242771/109064594-5b779600-76c9-11eb-8150-b49d6e240087.png)
