### PR TITLE
Update ZA forms

### DIFF
--- a/plugin-hrm-form/src/formDefinitions/za-v1/LayoutDefinitions.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/LayoutDefinitions.json
@@ -1,6 +1,7 @@
 {
   "contact": {
     "callerInformation": {
+      "splitFormAt": 7
     },
     "childInformation": {
       "splitFormAt": 10

--- a/plugin-hrm-form/src/formDefinitions/za-v1/tabbedForms/ChildInformationTab.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/tabbedForms/ChildInformationTab.json
@@ -1312,8 +1312,8 @@
     "label": "Child on the move or in migration",
     "type": "select",
     "options": [
-      { "value": "Voluntary" },
-      { "value": "Involuntary" }
+      { "value": "Voluntary", "label": "Voluntary" },
+      { "value": "Involuntary", "label": "Involuntary" }
     ]
   },
   {
@@ -1341,9 +1341,10 @@
     "label": "Region",
     "type": "select",
     "options": [
-      { "value": "", "label": "" },
-      { "value": "Rural", "label": "Rural" },
-      { "value": "Urban", "label": "Urban" }
+      { "value": "Unknown", "label": "" },
+      { "value": "Cities", "label": "Cities" },
+      { "value": "Rural areas", "label": "Rural areas" },
+      { "value": "Town & semi-dense areas", "label": "Town & semi-dense areas" }
     ]
   }
 ]

--- a/plugin-hrm-form/src/formDefinitions/za-v1/tabbedForms/ChildInformationTab.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/tabbedForms/ChildInformationTab.json
@@ -1312,6 +1312,7 @@
     "label": "Child on the move or in migration",
     "type": "select",
     "options": [
+      { "value": "Unknown", "label": "" },
       { "value": "Voluntary", "label": "Voluntary" },
       { "value": "Involuntary", "label": "Involuntary" }
     ]


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-559
Primary reviewer: @GPaoloni 

Small fixes on the ZA forms:
- In Child Information tab, "Child on the move" values "Voluntary" and "Involuntary" are missing labels. (The label can match the field name)
- In Child Information tab, "Region" possible values should be Rural Areas, Towns & semi-dense areas, and cities (match Zambia)
- 
Layout:
- Caller Info tab - move District to first column to stay grouped with Province and Municipality


Screenshots of the 3 fixes:
![image](https://user-images.githubusercontent.com/1504544/110953482-52302f80-833f-11eb-917a-e6b18b662ee6.png)
![image](https://user-images.githubusercontent.com/1504544/110953536-62e0a580-833f-11eb-9c23-c69f2e7447e0.png)
![image](https://user-images.githubusercontent.com/1504544/110953570-6f64fe00-833f-11eb-98f5-1e6ab8eecb54.png)

