### PR TITLE
Use Office value in Flex-plugins

### DIFF
--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -357,6 +357,7 @@ const Case: React.FC<Props> = props => {
   const notes = timeline.filter(x => x.type === 'note');
   const summary = info?.summary;
   const definitionVersion = props.definitionVersions[version];
+  const office = connectedCase.helpline; // Office name is being stored in the helpline
 
   const addScreenProps = {
     task: props.task,
@@ -383,7 +384,7 @@ const Case: React.FC<Props> = props => {
     notes,
     summary,
     childIsAtRisk,
-    officeName: 'Gautang', // ToDo: add the office here.
+    office,
     version,
     contact: firstConnectedContact,
   };
@@ -433,6 +434,7 @@ const Case: React.FC<Props> = props => {
                 lastUpdatedDate={lastUpdatedDate}
                 followUpDate={followUpDate}
                 childIsAtRisk={childIsAtRisk}
+                office={office}
                 handlePrintCase={onPrintCase}
                 handleInfoChange={onInfoChange}
                 handleStatusChange={onStatusChange}

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -33,6 +33,7 @@ const CaseDetails = ({
   followUpDate,
   status,
   isEditing,
+  office,
   childIsAtRisk,
   handlePrintCase,
   handleInfoChange,
@@ -59,6 +60,7 @@ const CaseDetails = ({
         childName={name}
         counselor={counselor}
         childIsAtRisk={childIsAtRisk}
+        office={office}
         status={status}
         handlePrintCase={handlePrintCase}
         handleClickChildIsAtRisk={handleClickChildIsAtRisk}
@@ -149,6 +151,7 @@ CaseDetails.propTypes = {
   counselor: PropTypes.string.isRequired,
   openedDate: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
+  office: PropTypes.string,
   isEditing: PropTypes.bool.isRequired,
   followUpDate: PropTypes.string,
   lastUpdatedDate: PropTypes.string,
@@ -162,6 +165,7 @@ CaseDetails.propTypes = {
 };
 
 CaseDetails.defaultProps = {
+  office: '',
   followUpDate: '',
   lastUpdatedDate: '',
   isOrphanedCase: false,

--- a/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
+++ b/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
@@ -23,7 +23,7 @@ import { CaseStatus } from '../../../types/types';
 type OwnProps = {
   caseId: string;
   childName: string;
-  officeName: string;
+  office: string;
   counselor: string;
   childIsAtRisk: boolean;
   status: CaseStatus;
@@ -35,7 +35,7 @@ type OwnProps = {
 const CaseDetailsHeader: React.FC<OwnProps> = ({
   caseId,
   childName,
-  officeName,
+  office,
   counselor,
   childIsAtRisk,
   status,
@@ -52,7 +52,7 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({
             <Template code="Case-CaseNumber" />
             {caseId}
           </DetailsHeaderCaseId>
-          {officeName && <DetailsHeaderOfficeName>{officeName}</DetailsHeaderOfficeName>}
+          {office && <DetailsHeaderOfficeName>({office})</DetailsHeaderOfficeName>}
         </DetailsHeaderCaseContainer>
         <DetailsHeaderCounselor>
           <Template code="Case-Counsellor" />: {counselor}

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintDetails.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintDetails.tsx
@@ -14,7 +14,8 @@ type OwnProps = {
   followUpDate: string;
   childIsAtRisk: boolean;
   counselor: string;
-  caseManager: {
+  caseManager?: {
+    office: string;
     name: string;
     phone: string;
     email: string;
@@ -82,9 +83,9 @@ const CasePrintDetails: React.FC<Props> = ({
           </View>
           <View style={{ marginTop: 15, ...styles.flexColumn }}>
             <Text>{strings['Case-CaseManager']}</Text>
-            <Text style={styles.caseDetailsBoldText}>{caseManager.name}</Text>
-            <Text style={styles.caseDetailsBoldText}>{caseManager.phone}</Text>
-            <Text style={styles.caseDetailsBoldText}>{caseManager.email}</Text>
+            <Text style={styles.caseDetailsBoldText}>{caseManager?.name}</Text>
+            <Text style={styles.caseDetailsBoldText}>{caseManager?.phone}</Text>
+            <Text style={styles.caseDetailsBoldText}>{caseManager?.email}</Text>
           </View>
         </View>
         <View>

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
@@ -18,7 +18,7 @@ import CasePrintNotes from './CasePrintNotes';
 import CasePrintHeader from './CasePrintHeader';
 import CasePrintFooter from './CasePrintFooter';
 // import CasePrintContact from './CasePrintContact'; // Removed by ZA request, could be useful for other helplines.
-import { caseManager, officeName } from './mockedData';
+import { caseManagers } from './mockedData';
 import { getImageAsString, ImageSource } from './helpers';
 import { DefinitionVersion, FormDefinition } from '../../common/forms/types';
 import callTypes from '../../../states/DomainConstants';
@@ -56,6 +56,9 @@ const addExtraValues = (caseInformation: ContactRawJson['caseInformation']) => {
 
 const CasePrintView: React.FC<Props> = ({ onClickClose, caseDetails, definitionVersion, counselorsHash }) => {
   const { pdfImagesSource, strings } = getConfig();
+
+  // ToDo: replace this mocked list with another source in the future.
+  const caseManager = caseDetails.office ? caseManagers.find(m => m.office === caseDetails.office) : null;
 
   const logoSource = `${pdfImagesSource}/helpline-logo.png`;
   const chkOnSource = `${pdfImagesSource}/chk_1.png`;
@@ -124,7 +127,7 @@ const CasePrintView: React.FC<Props> = ({ onClickClose, caseDetails, definitionV
                 id={caseDetails.id}
                 firstName={caseDetails.name.firstName}
                 lastName={caseDetails.name.lastName}
-                officeName={officeName}
+                officeName={caseDetails.office}
                 logoBlob={logoBlob}
               />
               <View>

--- a/plugin-hrm-form/src/components/case/casePrint/mockedData.ts
+++ b/plugin-hrm-form/src/components/case/casePrint/mockedData.ts
@@ -1,8 +1,20 @@
 export const caseManagers = [
   {
+    office: 'National Office',
+    name: 'Bhavna Lutchman',
+    phone: '031 201 2059',
+    email: 'research@childlinesa.org.za',
+  },
+  {
     office: 'Gauteng',
     name: 'Bhavna Lutchman',
     phone: '031 201 2059',
     email: 'research@childlinesa.org.za',
+  },
+  {
+    office: 'Western Cape',
+    name: 'Nicole Paulsen',
+    phone: '21 762 8198',
+    email: 'info@childlinewc.org',
   },
 ];

--- a/plugin-hrm-form/src/components/case/casePrint/mockedData.ts
+++ b/plugin-hrm-form/src/components/case/casePrint/mockedData.ts
@@ -1,3 +1,8 @@
-export const caseManager = { name: 'Bhavna Lutchman', phone: '031 201 2059', email: 'research@childlinesa.org.za' };
-
-export const officeName = 'Gauteng';
+export const caseManagers = [
+  {
+    office: 'Gauteng',
+    name: 'Bhavna Lutchman',
+    phone: '031 201 2059',
+    email: 'research@childlinesa.org.za',
+  },
+];

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -143,7 +143,7 @@ export type CaseDetails = {
   notes: NoteActivity[];
   summary: string;
   childIsAtRisk: boolean;
-  officeName: string;
+  office?: string;
   version?: string;
   contact: any; // ToDo: change this
 };


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-522

Primary reviewer: @murilovmachado 

Changes:
1. Getting Office value from worker attributes.
2. Sending that value in each request to HRM (this was already done by sending the helpline attribute).
3. Displaying Office value in Case View Header and in Case Print PDF.
4. Mockup Case Manager values per each Office.