### PR TITLE
Support workers in multiple queues

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
+++ b/plugin-hrm-form/src/___tests__/components/queuesStatus/QueuesStatusWriter.test.js
@@ -15,7 +15,7 @@ jest.mock('../../../services/ServerlessService', () => ({
   },
 }));
 
-// console.log = jest.fn();
+console.log = jest.fn();
 console.error = jest.fn();
 
 const queues = { Q1: { queue_name: 'Q1' }, Admin: { queue_name: 'Admin' } };

--- a/plugin-hrm-form/src/components/queuesStatus/QueuesStatusWriter.jsx
+++ b/plugin-hrm-form/src/components/queuesStatus/QueuesStatusWriter.jsx
@@ -40,6 +40,7 @@ export class InnerQueuesStatusWriter extends React.Component {
   async componentDidMount() {
     try {
       await this.subscribeToQueuesUpdates();
+
       const workerQuery = await this.props.insightsClient.liveQuery(
         'tr-worker',
         `data.worker_sid == "${this.props.workerSid}"`,
@@ -50,7 +51,7 @@ export class InnerQueuesStatusWriter extends React.Component {
         await this.subscribeToQueuesUpdates();
       });
     } catch (err) {
-      handleSubscribeError(err);
+      this.handleSubscribeError(err);
     }
   }
 
@@ -99,7 +100,7 @@ export class InnerQueuesStatusWriter extends React.Component {
         }
       });
     } catch (err) {
-      handleSubscribeError(err);
+      this.handleSubscribeError(err);
     }
   }
 

--- a/plugin-hrm-form/src/components/queuesStatus/helpers.ts
+++ b/plugin-hrm-form/src/components/queuesStatus/helpers.ts
@@ -56,4 +56,4 @@ export const getNewQueuesStatus = (cleanQueuesStatus: QueuesStatus, tasks: any[]
 };
 
 export const isAnyChatPending = (queuesStatus: QueuesStatus): boolean =>
-  queuesStatus && Object.values(queuesStatus).reduce((acc, e) => e.isChatPending || acc, false);
+  queuesStatus && Object.values(queuesStatus).reduce<boolean>((acc, e) => e.isChatPending || acc, false);

--- a/plugin-hrm-form/src/services/ServerlessService.ts
+++ b/plugin-hrm-form/src/services/ServerlessService.ts
@@ -105,6 +105,17 @@ export const sendSystemMessage = async (body: { taskSid: ITask['taskSid']; messa
 };
 
 /**
+ * Returns the task queues list for a given worker.
+ */
+export const listWorkerQueues = async (body: {
+  workerSid: string;
+}): Promise<{ workerQueues: { friendlyName: string }[] }> => {
+  const response = await fetchProtectedApi('/listWorkerQueues', body);
+
+  return response;
+};
+
+/**
  * Function that mimics the fetching of a version definition for all the forms used within the app.
  * Later on this will be fetched in async way.
  */

--- a/plugin-hrm-form/src/utils/setUpComponents.js
+++ b/plugin-hrm-form/src/utils/setUpComponents.js
@@ -75,13 +75,13 @@ const addButtonsUI = setupObject => {
  * @param {ReturnType<typeof getConfig> & { translateUI: (language: string) => Promise<void>; getMessage: (messageKey: string) => (language: string) => Promise<string>; }} setupObject
  */
 export const setUpQueuesStatusWriter = setupObject => {
-  const { helpline } = setupObject;
+  const { helpline, workerSid } = setupObject;
 
   Flex.MainContainer.Content.add(
     <QueuesStatusWriter
       insightsClient={Flex.Manager.getInstance().insightsClient}
       key="queue-status-writer"
-      helpline={helpline}
+      workerSid={workerSid}
     />,
     {
       sortOrder: -1,


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-548
This PR is related to https://github.com/tech-matters/serverless/pull/34
Primary reviewer: @andvirga 

This PR:
- Fetches all the matching queues for the worker, and subscribes to all of them. This is shown in the "Contacts Waiting" widget, and also allows the worker to "Add another task" from any of those queues.
- If worker attributes are updated, call the above again just in case the worker matches different queues this time.

To test this PR:
- Point to serverless dev env.
- Add `"routing":{"skills":["chat"]} `to your worker attributes in Twilio console.
- Check that both queues works for you, that you can pull tasks from both.
- Check that if you change your worker's attributes (to unsubscribe from a queue then re-subscribe), the queues widget should update without a page reload.