### PR TITLE
Added optional default value for select input type

### DIFF
--- a/plugin-hrm-form/src/___tests__/FieldText.test.js
+++ b/plugin-hrm-form/src/___tests__/FieldText.test.js
@@ -1,17 +1,10 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
+import './mockStyled';
+
 import FieldText from '../components/FieldText';
 import { ValidationType } from '../states/ContactFormStateFactory';
-
-jest.mock('../styles/HrmStyles', () => {
-  return {
-    StyledInput: 'StyledInput',
-    StyledLabel: 'StyledLabel',
-    ErrorText: 'ErrorText',
-    TextField: 'TextField',
-  };
-});
 
 // TODO: Improve assertion for all tests below
 test('render basic FieldText', () => {

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -66,6 +66,7 @@ jest.mock('../styles/HrmStyles', () => ({
   CategoryCheckboxLabel: 'CategoryCheckboxLabel',
   CategoryCheckboxField: 'CategoryCheckboxField',
   TaskCanvasOverride: 'TaskCanvasOverride',
+  PopoverText: 'PopoverText',
 }));
 
 jest.mock('../styles/search', () => ({

--- a/plugin-hrm-form/src/___tests__/states/ContactFormStateFactory.test.js
+++ b/plugin-hrm-form/src/___tests__/states/ContactFormStateFactory.test.js
@@ -1,5 +1,7 @@
 import { omit } from 'lodash';
 
+import '../mockGetConfig';
+
 import {
   FieldType,
   createBlankForm,

--- a/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
+++ b/plugin-hrm-form/src/components/common/forms/formGenerators.tsx
@@ -40,7 +40,7 @@ export const getInitialValue = (def: FormItemDefinition) => {
     case 'time-input':
       return '';
     case 'select':
-      return def.options[0].value;
+      return def.defaultOption ? def.defaultOption : def.options[0].value;
     case 'dependent-select':
       return def.defaultOption.value;
     case 'checkbox':

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -52,6 +52,7 @@ export type SelectOption = { value: any; label: string };
 type SelectDefinition = {
   type: 'select';
   options: SelectOption[];
+  defaultOption?: SelectOption['value'];
 } & ItemBase &
   RegisterOptions;
 

--- a/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
+++ b/plugin-hrm-form/src/components/tabbedForms/ContactlessTaskTabDefinition.ts
@@ -5,6 +5,7 @@ import type { FormDefinition } from '../common/forms/types';
 import { mapChannelForInsights } from '../../utils/mappers';
 import { splitDate } from '../../utils/helpers';
 import type { CounselorsList } from '../../states/configuration/types';
+import { getConfig } from '../../HrmFormPlugin';
 
 const channelOptions = [{ value: '', label: '' }].concat(
   [...Object.values(channelTypes), ...Object.values(otherContactChannels)].map(s => ({
@@ -14,6 +15,7 @@ const channelOptions = [{ value: '', label: '' }].concat(
 );
 
 export const createFormDefinition = (counselorsList: CounselorsList): FormDefinition => {
+  const { workerSid } = getConfig();
   const counsellorOptions = [
     { label: '', value: '' },
     ...counselorsList.map(c => ({ label: c.fullName, value: c.sid })),
@@ -32,6 +34,7 @@ export const createFormDefinition = (counselorsList: CounselorsList): FormDefini
       type: 'select',
       label: 'Counsellor',
       options: counsellorOptions,
+      defaultOption: workerSid,
       required: { value: true, message: 'RequiredFieldError' },
     },
     {


### PR DESCRIPTION
This PR is addressing a comment @dee-luo left in the task https://bugs.benetech.org/browse/CHI-500.
> 2. Is there anyway we're able to default the counselor drop-down in the form to the counselor that is logged in? Let me know if that's not easy to do.

In order to do this:
- `defaultOption` value is added as optional property of select input definitions.
- `defaultOption` with value of self counselor added to offline form tab definition.