### PR TITLE
Upgrade to Flex 1.25.2

### DIFF
--- a/plugin-hrm-form/package-lock.json
+++ b/plugin-hrm-form/package-lock.json
@@ -1336,68 +1336,28 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@gooddata/gooddata-js": {
-      "version": "11.19.1",
-      "resolved": "https://registry.npmjs.org/@gooddata/gooddata-js/-/gooddata-js-11.19.1.tgz",
-      "integrity": "sha512-on99qRdFtCs6QmnYFvlh8pBIR7HeaLVO9EwB7bLctXp5iT7O7aVmVTk//eZL/2fCx/b6bvTwjGZoh0IKvpeuXg==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@gooddata/gooddata-js/-/gooddata-js-13.2.0.tgz",
+      "integrity": "sha512-+EN2Gb9/5lptexllGt/0Mpq/jF4I4Hn4VwfQtWQopXve8b7s4OvUzyjC82Hy1U2a3oOwlH0KqnUFSJCoyVAzWQ==",
       "dev": true,
       "requires": {
-        "@gooddata/typings": "^2.18.0",
-        "es6-promise": "^3.0.2",
-        "fetch-cookie": "^0.7.0",
+        "@gooddata/typings": "^2.27.0",
+        "fetch-cookie": "^0.11.0",
         "invariant": "^2.2.2",
-        "isomorphic-fetch": "^2.2.1",
+        "isomorphic-fetch": "^3.0.0",
         "json-stable-stringify": "^1.0.1",
-        "lodash": "^4.7.11",
+        "lodash": "^4.17.20",
         "md5": "^2.2.1",
-        "node-fetch": "^1.7.3",
+        "node-fetch": "^2.6.1",
         "qs": "^6.5.1",
-        "rxjs": "^5.5.6",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        },
-        "rxjs": {
-          "version": "5.5.12",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-          "dev": true,
-          "requires": {
-            "symbol-observable": "1.0.1"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
+        "rxjs": "^6.3.1",
+        "uuid": "^8.3.1"
       }
     },
     "@gooddata/typings": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@gooddata/typings/-/typings-2.27.0.tgz",
-      "integrity": "sha512-vB9/BQHtWHZtTl/LgO/Hsl8xr8YlmHy61kbj7A316Ana08H2wnqV8Y8ZjlVf94bHq9Hza7ViF7urhbCbfP8PFA==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@gooddata/typings/-/typings-2.28.0.tgz",
+      "integrity": "sha512-v8nk8b2aIy2A6h88m3ec37TSbZk8CbBQ0FSLES5zu1cGka2z/JCGgKUNnAy46z/ieuR+/8c8QzXKwXPC1t5DkQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.11"
@@ -1779,9 +1739,9 @@
       }
     },
     "@material-ui/core": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.3.tgz",
-      "integrity": "sha512-REIj62+zEvTgI/C//YL4fZxrCVIySygmpZglsu/Nl5jPqy3CDjZv1F9ubBYorHqmRgeVPh64EghMMWqk4egmfg==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.4.tgz",
+      "integrity": "sha512-r8QFLSexcYZbnqy/Hn4v8xzmAJV41yaodUVjmbGLi1iGDLG3+W941hEtEiBmxTRRqv2BdK3r4ijILcqKmDv/Sw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.2.0",
@@ -2196,31 +2156,33 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-          "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==",
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+          "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
           "dev": true
         }
       }
     },
     "@twilio/flex-ui": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.23.4.tgz",
-      "integrity": "sha512-vlPeavUqK/J1OhiKmnEF7KHcy4Jmvc1IYqIkpeysu+QWKmFhzGG3spxQkGvmcLvd4U+mIElDAxc7r8f/CDeeeQ==",
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui/-/flex-ui-1.25.2.tgz",
+      "integrity": "sha512-lUq75L17s7qr7vJbrnvPbXqB/hZaEd7/m4CijKQ2RQQGEyc+XF/PZwxn3Ynt/TFabdzJagRmyPhZIl0w7s9z/A==",
       "dev": true,
       "requires": {
-        "@gooddata/gooddata-js": "11.19.1",
-        "@material-ui/core": "3.9.3",
+        "@gooddata/gooddata-js": "13.2.0",
+        "@material-ui/core": "3.9.4",
         "@material-ui/lab": "3.0.0-alpha.30",
         "@twilio/flex-insights-identity-client-js": "2.0.5",
         "@twilio/flex-insights-player": "2.3.1",
         "@twilio/flex-sdk": "0.4.3",
-        "@twilio/flex-ui-core": "0.46.2",
-        "@twilio/player": "1.0.0-beta.13",
-        "@types/react-select": "^3.0.23",
+        "@twilio/flex-ui-core": "0.50.5",
+        "@twilio/player": "1.0.0-beta.16",
+        "@types/deep-diff": "^1.0.0",
+        "@types/react-select": "2.0.19",
         "async-sema": "^3.0.0",
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "core-js": "^3.0.1",
+        "deep-diff": "^1.0.2",
         "emotion": "9.2.6",
         "emotion-theming": "9.2.6",
         "eventemitter3": "4.0.0",
@@ -2241,56 +2203,30 @@
         "react-router": "4.3.1",
         "react-router-dom": "4.3.1",
         "react-router-redux": "5.0.0-alpha.9",
+        "react-select": "2.4.3",
         "redux": "3.7.2",
         "redux-logger": "3.0.6",
         "redux-promise-middleware": "4.2.1",
         "reselect": "4.0.0",
         "semver": "~5.7.0",
         "twilio-chat": "~3.4.0",
-        "twilio-client": "1.11.0",
+        "twilio-client": "1.13.1",
         "twilio-sync": "^0.12.3",
         "twilio-taskrouter": "^0.5.2",
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        },
         "core-js": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-          "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==",
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+          "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
           "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
         },
         "eventemitter3": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
           "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
           "dev": true
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
         },
         "loglevel": {
           "version": "1.6.7",
@@ -2323,12 +2259,12 @@
       }
     },
     "@twilio/flex-ui-core": {
-      "version": "0.46.2",
-      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.46.2.tgz",
-      "integrity": "sha512-7B2f68K6RydTOF+RDEchQXGDpworE/RXMQo5i3TZuqd/vIQ8B0qr/60XfBuA8BjYbL4rxpXxOF7hMmxMB2D9Sg==",
+      "version": "0.50.5",
+      "resolved": "https://registry.npmjs.org/@twilio/flex-ui-core/-/flex-ui-core-0.50.5.tgz",
+      "integrity": "sha512-erT8CRQguTyVlixN1O3uMvk1bAY0wbtKnihzGxk5LcTWmDcIvr2R2Ma6MNhIcOq2vaVx5GOXIcyBUSVmVk3iyg==",
       "dev": true,
       "requires": {
-        "@material-ui/core": "3.9.3",
+        "@material-ui/core": "3.9.4",
         "@material-ui/icons": "2.0.3",
         "@twilio/flex-sdk": "0.4.3",
         "core-js": "^3.0.1",
@@ -2337,7 +2273,6 @@
         "emotion-theming": "9.2.6",
         "google-libphonenumber": "3.2.6",
         "handlebars": "4.7.6",
-        "hex-rgb": "3.0.0",
         "hoist-non-react-statics": "3.3.0",
         "lodash.debounce": "4.0.8",
         "loglevel": "1.6.7",
@@ -2357,9 +2292,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-          "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==",
+          "version": "3.9.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+          "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
           "dev": true
         },
         "hoist-non-react-statics": {
@@ -2402,9 +2337,9 @@
       }
     },
     "@twilio/player": {
-      "version": "1.0.0-beta.13",
-      "resolved": "https://registry.npmjs.org/@twilio/player/-/player-1.0.0-beta.13.tgz",
-      "integrity": "sha512-L+fcYp+P2t4gMsYXhYJLZHZzeer899pPE3g5uSLFdAsiJzNF2EFrmrgQ8r8biVtnRGM1Ug96uIE6bJJU0n+2jA==",
+      "version": "1.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@twilio/player/-/player-1.0.0-beta.16.tgz",
+      "integrity": "sha512-jSLQgJf7gaZqYEpn6Do3V30HBUk64N4OlbR8qnkyTjuxSntrvMuRCnZwrhx6tdR2GSTk3JRQjK2AD33ZtAWR8g==",
       "dev": true,
       "requires": {
         "debounce": "^1.2.0",
@@ -2473,6 +2408,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/deep-diff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/deep-diff/-/deep-diff-1.0.0.tgz",
+      "integrity": "sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw==",
+      "dev": true
     },
     "@types/enzyme": {
       "version": "3.10.8",
@@ -2710,9 +2651,9 @@
       }
     },
     "@types/react-select": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-3.1.2.tgz",
-      "integrity": "sha512-ygvR/2FL87R2OLObEWFootYzkvm67LRA+URYEAcBuvKk7IXmdsnIwSGm60cVXGaqkJQHozb2Cy1t94tCYb6rJA==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-2.0.19.tgz",
+      "integrity": "sha512-5GGBO3npQ0G/poQmEn+kI3Vn3DoJ9WjRXCeGcpwLxd5rYmjYPH235lbYPX5aclXE2RqEXyFxd96oh0wYwPXYpg==",
       "dev": true,
       "requires": {
         "@types/react": "*",
@@ -5605,9 +5546,9 @@
       "integrity": "sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA=="
     },
     "debounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
       "dev": true
     },
     "debug": {
@@ -5652,9 +5593,9 @@
       }
     },
     "deep-diff": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
       "dev": true
     },
     "deep-equal": {
@@ -6520,12 +6461,6 @@
         "next-tick": "~1.0.0"
       }
     },
-    "es6-denodeify": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-denodeify/-/es6-denodeify-0.1.5.tgz",
-      "integrity": "sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8=",
-      "dev": true
-    },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
@@ -6535,12 +6470,6 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
-    },
-    "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.3",
@@ -7715,6 +7644,32 @@
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+          "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+          "dev": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
         "promise": {
           "version": "7.3.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -7727,25 +7682,12 @@
       }
     },
     "fetch-cookie": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.7.3.tgz",
-      "integrity": "sha512-rZPkLnI8x5V+zYAiz8QonAHsTb4BY+iFowFBI1RFn0zrO343AVp9X7/yUj/9wL6Ef/8fLls8b/vGtzUvmyAUGA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.11.0.tgz",
+      "integrity": "sha512-BQm7iZLFhMWFy5CZ/162sAGjBfdNWb7a8LEqqnzsHFhxT/X/SVj/z2t2nu3aJvjlbQkrAlTUApplPRjWyH4mhA==",
       "dev": true,
       "requires": {
-        "es6-denodeify": "^0.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "dependencies": {
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
-          }
-        }
+        "tough-cookie": "^2.3.3 || ^3.0.1 || ^4.0.0"
       }
     },
     "figgy-pudding": {
@@ -8783,12 +8725,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
-    "hex-rgb": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-3.0.0.tgz",
-      "integrity": "sha512-iWOUTZu7KQGhErV8JfTQDH5F/M2D0HVd0sexS4Grg4e4RYAiN3c4jfpPqKgfedqeebKcNZBl2z3zlgCtFjpFJQ==",
-      "dev": true
-    },
     "history": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
@@ -9626,31 +9562,13 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
       "dev": true,
       "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
       }
     },
     "isstream": {
@@ -12260,6 +12178,12 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
+      "dev": true
+    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -14540,6 +14464,15 @@
         "prop-types": "^15.6.1"
       }
     },
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -14664,6 +14597,21 @@
         "history": "^4.7.2",
         "prop-types": "^15.6.0",
         "react-router": "^4.2.0"
+      }
+    },
+    "react-select": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.3.tgz",
+      "integrity": "sha512-cmxNaiHpviRYkojeW9rGEUJ4jpX7QTmPe2wcscwA4d1lStzw/cJtr4ft5H2O/YhfpkrcwaLghu3XmEYdXhBo8Q==",
+      "dev": true,
+      "requires": {
+        "classnames": "^2.2.5",
+        "emotion": "^9.1.2",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "raf": "^3.4.0",
+        "react-input-autosize": "^2.2.1",
+        "react-transition-group": "^2.2.1"
       }
     },
     "react-test-renderer": {
@@ -14825,6 +14773,14 @@
       "dev": true,
       "requires": {
         "deep-diff": "^0.3.5"
+      },
+      "dependencies": {
+        "deep-diff": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+          "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=",
+          "dev": true
+        }
       }
     },
     "redux-mock-store": {
@@ -16985,9 +16941,9 @@
       }
     },
     "twilio-client": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/twilio-client/-/twilio-client-1.11.0.tgz",
-      "integrity": "sha512-4+ScQQzvgBP4sRTskeTYTP61bu4BbCZSGdvV3YHF6Z5qQLmGKiUDL2S4b9DxLfXOpwL26UDdwMbx4yySDXVN0Q==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/twilio-client/-/twilio-client-1.13.1.tgz",
+      "integrity": "sha512-Bf7fVleqC6exXcPCE6BLalDeklfqHB3WiZTqP9t0r90qZtYFz/reHJXIw+re6Y9DqqrA7inV+zd5Kceey7MQxw==",
       "dev": true,
       "requires": {
         "@twilio/audioplayer": "1.0.6",
@@ -17204,9 +17160,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
-      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.2.tgz",
+      "integrity": "sha512-SbMu4D2Vo95LMC/MetNaso1194M1htEA+JrqE9Hk+G2DhI+itfS9TRu9ZKeCahLDNa/J3n4MqUJ/fOHMzQpRWw==",
       "dev": true,
       "optional": true
     },
@@ -17532,8 +17488,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",
@@ -17736,9 +17691,9 @@
       }
     },
     "wavesurfer.js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-4.5.0.tgz",
-      "integrity": "sha512-yWSusLHwokPpTWwYjW5hhzGjyKfELLs0ss6GQuvRRrKKLtPd8A8wetveFzNXP0FJjaZ/baoFYX1h048CcCTNlA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-4.6.0.tgz",
+      "integrity": "sha512-+nn6VD86pTtRu9leVNXoIGOCMJyaTNsKNy9v+SfUsYo+SxLCQvEzrZZ/eKMImqspsk+BX1V1xlY4FRkHswu3fA==",
       "dev": true
     },
     "wbuf": {

--- a/plugin-hrm-form/package.json
+++ b/plugin-hrm-form/package.json
@@ -35,7 +35,7 @@
     "@testing-library/dom": "^7.21.0",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^10.4.7",
-    "@twilio/flex-ui": "1.23",
+    "@twilio/flex-ui": "1.25.2",
     "@types/jest": "^26.0.20",
     "@types/react-redux": "^7.1.16",
     "@typescript-eslint/parser": "^3.8.0",

--- a/plugin-hrm-form/src/___tests__/utils/sharedState.test.js
+++ b/plugin-hrm-form/src/___tests__/utils/sharedState.test.js
@@ -155,22 +155,25 @@ describe('Test with connected sharedState', () => {
 describe('Test throwing errors', () => {
   const error = jest.fn();
   console.error = error;
+  beforeEach(() => {
+    error.mockReset();
+  });
 
   test('saveFormSharedState', async () => {
     const { saveFormSharedState } = require('../../utils/sharedState');
 
+    expect(error).not.toBeCalled();
     const documentName = await saveFormSharedState(form, task);
     expect(documentName).toBeNull();
-    expect(console.error).toBeCalled();
-    error.mockReset();
+    expect(error).toBeCalled();
   });
 
   test('loadFormSharedState', async () => {
     const { loadFormSharedState } = require('../../utils/sharedState');
 
+    expect(error).not.toBeCalled();
     const loadedForm = await loadFormSharedState(task);
     expect(loadedForm).toBeNull();
-    expect(console.error).toBeCalled();
-    error.mockReset();
+    expect(error).toBeCalled();
   });
 });


### PR DESCRIPTION
Upgrades Flex UI to version 1.25.2 and its dependencies

Primary reviewer: @andvirga 

Here are some relevant updates from the [changelog](https://www.twilio.com/docs/flex/release-notes/ui-release-notes#v-1252):
* Transfers:
  * It will no longer be possible to transfer to the agent that is unavailable
  * Transfer Directory will now close automatically when switching between tasks
* Fixed token refresh issue - invalidated sessions will no longer update the access token
* Worker has no longer access to the incoming task content after refreshing the page