### PR TITLE
PDF error fixing and improvements

### DIFF
--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintSection.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintSection.tsx
@@ -27,7 +27,7 @@ const CasePrintSection: React.FC<Props> = ({ sectionName, values, definitions, u
           return (
             <View key={i} style={i % 2 === 0 ? styles.sectionItemRowOdd : styles.sectionItemRowEven}>
               <View style={styles.sectionItemFirstColumn}>
-                <Text style={{ width: '95%' }}>{def.label}</Text>
+                <Text style={{ marginRight: '10px' }}>{def.label}</Text>
               </View>
               <View style={styles.sectionItemSecondColumn}>
                 <Text>{presentValue(unNestInfo ? unNestInformation(def, values) : values[def.name])(def)}</Text>

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintSection.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintSection.tsx
@@ -26,10 +26,14 @@ const CasePrintSection: React.FC<Props> = ({ sectionName, values, definitions, u
         {definitions.map((def, i) => {
           return (
             <View key={i} style={i % 2 === 0 ? styles.sectionItemRowOdd : styles.sectionItemRowEven}>
-              <Text style={styles.sectionItemFirstColumn}>{def.label}</Text>
-              <Text style={styles.sectionItemSecondColumn}>
-                {presentValue(unNestInfo ? unNestInformation(def, values) : values[def.name])(def)}
-              </Text>
+              <View style={styles.sectionItemFirstColumn}>
+                <Text style={{ width: '95%' }}>{def.label}</Text>  
+              </View>
+              <View style={styles.sectionItemSecondColumn}>
+                <Text>
+                  {presentValue(unNestInfo ? unNestInformation(def, values) : values[def.name])(def)}
+                </Text>
+              </View>
             </View>
           );
         })}

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintSection.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintSection.tsx
@@ -27,12 +27,10 @@ const CasePrintSection: React.FC<Props> = ({ sectionName, values, definitions, u
           return (
             <View key={i} style={i % 2 === 0 ? styles.sectionItemRowOdd : styles.sectionItemRowEven}>
               <View style={styles.sectionItemFirstColumn}>
-                <Text style={{ width: '95%' }}>{def.label}</Text>  
+                <Text style={{ width: '95%' }}>{def.label}</Text>
               </View>
               <View style={styles.sectionItemSecondColumn}>
-                <Text>
-                  {presentValue(unNestInfo ? unNestInformation(def, values) : values[def.name])(def)}
-                </Text>
+                <Text>{presentValue(unNestInfo ? unNestInformation(def, values) : values[def.name])(def)}</Text>
               </View>
             </View>
           );

--- a/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
+++ b/plugin-hrm-form/src/components/case/casePrint/CasePrintView.tsx
@@ -41,7 +41,7 @@ const extraFieldDefinitions = (strings: Strings<string>): FormDefinition => {
     {
       name: 'okForCaseWorkerToCall',
       label: strings['ContactDetails-GeneralDetails-OKToCall'],
-      type: 'checkbox',
+      type: 'mixed-checkbox',
     },
   ];
 };
@@ -49,7 +49,7 @@ const extraFieldDefinitions = (strings: Strings<string>): FormDefinition => {
 const addExtraValues = (caseInformation: ContactRawJson['caseInformation']) => {
   return {
     keepConfidential: Boolean(caseInformation?.keepConfidential),
-    okForCaseWorkerToCall: Boolean(caseInformation?.okForCaseWorkerToCall),
+    okForCaseWorkerToCall: caseInformation?.okForCaseWorkerToCall,
   };
 };
 

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -241,7 +241,7 @@
   "ContactDetails-GeneralDetails-ReferredTo": "Referred To",
   "ContactDetails-GeneralDetails-ChildHearAboutUs": "How did the child hear about us?",
   "ContactDetails-GeneralDetails-KeepConfidential": "Keep Confidential?",
-  "ContactDetails-GeneralDetails-OKToCall": "OK for case worker to call?",
+  "ContactDetails-GeneralDetails-OKToCall": "May social worker call/SMS?",
   "ContactDetails-GeneralDetails-DiscussRights": "Did you discuss rights with the child?",
   "ContactDetails-GeneralDetails-SolvedProblem": "Did the child feel we solved their problem?",
   "ContactDetails-GeneralDetails-WouldRecommend": "Would the child recommend us to a friend?",


### PR DESCRIPTION
This PR contains changes requested for [CHI-515](https://bugs.benetech.org/browse/CHI-515).

Primary reviewer: @GPaoloni 

Changes summary:

1. Added a tiny space between the two text columns that makes long texts occupy another line instead of being too long (for example: Is the perpetrator still in contact with the child? now occupies two lines).
2. Renamed "OK for case worker to call?" to "May social worker call/SMS?" and fixed the incorrect value display (this field is now a multi checkbox and its values can be: Yes, No, Unknown).