### PR TITLE
Map helpline value to Insights

### DIFF
--- a/plugin-hrm-form/src/formDefinitions/za-v1/insights/oneToManyConfigSpecs.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/insights/oneToManyConfigSpecs.json
@@ -7,5 +7,10 @@
       "contactForm.childInformation.municipality",
       "contactForm.childInformation.district"
     ]
+  },
+  {
+    "attributeName": "conversation_attribute_8",
+    "insightsObject": "conversations",
+    "paths": ["taskAttributes.helpline"]
   }
 ]

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -249,10 +249,10 @@ export const processHelplineConfig = (
 };
 
 const applyCustomUpdate = (customUpdate: OneToManyConfigSpec): InsightsUpdateFunction => {
-  return (attributes, contactForm, caseForm) => {
+  return (taskAttributes, contactForm, caseForm) => {
     if (isNonDataCallType(contactForm.callType)) return {};
 
-    const dataSource = { contactForm, caseForm };
+    const dataSource = { contactForm, caseForm, taskAttributes };
     // concatenate the values, taken from dataSource using paths (e.g. 'contactForm.childInformation.province')
     const value = customUpdate.paths.map(path => get(dataSource, path, '')).join(delimiter);
 

--- a/plugin-hrm-form/src/services/InsightsService.ts
+++ b/plugin-hrm-form/src/services/InsightsService.ts
@@ -252,7 +252,7 @@ const applyCustomUpdate = (customUpdate: OneToManyConfigSpec): InsightsUpdateFun
   return (taskAttributes, contactForm, caseForm) => {
     if (isNonDataCallType(contactForm.callType)) return {};
 
-    const dataSource = { contactForm, caseForm, taskAttributes };
+    const dataSource = { taskAttributes, contactForm, caseForm };
     // concatenate the values, taken from dataSource using paths (e.g. 'contactForm.childInformation.province')
     const value = customUpdate.paths.map(path => get(dataSource, path, '')).join(delimiter);
 
@@ -295,7 +295,6 @@ export const mergeAttributes = (
   };
 };
 
-// In TS, how do we say that we are returning a function?
 const getInsightsUpdateFunctionsForConfig = (
   customInsights: DefinitionVersion['insights'],
 ): InsightsUpdateFunction[] => {


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-584

This PR:
- Adds task attributes (as `taskAttributes`) to the possible paths to retrieve data from in `applyCustomUpdate`.
- `taskAttributes.helpline` added to `conversation_attribute_8` for ZA.