### PR TITLE
Front-end Permissions 

### DIFF
--- a/plugin-hrm-form/src/HrmFormPlugin.js
+++ b/plugin-hrm-form/src/HrmFormPlugin.js
@@ -36,6 +36,7 @@ export const getConfig = () => {
   const currentWorkspace = manager.serviceConfiguration.taskrouter_workspace_sid;
   const { identity, token } = manager.user;
   const counselorName = manager.workerClient.attributes.full_name;
+  const isSupervisor = manager.workerClient.attributes.roles.includes('supervisor');
   const {
     configuredLanguage,
     definitionVersion,
@@ -58,6 +59,7 @@ export const getConfig = () => {
     identity,
     token,
     counselorName,
+    isSupervisor,
     featureFlags,
     sharedStateClient,
     strings,

--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.js
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.js
@@ -22,6 +22,12 @@ jest.mock('react', () => ({
   useState: jest.fn(),
 }));
 jest.mock('../../../services/CaseService', () => ({ getActivities: jest.fn(() => []), cancelCase: jest.fn() }));
+jest.mock('../../../permissions', () => ({
+  getPermissionsForCase: jest.fn(() => ({
+    can: () => true,
+  })),
+  PermissionActions: {},
+}));
 
 /**
  * Fix issue with Popper.js:

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -283,13 +283,6 @@ const Case: React.FC<Props> = props => {
     props.updateCaseInfo(newInfo, props.task.taskSid);
   };
 
-  /**
-   * Setting this flag in the first render.
-   */
-  const [isEditing, setIsEditing] = useState(
-    props.connectedCaseState?.connectedCase && props.connectedCaseState?.connectedCase?.status === 'open',
-  );
-
   if (!props.connectedCaseState) return null;
 
   const { task, form, counselorsHash } = props;
@@ -318,7 +311,6 @@ const Case: React.FC<Props> = props => {
       if (props.updateAllCasesView) {
         props.updateAllCasesView(updatedCase);
       }
-      setIsEditing(connectedCase.status === 'open');
     } catch (error) {
       console.error(error);
       window.alert(strings['Error-Backend']);
@@ -514,11 +506,9 @@ const Case: React.FC<Props> = props => {
                     <Template code="BottomBar-Close" />
                   </StyledNextStepButton>
                 </Box>
-                {isEditing && (
-                  <StyledNextStepButton disabled={!caseHasBeenEdited} roundCorners onClick={handleUpdate}>
-                    <Template code="BottomBar-Update" />
-                  </StyledNextStepButton>
-                )}
+                <StyledNextStepButton disabled={!caseHasBeenEdited} roundCorners onClick={handleUpdate}>
+                  <Template code="BottomBar-Update" />
+                </StyledNextStepButton>
               </>
             )}
           </BottomButtonBar>

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -340,7 +340,7 @@ const Case: React.FC<Props> = props => {
   const fullName = splitFullName(name);
   const categories = getCategories(firstConnectedContact);
   const { createdAt, updatedAt, twilioWorkerId, status, info } = connectedCase || {};
-  const { workerSid } = getConfig(); // -- Gets the current counselor that is using the application.
+  const { workerSid, isSupervisor } = getConfig(); // -- Gets the current counselor that is using the application.
   const caseCounselor = counselorsHash[twilioWorkerId];
   const currentCounselor = counselorsHash[workerSid];
   const openedDate = getLocaleDateTime(createdAt);
@@ -389,6 +389,15 @@ const Case: React.FC<Props> = props => {
     contact: firstConnectedContact,
   };
 
+  const canEditFields = workerSid === twilioWorkerId && status === 'open';
+  let canEditCaseSummary = false;
+
+  if (version === 'v1') {
+    canEditCaseSummary = isSupervisor || canEditFields;
+  } else if (version === 'za-v1') {
+    canEditCaseSummary = isSupervisor;
+  }
+
   switch (subroute) {
     case 'add-note':
       return <AddNote {...addScreenProps} />;
@@ -427,6 +436,7 @@ const Case: React.FC<Props> = props => {
                 caseId={connectedCase.id}
                 name={fullName}
                 status={status}
+                canEditFields={canEditFields}
                 isEditing={isEditing}
                 counselor={caseCounselor}
                 categories={categories}
@@ -444,12 +454,18 @@ const Case: React.FC<Props> = props => {
               />
             </Box>
             <Box marginLeft="25px" marginTop="25px">
-              <Timeline timelineActivities={timeline} caseObj={connectedCase} task={task} form={form} status={status} />
+              <Timeline
+                timelineActivities={timeline}
+                caseObj={connectedCase}
+                task={task}
+                form={form}
+                canEditFields={canEditFields}
+              />
             </Box>
             <Box marginLeft="25px" marginTop="25px">
               <Households
                 households={households}
-                status={status}
+                canEditFields={canEditFields}
                 onClickAddHousehold={onClickAddHousehold}
                 onClickView={onClickViewHousehold}
               />
@@ -457,7 +473,7 @@ const Case: React.FC<Props> = props => {
             <Box marginLeft="25px" marginTop="25px">
               <Perpetrators
                 perpetrators={perpetrators}
-                status={status}
+                canEditFields={canEditFields}
                 onClickAddPerpetrator={onClickAddPerpetrator}
                 onClickView={onClickViewPerpetrator}
               />
@@ -467,12 +483,12 @@ const Case: React.FC<Props> = props => {
                 incidents={incidents}
                 onClickAddIncident={onClickAddIncident}
                 onClickView={onClickViewIncident}
-                status={status}
+                canEditFields={canEditFields}
                 definitionVersion={definitionVersion}
               />
             </Box>
             <Box marginLeft="25px" marginTop="25px">
-              <CaseSummary task={props.task} readonly={status === 'closed'} />
+              <CaseSummary task={props.task} readonly={!canEditCaseSummary} />
             </Box>
             <Dialog onClose={closeMockedMessage} open={isMockedMessageOpen}>
               <DialogContent>{mockedMessage}</DialogContent>

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -431,7 +431,6 @@ const Case: React.FC<Props> = props => {
                 name={fullName}
                 status={status}
                 can={can}
-                isEditing={isEditing}
                 counselor={caseCounselor}
                 categories={categories}
                 openedDate={openedDate}

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -54,6 +54,7 @@ import ViewReferral from './ViewReferral';
 import type { CaseDetailsName } from '../../states/case/types';
 import type { HouseholdEntry, PerpetratorEntry, IncidentEntry, Case as CaseType, CustomITask } from '../../types/types';
 import CasePrintView from './casePrint/CasePrintView';
+import { getPermissionsForCase, PermissionActions } from '../../permissions';
 
 const isStandaloneITask = (task): task is StandaloneITask => {
   return task.taskSid === 'standalone-task-sid';
@@ -389,14 +390,7 @@ const Case: React.FC<Props> = props => {
     contact: firstConnectedContact,
   };
 
-  const canEditFields = workerSid === twilioWorkerId && status === 'open';
-  let canEditCaseSummary = false;
-
-  if (version === 'v1') {
-    canEditCaseSummary = isSupervisor || canEditFields;
-  } else if (version === 'za-v1') {
-    canEditCaseSummary = isSupervisor;
-  }
+  const { can } = getPermissionsForCase(connectedCase);
 
   switch (subroute) {
     case 'add-note':
@@ -436,7 +430,7 @@ const Case: React.FC<Props> = props => {
                 caseId={connectedCase.id}
                 name={fullName}
                 status={status}
-                canEditFields={canEditFields}
+                can={can}
                 isEditing={isEditing}
                 counselor={caseCounselor}
                 categories={categories}
@@ -454,18 +448,12 @@ const Case: React.FC<Props> = props => {
               />
             </Box>
             <Box marginLeft="25px" marginTop="25px">
-              <Timeline
-                timelineActivities={timeline}
-                caseObj={connectedCase}
-                task={task}
-                form={form}
-                canEditFields={canEditFields}
-              />
+              <Timeline timelineActivities={timeline} caseObj={connectedCase} task={task} form={form} can={can} />
             </Box>
             <Box marginLeft="25px" marginTop="25px">
               <Households
                 households={households}
-                canEditFields={canEditFields}
+                can={can}
                 onClickAddHousehold={onClickAddHousehold}
                 onClickView={onClickViewHousehold}
               />
@@ -473,7 +461,7 @@ const Case: React.FC<Props> = props => {
             <Box marginLeft="25px" marginTop="25px">
               <Perpetrators
                 perpetrators={perpetrators}
-                canEditFields={canEditFields}
+                can={can}
                 onClickAddPerpetrator={onClickAddPerpetrator}
                 onClickView={onClickViewPerpetrator}
               />
@@ -483,12 +471,12 @@ const Case: React.FC<Props> = props => {
                 incidents={incidents}
                 onClickAddIncident={onClickAddIncident}
                 onClickView={onClickViewIncident}
-                canEditFields={canEditFields}
+                can={can}
                 definitionVersion={definitionVersion}
               />
             </Box>
             <Box marginLeft="25px" marginTop="25px">
-              <CaseSummary task={props.task} readonly={!canEditCaseSummary} />
+              <CaseSummary task={props.task} readonly={!can(PermissionActions.EDIT_CASE_SUMMARY)} />
             </Box>
             <Dialog onClose={closeMockedMessage} open={isMockedMessageOpen}>
               <DialogContent>{mockedMessage}</DialogContent>

--- a/plugin-hrm-form/src/components/case/CaseAddButton.jsx
+++ b/plugin-hrm-form/src/components/case/CaseAddButton.jsx
@@ -7,8 +7,7 @@ import { Template } from '@twilio/flex-ui';
 import { CaseAddButtonFont } from '../../styles/case';
 import HrmTheme from '../../styles/HrmTheme';
 
-const CaseAddButton = ({ canEditFields, templateCode, onClick, withDivider }) => {
-  const disabled = !canEditFields;
+const CaseAddButton = ({ disabled, templateCode, onClick, withDivider }) => {
   const color = disabled ? HrmTheme.colors.disabledColor : 'initial';
 
   return (
@@ -31,7 +30,7 @@ const CaseAddButton = ({ canEditFields, templateCode, onClick, withDivider }) =>
 
 CaseAddButton.displayName = 'CaseAddButton';
 CaseAddButton.propTypes = {
-  canEditFields: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
   templateCode: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   withDivider: PropTypes.bool,

--- a/plugin-hrm-form/src/components/case/CaseAddButton.jsx
+++ b/plugin-hrm-form/src/components/case/CaseAddButton.jsx
@@ -7,8 +7,8 @@ import { Template } from '@twilio/flex-ui';
 import { CaseAddButtonFont } from '../../styles/case';
 import HrmTheme from '../../styles/HrmTheme';
 
-const CaseAddButton = ({ status, templateCode, onClick, withDivider }) => {
-  const disabled = status === 'closed';
+const CaseAddButton = ({ canEditFields, templateCode, onClick, withDivider }) => {
+  const disabled = !canEditFields;
   const color = disabled ? HrmTheme.colors.disabledColor : 'initial';
 
   return (
@@ -31,7 +31,7 @@ const CaseAddButton = ({ status, templateCode, onClick, withDivider }) => {
 
 CaseAddButton.displayName = 'CaseAddButton';
 CaseAddButton.propTypes = {
-  status: PropTypes.string.isRequired,
+  canEditFields: PropTypes.bool.isRequired,
   templateCode: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   withDivider: PropTypes.bool,

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -34,7 +34,6 @@ const CaseDetails = ({
   followUpDate,
   status,
   can,
-  isEditing,
   office,
   childIsAtRisk,
   handlePrintCase,
@@ -55,7 +54,9 @@ const CaseDetails = ({
     handleStatusChange(selectedOption);
   };
 
-  const changeStatusDisabled = !isEditing || !can(PermissionActions.CLOSE_CASE);
+  const canChangeStatus =
+    (status === 'open' && can(PermissionActions.CLOSE_CASE)) ||
+    (status === 'closed' && can(PermissionActions.REOPEN_CASE));
 
   return (
     <>
@@ -120,12 +121,12 @@ const CaseDetails = ({
                 <Template code="Case-CaseDetailsStatusLabel" />
               </label>
             </DetailDescription>
-            <StyledSelectWrapper disabled={changeStatusDisabled}>
+            <StyledSelectWrapper disabled={!canChangeStatus}>
               <StyledSelectField
                 id="Details_CaseStatus"
                 name="Details_CaseStatus"
                 aria-labelledby="CaseDetailsStatusLabel"
-                disabled={changeStatusDisabled}
+                disabled={!canChangeStatus}
                 onChange={e => onStatusChange(e.target.value)}
                 defaultValue={status}
                 color={color}
@@ -157,7 +158,6 @@ CaseDetails.propTypes = {
   status: PropTypes.string.isRequired,
   can: PropTypes.func.isRequired,
   office: PropTypes.string,
-  isEditing: PropTypes.bool.isRequired,
   followUpDate: PropTypes.string,
   lastUpdatedDate: PropTypes.string,
   childIsAtRisk: PropTypes.bool.isRequired,

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -17,6 +17,7 @@ import {
   StyledSelectWrapper,
 } from '../../styles/case';
 import { FormOption } from '../../styles/HrmStyles';
+import { PermissionActions } from '../../permissions';
 
 const statusOptions = [
   { label: 'Open', value: 'open', color: 'green' },
@@ -32,7 +33,7 @@ const CaseDetails = ({
   lastUpdatedDate,
   followUpDate,
   status,
-  canEditFields,
+  can,
   isEditing,
   office,
   childIsAtRisk,
@@ -54,7 +55,7 @@ const CaseDetails = ({
     handleStatusChange(selectedOption);
   };
 
-  const changeStatusDisabled = !isEditing || !canEditFields;
+  const changeStatusDisabled = !isEditing || !can(PermissionActions.CLOSE_CASE);
 
   return (
     <>
@@ -154,7 +155,7 @@ CaseDetails.propTypes = {
   counselor: PropTypes.string.isRequired,
   openedDate: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
-  canEditFields: PropTypes.bool.isRequired,
+  can: PropTypes.func.isRequired,
   office: PropTypes.string,
   isEditing: PropTypes.bool.isRequired,
   followUpDate: PropTypes.string,

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -65,10 +65,10 @@ const CaseDetails = ({
         counselor={counselor}
         childIsAtRisk={childIsAtRisk}
         office={office}
-        status={status}
         handlePrintCase={handlePrintCase}
         handleClickChildIsAtRisk={handleClickChildIsAtRisk}
         isOrphanedCase={isOrphanedCase}
+        can={can}
       />
       <DetailsContainer tabIndex={0} aria-labelledby="Case-CaseId-label">
         <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -108,7 +108,7 @@ const CaseDetails = ({
               type="date"
               id="Details_DateFollowUp"
               name="Details_DateFollowUp"
-              disabled={status === 'closed'}
+              disabled={!can(PermissionActions.EDIT_FOLLOW_UP_DATE)}
               value={followUpDate}
               onChange={e => handleInfoChange('followUpDate', e.target.value)}
               aria-labelledby="CaseDetailsFollowUpDate"

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -32,6 +32,7 @@ const CaseDetails = ({
   lastUpdatedDate,
   followUpDate,
   status,
+  canEditFields,
   isEditing,
   office,
   childIsAtRisk,
@@ -52,6 +53,8 @@ const CaseDetails = ({
     setColor(statusOptions.find(x => x.value === selectedOption).color);
     handleStatusChange(selectedOption);
   };
+
+  const changeStatusDisabled = !isEditing || !canEditFields;
 
   return (
     <>
@@ -116,12 +119,12 @@ const CaseDetails = ({
                 <Template code="Case-CaseDetailsStatusLabel" />
               </label>
             </DetailDescription>
-            <StyledSelectWrapper disabled={!isEditing}>
+            <StyledSelectWrapper disabled={changeStatusDisabled}>
               <StyledSelectField
                 id="Details_CaseStatus"
                 name="Details_CaseStatus"
                 aria-labelledby="CaseDetailsStatusLabel"
-                disabled={!isEditing}
+                disabled={changeStatusDisabled}
                 onChange={e => onStatusChange(e.target.value)}
                 defaultValue={status}
                 color={color}
@@ -151,6 +154,7 @@ CaseDetails.propTypes = {
   counselor: PropTypes.string.isRequired,
   openedDate: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
+  canEditFields: PropTypes.bool.isRequired,
   office: PropTypes.string,
   isEditing: PropTypes.bool.isRequired,
   followUpDate: PropTypes.string,

--- a/plugin-hrm-form/src/components/case/Households.tsx
+++ b/plugin-hrm-form/src/components/case/Households.tsx
@@ -7,15 +7,16 @@ import { Box, Row } from '../../styles/HrmStyles';
 import { CaseSectionFont, TimelineRow, PlaceHolderText } from '../../styles/case';
 import CaseAddButton from './CaseAddButton';
 import InformationRow from './InformationRow';
+import { PermissionActions, PermissionActionType } from '../../permissions';
 
 type OwnProps = {
   onClickAddHousehold: () => void;
   onClickView: (household: HouseholdEntry) => void;
   households: CaseInfo['households'];
-  canEditFields: boolean;
+  can: (action: PermissionActionType) => boolean;
 };
 
-const Households: React.FC<OwnProps> = ({ onClickAddHousehold, onClickView, households, canEditFields }) => {
+const Households: React.FC<OwnProps> = ({ onClickAddHousehold, onClickView, households, can }) => {
   return (
     <>
       <Box marginBottom="10px">
@@ -23,7 +24,11 @@ const Households: React.FC<OwnProps> = ({ onClickAddHousehold, onClickView, hous
           <CaseSectionFont id="Case-AddHouseholdSection-label">
             <Template code="Case-AddHouseholdSection" />
           </CaseSectionFont>
-          <CaseAddButton templateCode="Case-Household" onClick={onClickAddHousehold} canEditFields={canEditFields} />
+          <CaseAddButton
+            templateCode="Case-Household"
+            onClick={onClickAddHousehold}
+            disabled={!can(PermissionActions.ADD_HOUSEHOLD)}
+          />
         </Row>
       </Box>
       {households.length ? (

--- a/plugin-hrm-form/src/components/case/Households.tsx
+++ b/plugin-hrm-form/src/components/case/Households.tsx
@@ -12,10 +12,10 @@ type OwnProps = {
   onClickAddHousehold: () => void;
   onClickView: (household: HouseholdEntry) => void;
   households: CaseInfo['households'];
-  status: string;
+  canEditFields: boolean;
 };
 
-const Households: React.FC<OwnProps> = ({ onClickAddHousehold, onClickView, households, status }) => {
+const Households: React.FC<OwnProps> = ({ onClickAddHousehold, onClickView, households, canEditFields }) => {
   return (
     <>
       <Box marginBottom="10px">
@@ -23,7 +23,7 @@ const Households: React.FC<OwnProps> = ({ onClickAddHousehold, onClickView, hous
           <CaseSectionFont id="Case-AddHouseholdSection-label">
             <Template code="Case-AddHouseholdSection" />
           </CaseSectionFont>
-          <CaseAddButton templateCode="Case-Household" onClick={onClickAddHousehold} status={status} />
+          <CaseAddButton templateCode="Case-Household" onClick={onClickAddHousehold} canEditFields={canEditFields} />
         </Row>
       </Box>
       {households.length ? (

--- a/plugin-hrm-form/src/components/case/Incidents.tsx
+++ b/plugin-hrm-form/src/components/case/Incidents.tsx
@@ -13,11 +13,17 @@ type OwnProps = {
   onClickAddIncident: () => void;
   onClickView: (incident: IncidentEntry) => void;
   incidents: CaseInfo['incidents'];
-  status: CaseStatus;
+  canEditFields: boolean;
   definitionVersion: DefinitionVersion;
 };
 
-const Incidents: React.FC<OwnProps> = ({ onClickAddIncident, onClickView, incidents, status, definitionVersion }) => {
+const Incidents: React.FC<OwnProps> = ({
+  onClickAddIncident,
+  onClickView,
+  incidents,
+  canEditFields,
+  definitionVersion,
+}) => {
   return (
     <>
       <Box marginBottom="10px">
@@ -25,7 +31,7 @@ const Incidents: React.FC<OwnProps> = ({ onClickAddIncident, onClickView, incide
           <CaseSectionFont id="Case-AddIncidentSection-label">
             <Template code="Case-AddIncidentSection" />
           </CaseSectionFont>
-          <CaseAddButton templateCode="Case-Incident" onClick={onClickAddIncident} status={status} />
+          <CaseAddButton templateCode="Case-Incident" onClick={onClickAddIncident} canEditFields={canEditFields} />
         </Row>
       </Box>
       {incidents.length ? (

--- a/plugin-hrm-form/src/components/case/Incidents.tsx
+++ b/plugin-hrm-form/src/components/case/Incidents.tsx
@@ -8,22 +8,17 @@ import { CaseSectionFont, TimelineRow, PlaceHolderText } from '../../styles/case
 import CaseAddButton from './CaseAddButton';
 import TimelineInformationRow from './TimelineInformationRow';
 import type { DefinitionVersion } from '../common/forms/types';
+import { PermissionActions, PermissionActionType } from '../../permissions';
 
 type OwnProps = {
   onClickAddIncident: () => void;
   onClickView: (incident: IncidentEntry) => void;
   incidents: CaseInfo['incidents'];
-  canEditFields: boolean;
+  can: (action: PermissionActionType) => boolean;
   definitionVersion: DefinitionVersion;
 };
 
-const Incidents: React.FC<OwnProps> = ({
-  onClickAddIncident,
-  onClickView,
-  incidents,
-  canEditFields,
-  definitionVersion,
-}) => {
+const Incidents: React.FC<OwnProps> = ({ onClickAddIncident, onClickView, incidents, can, definitionVersion }) => {
   return (
     <>
       <Box marginBottom="10px">
@@ -31,7 +26,11 @@ const Incidents: React.FC<OwnProps> = ({
           <CaseSectionFont id="Case-AddIncidentSection-label">
             <Template code="Case-AddIncidentSection" />
           </CaseSectionFont>
-          <CaseAddButton templateCode="Case-Incident" onClick={onClickAddIncident} canEditFields={canEditFields} />
+          <CaseAddButton
+            templateCode="Case-Incident"
+            onClick={onClickAddIncident}
+            disabled={!can(PermissionActions.ADD_INCIDENT)}
+          />
         </Row>
       </Box>
       {incidents.length ? (

--- a/plugin-hrm-form/src/components/case/Perpetrators.tsx
+++ b/plugin-hrm-form/src/components/case/Perpetrators.tsx
@@ -12,10 +12,10 @@ type OwnProps = {
   onClickAddPerpetrator: () => void;
   onClickView: (perpetrator: PerpetratorEntry) => void;
   perpetrators: CaseInfo['perpetrators'];
-  status: string;
+  canEditFields: boolean;
 };
 
-const Perpetrators: React.FC<OwnProps> = ({ onClickAddPerpetrator, onClickView, perpetrators, status }) => {
+const Perpetrators: React.FC<OwnProps> = ({ onClickAddPerpetrator, onClickView, perpetrators, canEditFields }) => {
   return (
     <>
       <Box marginBottom="10px">
@@ -23,7 +23,11 @@ const Perpetrators: React.FC<OwnProps> = ({ onClickAddPerpetrator, onClickView, 
           <CaseSectionFont id="Case-AddPerpetratorSection-label">
             <Template code="Case-AddPerpetratorSection" />
           </CaseSectionFont>
-          <CaseAddButton templateCode="Case-Perpetrator" onClick={onClickAddPerpetrator} status={status} />
+          <CaseAddButton
+            templateCode="Case-Perpetrator"
+            onClick={onClickAddPerpetrator}
+            canEditFields={canEditFields}
+          />
         </Row>
       </Box>
       {perpetrators.length ? (

--- a/plugin-hrm-form/src/components/case/Perpetrators.tsx
+++ b/plugin-hrm-form/src/components/case/Perpetrators.tsx
@@ -7,15 +7,16 @@ import { Box, Row } from '../../styles/HrmStyles';
 import { CaseSectionFont, TimelineRow, PlaceHolderText } from '../../styles/case';
 import CaseAddButton from './CaseAddButton';
 import InformationRow from './InformationRow';
+import { PermissionActions, PermissionActionType } from '../../permissions';
 
 type OwnProps = {
   onClickAddPerpetrator: () => void;
   onClickView: (perpetrator: PerpetratorEntry) => void;
   perpetrators: CaseInfo['perpetrators'];
-  canEditFields: boolean;
+  can: (action: PermissionActionType) => boolean;
 };
 
-const Perpetrators: React.FC<OwnProps> = ({ onClickAddPerpetrator, onClickView, perpetrators, canEditFields }) => {
+const Perpetrators: React.FC<OwnProps> = ({ onClickAddPerpetrator, onClickView, perpetrators, can }) => {
   return (
     <>
       <Box marginBottom="10px">
@@ -26,7 +27,7 @@ const Perpetrators: React.FC<OwnProps> = ({ onClickAddPerpetrator, onClickView, 
           <CaseAddButton
             templateCode="Case-Perpetrator"
             onClick={onClickAddPerpetrator}
-            canEditFields={canEditFields}
+            disabled={!can(PermissionActions.ADD_PERPETRATOR)}
           />
         </Row>
       </Box>

--- a/plugin-hrm-form/src/components/case/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/Timeline.tsx
@@ -30,7 +30,7 @@ import { Activity } from '../../states/case/types';
 
 type OwnProps = {
   timelineActivities: Activity[];
-  status: string;
+  canEditFields: boolean;
   task: ITask;
   form: TaskEntry;
   caseObj: CaseType;
@@ -40,7 +40,7 @@ type OwnProps = {
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const Timeline: React.FC<Props> = props => {
-  const { status, task, form, caseObj, changeRoute, updateTempInfo, route, timelineActivities } = props;
+  const { canEditFields, task, form, caseObj, changeRoute, updateTempInfo, route, timelineActivities } = props;
   const [mockedMessage, setMockedMessage] = useState(null);
 
   const handleOnClickView = activity => {
@@ -112,8 +112,13 @@ const Timeline: React.FC<Props> = props => {
             <Template code="Case-TimelineSection" />
           </CaseSectionFont>
           <Box marginLeft="auto">
-            <CaseAddButton templateCode="Case-Note" onClick={handleAddNoteClick} status={status} />
-            <CaseAddButton templateCode="Case-Referral" onClick={handleAddReferralClick} status={status} withDivider />
+            <CaseAddButton templateCode="Case-Note" onClick={handleAddNoteClick} canEditFields={canEditFields} />
+            <CaseAddButton
+              templateCode="Case-Referral"
+              onClick={handleAddReferralClick}
+              canEditFields={canEditFields}
+              withDivider
+            />
           </Box>
         </Row>
       </Box>

--- a/plugin-hrm-form/src/components/case/Timeline.tsx
+++ b/plugin-hrm-form/src/components/case/Timeline.tsx
@@ -27,10 +27,11 @@ import { blankReferral, Case as CaseType } from '../../types/types';
 import { isConnectedCaseActivity } from './caseHelpers';
 import { TaskEntry } from '../../states/contacts/reducer';
 import { Activity } from '../../states/case/types';
+import { PermissionActions, PermissionActionType } from '../../permissions';
 
 type OwnProps = {
   timelineActivities: Activity[];
-  canEditFields: boolean;
+  can: (action: PermissionActionType) => boolean;
   task: ITask;
   form: TaskEntry;
   caseObj: CaseType;
@@ -40,7 +41,7 @@ type OwnProps = {
 type Props = OwnProps & ConnectedProps<typeof connector>;
 
 const Timeline: React.FC<Props> = props => {
-  const { canEditFields, task, form, caseObj, changeRoute, updateTempInfo, route, timelineActivities } = props;
+  const { can, task, form, caseObj, changeRoute, updateTempInfo, route, timelineActivities } = props;
   const [mockedMessage, setMockedMessage] = useState(null);
 
   const handleOnClickView = activity => {
@@ -112,11 +113,15 @@ const Timeline: React.FC<Props> = props => {
             <Template code="Case-TimelineSection" />
           </CaseSectionFont>
           <Box marginLeft="auto">
-            <CaseAddButton templateCode="Case-Note" onClick={handleAddNoteClick} canEditFields={canEditFields} />
+            <CaseAddButton
+              templateCode="Case-Note"
+              onClick={handleAddNoteClick}
+              disabled={!can(PermissionActions.ADD_NOTE)}
+            />
             <CaseAddButton
               templateCode="Case-Referral"
               onClick={handleAddReferralClick}
-              canEditFields={canEditFields}
+              disabled={!can(PermissionActions.ADD_REFERRAL)}
               withDivider
             />
           </Box>

--- a/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
+++ b/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
@@ -18,7 +18,7 @@ import {
   StyledPrintButton,
 } from '../../../styles/case';
 import { Box, FormCheckbox, FormLabel } from '../../../styles/HrmStyles';
-import { CaseStatus } from '../../../types/types';
+import { PermissionActions, PermissionActionType } from '../../../permissions';
 
 type OwnProps = {
   caseId: string;
@@ -26,10 +26,10 @@ type OwnProps = {
   office: string;
   counselor: string;
   childIsAtRisk: boolean;
-  status: CaseStatus;
   handlePrintCase: () => void;
   handleClickChildIsAtRisk: () => void;
   isOrphanedCase: boolean;
+  can: (action: PermissionActionType) => boolean;
 };
 
 const CaseDetailsHeader: React.FC<OwnProps> = ({
@@ -38,10 +38,10 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({
   office,
   counselor,
   childIsAtRisk,
-  status,
   handlePrintCase,
   handleClickChildIsAtRisk,
   isOrphanedCase,
+  can,
 }) => {
   const { multipleOfficeSupport } = getConfig();
   return (
@@ -73,7 +73,7 @@ const CaseDetailsHeader: React.FC<OwnProps> = ({
                 type="checkbox"
                 onChange={handleClickChildIsAtRisk}
                 defaultChecked={Boolean(childIsAtRisk)}
-                disabled={status === 'closed'}
+                disabled={!can(PermissionActions.EDIT_CHILD_IS_AT_RISK)}
               />
             </Box>
             <Template code="Case-ChildIsAtRisk" />

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -22,9 +22,7 @@ type Version = 'v1' | 'za-v1';
 type Rule = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => boolean;
 type Rules = {
   canEditCaseSummary: Rule;
-  canEditChildIsAtRisk: Rule;
   canEditGenericField: Rule;
-  canEditFollowUpDate: Rule;
 };
 
 const rulesMap: { [version in Version]: Rules } = {
@@ -44,10 +42,8 @@ export const getPermissionsForCase = (caseObj: t.Case) => {
     switch (action) {
       case PermissionActions.EDIT_CASE_SUMMARY:
         return rules.canEditCaseSummary(isSupervisor, isCreator, isCaseOpen);
-      case PermissionActions.EDIT_CHILD_IS_AT_RISK:
-        return rules.canEditChildIsAtRisk(isSupervisor, isCreator, isCaseOpen);
-      case PermissionActions.EDIT_FOLLOW_UP_DATE:
-        return rules.canEditFollowUpDate(isSupervisor, isCreator, isCaseOpen);
+      case PermissionActions.REOPEN_CASE:
+        return false;
       default:
         return rules.canEditGenericField(isSupervisor, isCreator, isCaseOpen);
     }

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -1,0 +1,57 @@
+import { getConfig } from '../HrmFormPlugin';
+import type * as t from '../types/types';
+import { canEditCaseSummary as canEditCaseSummaryV1 } from './v1';
+import { canEditCaseSummary as canEditCaseSummaryZaV1 } from './za-v1';
+
+export const PermissionActions = {
+  OTHER: 'other',
+  CLOSE_CASE: 'closeCase',
+  REOPEN_CASE: 'reopenCase',
+  ADD_NOTE: 'addNote',
+  EDIT_NOTE: 'editNote',
+  ADD_REFERRAL: 'addReferral',
+  EDIT_REFERRAL: 'editReferral',
+  ADD_HOUSEHOLD: 'addHousehold',
+  EDIT_HOUSEHOLD: 'editHousehold',
+  ADD_PERPETRATOR: 'addPerpetrator',
+  EDIT_PERPETRATOR: 'editPerpetrator',
+  ADD_INCIDENT: 'addIncident',
+  EDIT_INCIDENT: 'editIncident',
+  EDIT_CASE_SUMMARY: 'editCaseSummary',
+};
+
+type PermissionActionsKeys = keyof typeof PermissionActions;
+export type PermissionActionType = typeof PermissionActions[PermissionActionsKeys];
+type Version = 'v1' | 'za-v1';
+
+type canEditCaseSummaryType = (isSpervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => boolean;
+const canEditCaseSummaryMap: { [version in Version]: canEditCaseSummaryType } = {
+  v1: canEditCaseSummaryV1,
+  'za-v1': canEditCaseSummaryZaV1,
+};
+
+export const getPermissionsForCase = (caseObj: t.Case) => {
+  const { workerSid, isSupervisor } = getConfig();
+  const version = (caseObj.info.definitionVersion || 'za-v1') as Version;
+  const { twilioWorkerId } = caseObj;
+  const isCreator = workerSid === twilioWorkerId;
+  const isCaseOpen = caseObj.status === 'open';
+
+  const canEditFields = isSupervisor || (isCreator && isCaseOpen);
+  const canEditCaseSummary = canEditCaseSummaryMap[version];
+
+  const can = (action: PermissionActionType): boolean => {
+    switch (action) {
+      case PermissionActions.OTHER:
+        return true;
+      case PermissionActions.EDIT_CASE_SUMMARY:
+        return canEditCaseSummary(isSupervisor, isCreator, isCaseOpen);
+      default:
+        return canEditFields;
+    }
+  };
+
+  return {
+    can,
+  };
+};

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -1,33 +1,32 @@
 import { getConfig } from '../HrmFormPlugin';
 import type * as t from '../types/types';
-import { canEditCaseSummary as canEditCaseSummaryV1 } from './v1';
-import { canEditCaseSummary as canEditCaseSummaryZaV1 } from './za-v1';
+import * as v1Rules from './v1';
+import * as zaV1Rules from './za-v1';
 
 export const PermissionActions = {
   OTHER: 'other',
   CLOSE_CASE: 'closeCase',
   REOPEN_CASE: 'reopenCase',
   ADD_NOTE: 'addNote',
-  EDIT_NOTE: 'editNote',
   ADD_REFERRAL: 'addReferral',
-  EDIT_REFERRAL: 'editReferral',
   ADD_HOUSEHOLD: 'addHousehold',
-  EDIT_HOUSEHOLD: 'editHousehold',
   ADD_PERPETRATOR: 'addPerpetrator',
-  EDIT_PERPETRATOR: 'editPerpetrator',
   ADD_INCIDENT: 'addIncident',
-  EDIT_INCIDENT: 'editIncident',
   EDIT_CASE_SUMMARY: 'editCaseSummary',
 };
 
 type PermissionActionsKeys = keyof typeof PermissionActions;
 export type PermissionActionType = typeof PermissionActions[PermissionActionsKeys];
 type Version = 'v1' | 'za-v1';
+type Rule = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => boolean;
+type Rules = {
+  canEditCaseSummary: Rule;
+  canEditGenericField: Rule;
+};
 
-type canEditCaseSummaryType = (isSpervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => boolean;
-const canEditCaseSummaryMap: { [version in Version]: canEditCaseSummaryType } = {
-  v1: canEditCaseSummaryV1,
-  'za-v1': canEditCaseSummaryZaV1,
+const rulesMap: { [version in Version]: Rules } = {
+  v1: v1Rules,
+  'za-v1': zaV1Rules,
 };
 
 export const getPermissionsForCase = (caseObj: t.Case) => {
@@ -36,18 +35,16 @@ export const getPermissionsForCase = (caseObj: t.Case) => {
   const { twilioWorkerId } = caseObj;
   const isCreator = workerSid === twilioWorkerId;
   const isCaseOpen = caseObj.status === 'open';
-
-  const canEditFields = isSupervisor || (isCreator && isCaseOpen);
-  const canEditCaseSummary = canEditCaseSummaryMap[version];
+  const rules = rulesMap[version];
 
   const can = (action: PermissionActionType): boolean => {
     switch (action) {
       case PermissionActions.OTHER:
         return true;
       case PermissionActions.EDIT_CASE_SUMMARY:
-        return canEditCaseSummary(isSupervisor, isCreator, isCaseOpen);
+        return rules.canEditCaseSummary(isSupervisor, isCreator, isCaseOpen);
       default:
-        return canEditFields;
+        return rules.canEditGenericField(isSupervisor, isCreator, isCaseOpen);
     }
   };
 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -23,6 +23,7 @@ type Rule = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => 
 type Rules = {
   canEditCaseSummary: Rule;
   canEditGenericField: Rule;
+  canReopenCase: Rule;
 };
 
 const rulesMap: { [version in Version]: Rules } = {
@@ -43,7 +44,7 @@ export const getPermissionsForCase = (caseObj: t.Case) => {
       case PermissionActions.EDIT_CASE_SUMMARY:
         return rules.canEditCaseSummary(isSupervisor, isCreator, isCaseOpen);
       case PermissionActions.REOPEN_CASE:
-        return false;
+        return rules.canReopenCase(isSupervisor, isCreator, isCaseOpen);
       default:
         return rules.canEditGenericField(isSupervisor, isCreator, isCaseOpen);
     }

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -13,6 +13,8 @@ export const PermissionActions = {
   ADD_PERPETRATOR: 'addPerpetrator',
   ADD_INCIDENT: 'addIncident',
   EDIT_CASE_SUMMARY: 'editCaseSummary',
+  EDIT_CHILD_IS_AT_RISK: 'editChildIsAtRisk',
+  EDIT_FOLLOW_UP_DATE: 'editFollowUpDate',
 };
 
 type PermissionActionsKeys = keyof typeof PermissionActions;
@@ -21,7 +23,9 @@ type Version = 'v1' | 'za-v1';
 type Rule = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => boolean;
 type Rules = {
   canEditCaseSummary: Rule;
+  canEditChildIsAtRisk: Rule;
   canEditGenericField: Rule;
+  canEditFollowUpDate: Rule;
 };
 
 const rulesMap: { [version in Version]: Rules } = {
@@ -43,6 +47,10 @@ export const getPermissionsForCase = (caseObj: t.Case) => {
         return true;
       case PermissionActions.EDIT_CASE_SUMMARY:
         return rules.canEditCaseSummary(isSupervisor, isCreator, isCaseOpen);
+      case PermissionActions.EDIT_CHILD_IS_AT_RISK:
+        return rules.canEditChildIsAtRisk(isSupervisor, isCreator, isCaseOpen);
+      case PermissionActions.EDIT_FOLLOW_UP_DATE:
+        return rules.canEditFollowUpDate(isSupervisor, isCreator, isCaseOpen);
       default:
         return rules.canEditGenericField(isSupervisor, isCreator, isCaseOpen);
     }

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -4,7 +4,6 @@ import * as v1Rules from './v1';
 import * as zaV1Rules from './za-v1';
 
 export const PermissionActions = {
-  OTHER: 'other',
   CLOSE_CASE: 'closeCase',
   REOPEN_CASE: 'reopenCase',
   ADD_NOTE: 'addNote',
@@ -43,8 +42,6 @@ export const getPermissionsForCase = (caseObj: t.Case) => {
 
   const can = (action: PermissionActionType): boolean => {
     switch (action) {
-      case PermissionActions.OTHER:
-        return true;
       case PermissionActions.EDIT_CASE_SUMMARY:
         return rules.canEditCaseSummary(isSupervisor, isCreator, isCaseOpen);
       case PermissionActions.EDIT_CHILD_IS_AT_RISK:

--- a/plugin-hrm-form/src/permissions/v1.ts
+++ b/plugin-hrm-form/src/permissions/v1.ts
@@ -1,0 +1,1 @@
+export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;

--- a/plugin-hrm-form/src/permissions/v1.ts
+++ b/plugin-hrm-form/src/permissions/v1.ts
@@ -1,1 +1,7 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
+
+/**
+ * For now, all the other actions are the same, and can use the below permission.
+ */
+ export const canEditGenericField = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+ isSupervisor || (isCreator && isCaseOpen);

--- a/plugin-hrm-form/src/permissions/v1.ts
+++ b/plugin-hrm-form/src/permissions/v1.ts
@@ -1,9 +1,5 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
-export const canEditChildIsAtRisk = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
-
-export const canEditFollowUpDate = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
-
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/v1.ts
+++ b/plugin-hrm-form/src/permissions/v1.ts
@@ -1,7 +1,11 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canEditChildIsAtRisk = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
+
+export const canEditFollowUpDate = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */
- export const canEditGenericField = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
- isSupervisor || (isCreator && isCaseOpen);
+export const canEditGenericField = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);

--- a/plugin-hrm-form/src/permissions/v1.ts
+++ b/plugin-hrm-form/src/permissions/v1.ts
@@ -1,5 +1,7 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
 
+export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/za-v1.ts
+++ b/plugin-hrm-form/src/permissions/za-v1.ts
@@ -1,6 +1,8 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
   isSupervisor || (isCreator && isCaseOpen);
 
+export const canReopenCase = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isSupervisor;
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/za-v1.ts
+++ b/plugin-hrm-form/src/permissions/za-v1.ts
@@ -1,0 +1,2 @@
+export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);

--- a/plugin-hrm-form/src/permissions/za-v1.ts
+++ b/plugin-hrm-form/src/permissions/za-v1.ts
@@ -1,10 +1,6 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
   isSupervisor || (isCreator && isCaseOpen);
 
-export const canEditChildIsAtRisk = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
-
-export const canEditFollowUpDate = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
-
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */

--- a/plugin-hrm-form/src/permissions/za-v1.ts
+++ b/plugin-hrm-form/src/permissions/za-v1.ts
@@ -1,2 +1,8 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
   isSupervisor || (isCreator && isCaseOpen);
+
+/**
+ * For now, all the other actions are the same, and can use the below permission.
+ */
+export const canEditGenericField = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
+  isSupervisor || (isCreator && isCaseOpen);

--- a/plugin-hrm-form/src/permissions/za-v1.ts
+++ b/plugin-hrm-form/src/permissions/za-v1.ts
@@ -1,6 +1,10 @@
 export const canEditCaseSummary = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) =>
   isSupervisor || (isCreator && isCaseOpen);
 
+export const canEditChildIsAtRisk = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
+
+export const canEditFollowUpDate = (isSupervisor: boolean, isCreator: boolean, isCaseOpen: boolean) => isCaseOpen;
+
 /**
  * For now, all the other actions are the same, and can use the below permission.
  */


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-571
Primary Reviewer: @nickhurlburt 

~This initial commit already applies permission rules to the front-end. Still working on making it less hardcoded than it is right now.~

Comments:
- For editing **Child is at Risk** and **Follow Up Date**, I've let the same logic as before because we don't have them defined. But I've let the code in a state where it'll be super easy to change it;
- Logic for adding notes, households, perpetrators they are all the same, so for now I have a generic rule for all of them;

Future TODOs:
- Get set of permission rules from **accountSid** instead of case's **definitionVersion**.