### PR TITLE
[WIP] Add customization support for case statuses

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.js
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.js
@@ -168,6 +168,7 @@ describe('useState mocked', () => {
             connectedContacts: [],
           },
           temporaryCaseInfo: '',
+          prevStatus: 'open',
         },
       },
     },

--- a/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
@@ -2,6 +2,7 @@ import { reduce } from '../../../states/case/reducer';
 import * as actions from '../../../states/case/actions';
 import * as GeneralActions from '../../../states/actions';
 import { Case } from '../../../types/types';
+import mockV1 from '../../../formDefinitions/v1';
 
 const task = { taskSid: 'task1' };
 const voidDefinitions = {
@@ -24,7 +25,7 @@ describe('test reducer', () => {
   });
 
   test('should ignore INITIALIZE_CONTACT_STATE', async () => {
-    const result = reduce(state, GeneralActions.initializeContactState(voidDefinitions)(task.taskSid));
+    const result = reduce(state, GeneralActions.initializeContactState(mockV1.tabbedForms)(task.taskSid));
     expect(result).toStrictEqual(state);
   });
 
@@ -40,7 +41,9 @@ describe('test reducer', () => {
       connectedContacts: null,
     };
 
-    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: null, caseHasBeenEdited: false } } };
+    const expected = {
+      tasks: { task1: { connectedCase, temporaryCaseInfo: null, caseHasBeenEdited: false, prevStatus: 'open' } },
+    };
 
     const result = reduce(state, actions.setConnectedCase(connectedCase, task.taskSid, false));
     expect(result).toStrictEqual(expected);
@@ -71,7 +74,14 @@ describe('test reducer', () => {
 
     const { connectedCase, temporaryCaseInfo } = state.tasks.task1;
     const expected = {
-      tasks: { task1: { connectedCase: { ...connectedCase, info }, temporaryCaseInfo, caseHasBeenEdited: true } },
+      tasks: {
+        task1: {
+          connectedCase: { ...connectedCase, info },
+          temporaryCaseInfo,
+          caseHasBeenEdited: true,
+          prevStatus: 'open',
+        },
+      },
     };
 
     const result = reduce(state, actions.updateCaseInfo(info, task.taskSid));
@@ -84,7 +94,9 @@ describe('test reducer', () => {
     const randomTemp = { screen: 'add-note', info: '' };
 
     const { connectedCase } = state.tasks.task1;
-    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: randomTemp, caseHasBeenEdited: true } } };
+    const expected = {
+      tasks: { task1: { connectedCase, temporaryCaseInfo: randomTemp, caseHasBeenEdited: true, prevStatus: 'open' } },
+    };
 
     const result = reduce(state, actions.updateTempInfo({ screen: 'add-note', info: '' }, task.taskSid));
     expect(result).toStrictEqual(expected);

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -286,14 +286,14 @@ const Case: React.FC<Props> = props => {
    * Setting this flag in the first render.
    */
   const [isEditing, setIsEditing] = useState(
-    props.connectedCaseState?.connectedCase && props.connectedCaseState?.connectedCase?.status === 'open',
+    props.connectedCaseState?.connectedCase && props.connectedCaseState?.connectedCase?.status !== 'closed',
   );
 
   if (!props.connectedCaseState) return null;
 
   const { task, form, counselorsHash } = props;
 
-  const { connectedCase, caseHasBeenEdited } = props.connectedCaseState;
+  const { connectedCase, caseHasBeenEdited, prevStatus } = props.connectedCaseState;
 
   const getCategories = firstConnectedContact => {
     if (firstConnectedContact?.rawJson?.caseInformation) {
@@ -317,7 +317,7 @@ const Case: React.FC<Props> = props => {
       if (props.updateAllCasesView) {
         props.updateAllCasesView(updatedCase);
       }
-      setIsEditing(connectedCase.status === 'open');
+      setIsEditing(connectedCase.status !== 'closed');
     } catch (error) {
       console.error(error);
       window.alert(strings['Error-Backend']);
@@ -428,6 +428,7 @@ const Case: React.FC<Props> = props => {
                 name={fullName}
                 status={status}
                 isEditing={isEditing}
+                prevStatus={prevStatus}
                 counselor={caseCounselor}
                 categories={categories}
                 openedDate={openedDate}
@@ -512,7 +513,7 @@ const Case: React.FC<Props> = props => {
                     <Template code="BottomBar-Close" />
                   </StyledNextStepButton>
                 </Box>
-                {isEditing && (
+                {(isEditing || caseHasBeenEdited) && (
                   <StyledNextStepButton disabled={!caseHasBeenEdited} roundCorners onClick={handleUpdate}>
                     <Template code="BottomBar-Update" />
                   </StyledNextStepButton>

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -439,7 +439,8 @@ const Case: React.FC<Props> = props => {
                 handleInfoChange={onInfoChange}
                 handleStatusChange={onStatusChange}
                 handleClickChildIsAtRisk={onClickChildIsAtRisk}
-                definitionVersion={connectedCase.info.definitionVersion}
+                definitionVersion={definitionVersion}
+                definitionVersionName={connectedCase.info.definitionVersion}
                 isOrphanedCase={!firstConnectedContact}
               />
             </Box>

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable no-empty-function */
 /* eslint-disable react/jsx-max-depth */
@@ -18,11 +19,6 @@ import {
 } from '../../styles/case';
 import { FormOption } from '../../styles/HrmStyles';
 
-const statusOptions = [
-  { label: 'Open', value: 'open', color: 'green' },
-  { label: 'Closed', value: 'closed', color: 'red' },
-];
-
 const CaseDetails = ({
   caseId,
   name,
@@ -40,19 +36,25 @@ const CaseDetails = ({
   handleStatusChange,
   handleClickChildIsAtRisk,
   definitionVersion,
+  definitionVersionName,
   isOrphanedCase,
 }) => {
-  const lastUpdatedClosedDate = openedDate === lastUpdatedDate ? '—' : lastUpdatedDate;
+  const currentStatus = definitionVersion.caseStatus[status];
 
-  const initialColor = (statusOptions.find(x => x.value === status) || {}).color || '#000000';
-
-  const [color, setColor] = useState(initialColor);
+  const statusOptions = React.useMemo(() => {
+    const possibleTransitions = currentStatus.transitions.reduce(
+      (acc, curr) => [...acc, definitionVersion.caseStatus[curr]],
+      [],
+    );
+    return [currentStatus, possibleTransitions];
+  }, [currentStatus, definitionVersion]);
 
   const onStatusChange = selectedOption => {
-    setColor(statusOptions.find(x => x.value === selectedOption).color);
     handleStatusChange(selectedOption);
   };
 
+  const color = currentStatus.color || '#000000';
+  const lastUpdatedClosedDate = openedDate === lastUpdatedDate ? '—' : lastUpdatedDate;
   return (
     <>
       <CaseDetailsHeader
@@ -136,7 +138,7 @@ const CaseDetails = ({
           </div>
         </div>
         <div style={{ paddingTop: '15px' }}>
-          <CaseTags definitionVersion={definitionVersion} categories={categories} />
+          <CaseTags definitionVersion={definitionVersionName} categories={categories} />
         </div>
       </DetailsContainer>
     </>
@@ -160,7 +162,8 @@ CaseDetails.propTypes = {
   handleInfoChange: PropTypes.func.isRequired,
   handleStatusChange: PropTypes.func.isRequired,
   handleClickChildIsAtRisk: PropTypes.func.isRequired,
-  definitionVersion: PropTypes.string.isRequired,
+  definitionVersion: PropTypes.shape({}).isRequired,
+  definitionVersionName: PropTypes.string.isRequired,
   isOrphanedCase: PropTypes.bool,
 };
 

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -4,7 +4,7 @@
 /* eslint-disable react/jsx-max-depth */
 /* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable react/no-multi-comp */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Template } from '@twilio/flex-ui';
 
@@ -28,6 +28,7 @@ const CaseDetails = ({
   lastUpdatedDate,
   followUpDate,
   status,
+  prevStatus,
   isEditing,
   office,
   childIsAtRisk,
@@ -39,22 +40,21 @@ const CaseDetails = ({
   definitionVersionName,
   isOrphanedCase,
 }) => {
-  const currentStatus = definitionVersion.caseStatus[status];
-
   const statusOptions = React.useMemo(() => {
-    const possibleTransitions = currentStatus.transitions.reduce(
-      (acc, curr) => [...acc, definitionVersion.caseStatus[curr]],
+    const statusTransitions = [prevStatus, ...definitionVersion.caseStatus[prevStatus].transitions];
+    return statusTransitions.reduce(
+      (acc, curr) => [...acc, { value: curr, label: definitionVersion.caseStatus[curr].label }],
       [],
     );
-    return [currentStatus, possibleTransitions];
-  }, [currentStatus, definitionVersion]);
+  }, [definitionVersion.caseStatus, prevStatus]);
 
   const onStatusChange = selectedOption => {
     handleStatusChange(selectedOption);
   };
 
-  const color = currentStatus.color || '#000000';
+  const color = definitionVersion.caseStatus[status].color || '#000000';
   const lastUpdatedClosedDate = openedDate === lastUpdatedDate ? '—' : lastUpdatedDate;
+  const statusCanTransition = statusOptions.length !== 1;
   return (
     <>
       <CaseDetailsHeader
@@ -118,12 +118,12 @@ const CaseDetails = ({
                 <Template code="Case-CaseDetailsStatusLabel" />
               </label>
             </DetailDescription>
-            <StyledSelectWrapper disabled={!isEditing}>
+            <StyledSelectWrapper disabled={!statusCanTransition}>
               <StyledSelectField
                 id="Details_CaseStatus"
                 name="Details_CaseStatus"
                 aria-labelledby="CaseDetailsStatusLabel"
-                disabled={!isEditing}
+                disabled={!statusCanTransition}
                 onChange={e => onStatusChange(e.target.value)}
                 defaultValue={status}
                 color={color}
@@ -153,6 +153,7 @@ CaseDetails.propTypes = {
   counselor: PropTypes.string.isRequired,
   openedDate: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
+  prevStatus: PropTypes.string.isRequired,
   office: PropTypes.string,
   isEditing: PropTypes.bool.isRequired,
   followUpDate: PropTypes.string,

--- a/plugin-hrm-form/src/components/case/Incidents.tsx
+++ b/plugin-hrm-form/src/components/case/Incidents.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Template } from '@twilio/flex-ui';
 
-import type { CaseInfo, IncidentEntry, CaseStatus } from '../../types/types';
+import type { CaseInfo, IncidentEntry } from '../../types/types';
 import { Box, Row } from '../../styles/HrmStyles';
 import { CaseSectionFont, TimelineRow, PlaceHolderText } from '../../styles/case';
 import CaseAddButton from './CaseAddButton';
@@ -13,7 +13,7 @@ type OwnProps = {
   onClickAddIncident: () => void;
   onClickView: (incident: IncidentEntry) => void;
   incidents: CaseInfo['incidents'];
-  status: CaseStatus;
+  status: string;
   definitionVersion: DefinitionVersion;
 };
 

--- a/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
+++ b/plugin-hrm-form/src/components/case/caseDetails/CaseDetailsHeader.tsx
@@ -18,7 +18,6 @@ import {
   StyledPrintButton,
 } from '../../../styles/case';
 import { Box, FormCheckbox, FormLabel } from '../../../styles/HrmStyles';
-import { CaseStatus } from '../../../types/types';
 
 type OwnProps = {
   caseId: string;
@@ -26,7 +25,7 @@ type OwnProps = {
   office: string;
   counselor: string;
   childIsAtRisk: boolean;
-  status: CaseStatus;
+  status: string;
   handlePrintCase: () => void;
   handleClickChildIsAtRisk: () => void;
   isOrphanedCase: boolean;

--- a/plugin-hrm-form/src/components/caseList/CaseListTableRow.jsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTableRow.jsx
@@ -38,7 +38,7 @@ const CaseListTableRow = ({ caseItem, counselorsHash, handleClickViewCase }) => 
       ? `${format(parseISO(caseItem.info.followUpDate), 'MMM d, yyyy')}`
       : '—';
   const categories = getContactTags(caseItem.info.definitionVersion, caseItem.categories);
-  const isOpenCase = caseItem.status === caseStatuses.open;
+  const isOpenCase = caseItem.status !== caseStatuses.closed;
 
   return (
     <CLTableRow data-testid="CaseList-TableRow">

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -164,6 +164,13 @@ export type LayoutVersion = {
   };
 };
 
+type StatusInfo = {
+  value: string;
+  label: string;
+  color: string;
+  transitions: [string];
+};
+
 /**
  * Type that defines a complete version for all the customizable forms used across the app
  */
@@ -188,5 +195,8 @@ export type DefinitionVersion = {
   insights: {
     oneToOneConfigSpec: OneToOneConfigSpec;
     oneToManyConfigSpecs: OneToManyConfigSpecs;
+  };
+  caseStatus: {
+    [status: string]: StatusInfo;
   };
 };

--- a/plugin-hrm-form/src/formDefinitions/v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/v1/CaseStatus.json
@@ -1,0 +1,14 @@
+{
+  "open": { 
+    "value": "open", 
+    "label": "Open", 
+    "color": "green", 
+    "transitions": ["closed"] 
+  },
+  "closed": { 
+    "value": "closed", 
+    "label": "Closed", 
+    "color": "red", 
+    "transitions": ["open"] 
+  }
+}

--- a/plugin-hrm-form/src/formDefinitions/v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/v1/CaseStatus.json
@@ -9,6 +9,6 @@
     "value": "closed", 
     "label": "Closed", 
     "color": "red", 
-    "transitions": ["open"] 
+    "transitions": []
   }
 }

--- a/plugin-hrm-form/src/formDefinitions/v1/index.ts
+++ b/plugin-hrm-form/src/formDefinitions/v1/index.ts
@@ -11,6 +11,7 @@ import IssueCategorizationTab from './tabbedForms/IssueCategorizationTab.json';
 import CallTypeButtons from './CallTypeButtons.json';
 import oneToOneConfigSpec from './insights/oneToOneConfigSpec.json';
 import oneToManyConfigSpecs from './insights/oneToManyConfigSpecs.json';
+import CaseStatus from './CaseStatus.json';
 import type {
   DefinitionVersion,
   LayoutVersion,
@@ -39,6 +40,7 @@ const version: DefinitionVersion = {
     oneToOneConfigSpec: (oneToOneConfigSpec as unknown) as OneToOneConfigSpec,
     oneToManyConfigSpecs: oneToManyConfigSpecs as OneToManyConfigSpecs,
   },
+  caseStatus: (CaseStatus as unknown) as DefinitionVersion['caseStatus'],
 };
 
 export default version;

--- a/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
@@ -1,0 +1,26 @@
+{
+  "open": { 
+    "value": "open", 
+    "label": "Open", 
+    "color": "green", 
+    "transitions": ["inProgress", "closed"] 
+  },
+  "inProgress": { 
+    "value": "inProgress", 
+    "label": "In Progress", 
+    "color": "grey", 
+    "transitions": ["closed"] 
+  },
+  "closed": { 
+    "value": "closed", 
+    "label": "Closed", 
+    "color": "red", 
+    "transitions": ["reOpened"] 
+  },
+  "reopened": { 
+    "value": "reopened", 
+    "label": "Reopened", 
+    "color": "green", 
+    "transitions": ["closed"]
+  }
+}

--- a/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
@@ -15,7 +15,7 @@
     "value": "closed", 
     "label": "Closed", 
     "color": "red", 
-    "transitions": ["reOpened"] 
+    "transitions": ["reopened"] 
   },
   "reopened": { 
     "value": "reopened", 

--- a/plugin-hrm-form/src/formDefinitions/za-v1/index.ts
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/index.ts
@@ -12,6 +12,7 @@ import CallTypeButtons from './CallTypeButtons.json';
 import OfficeInformation from './OfficeInformation.json';
 import oneToOneConfigSpec from './insights/oneToOneConfigSpec.json';
 import oneToManyConfigSpecs from './insights/oneToManyConfigSpecs.json';
+import CaseStatus from './CaseStatus.json';
 import type {
   DefinitionVersion,
   LayoutVersion,
@@ -19,7 +20,7 @@ import type {
   CallTypeButtonsDefinitions,
   OfficeDefinitions,
 } from '../../components/common/forms/types';
-import { OneToOneConfigSpec, OneToManyConfigSpecs } from '../../insightsConfig/types';
+import type { OneToOneConfigSpec, OneToManyConfigSpecs } from '../../insightsConfig/types';
 
 const version: DefinitionVersion = {
   caseForms: {
@@ -42,6 +43,7 @@ const version: DefinitionVersion = {
     oneToOneConfigSpec: (oneToOneConfigSpec as unknown) as OneToOneConfigSpec,
     oneToManyConfigSpecs: oneToManyConfigSpecs as OneToManyConfigSpecs,
   },
+  caseStatus: (CaseStatus as unknown) as DefinitionVersion['caseStatus'],
 };
 
 export default version;

--- a/plugin-hrm-form/src/states/case/actions.ts
+++ b/plugin-hrm-form/src/states/case/actions.ts
@@ -1,4 +1,4 @@
-import { Case, CaseInfo, CaseStatus } from '../../types/types';
+import { Case, CaseInfo } from '../../types/types';
 import {
   CaseActionType,
   TemporaryCaseInfo,
@@ -37,10 +37,10 @@ export const updateTempInfo = (value: TemporaryCaseInfo, taskId: string): CaseAc
 
 /**
  * Redux: Updates status for a provided case.
- * @param status CaseStatus (open, close, etc.)
+ * @param status string (open, close, etc.)
  * @param taskId Twilio Task Id
  */
-export const updateCaseStatus = (status: CaseStatus, taskId: string): CaseActionType => ({
+export const updateCaseStatus = (status: string, taskId: string): CaseActionType => ({
   type: UPDATE_CASE_STATUS,
   status,
   taskId,

--- a/plugin-hrm-form/src/states/case/reducer.ts
+++ b/plugin-hrm-form/src/states/case/reducer.ts
@@ -15,7 +15,12 @@ import { GeneralActionType, REMOVE_CONTACT_STATE } from '../types';
 
 export type CaseState = {
   tasks: {
-    [taskId: string]: { connectedCase: Case; temporaryCaseInfo?: TemporaryCaseInfo; caseHasBeenEdited: Boolean };
+    [taskId: string]: {
+      connectedCase: Case;
+      temporaryCaseInfo?: TemporaryCaseInfo;
+      caseHasBeenEdited: Boolean;
+      prevStatus: string; // the status as it comes from the DB (required as it may be locally updated in connectedCase)
+    };
   };
 };
 
@@ -34,6 +39,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
             connectedCase: action.connectedCase,
             temporaryCaseInfo: null,
             caseHasBeenEdited: action.caseHasBeenEdited,
+            prevStatus: action.connectedCase.status,
           },
         },
       };
@@ -56,6 +62,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
         tasks: {
           ...state.tasks,
           [action.taskId]: {
+            ...state.tasks[action.taskId],
             connectedCase: updatedCase,
             temporaryCaseInfo: null,
             caseHasBeenEdited: true,
@@ -82,6 +89,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
         tasks: {
           ...state.tasks,
           [action.taskId]: {
+            ...state.tasks[action.taskId],
             connectedCase: updatedCase,
             caseHasBeenEdited: true,
           },

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -69,7 +69,7 @@ type TemporaryCaseInfoAction = {
 
 type UpdateCasesStatusAction = {
   type: typeof UPDATE_CASE_STATUS;
-  status: t.CaseStatus;
+  status: string;
   taskId: string;
 };
 

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -3,8 +3,6 @@ import { ITask } from '@twilio/flex-ui';
 
 import type { CallTypes } from '../states/DomainConstants';
 
-export type CaseStatus = 'open' | 'closed';
-
 type EntryInfo = { createdAt: string; twilioWorkerId: string };
 
 /*
@@ -56,7 +54,7 @@ export type CaseInfo = {
 
 export type Case = {
   id: number;
-  status: CaseStatus;
+  status: string;
   helpline: string;
   twilioWorkerId: string;
   info?: CaseInfo;


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-567

This PR:
- Adds a new property to the case reducer: `prevStatus`, which stores the case status as it comes from the DB.
- Adds case statuses as part of customization (each status describes the possible transitions to other statuses).
- Using above information, decide when and to which statuses the UI allows to transition at a given time.