### PR TITLE
Add customization support for case statuses

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/case/Case.test.js
+++ b/plugin-hrm-form/src/___tests__/components/case/Case.test.js
@@ -174,6 +174,7 @@ describe('useState mocked', () => {
             connectedContacts: [],
           },
           temporaryCaseInfo: '',
+          prevStatus: 'open',
         },
       },
     },

--- a/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
+++ b/plugin-hrm-form/src/___tests__/states/case/reducer.test.ts
@@ -2,6 +2,7 @@ import { reduce } from '../../../states/case/reducer';
 import * as actions from '../../../states/case/actions';
 import * as GeneralActions from '../../../states/actions';
 import { Case } from '../../../types/types';
+import mockV1 from '../../../formDefinitions/v1';
 
 const task = { taskSid: 'task1' };
 const voidDefinitions = {
@@ -24,7 +25,7 @@ describe('test reducer', () => {
   });
 
   test('should ignore INITIALIZE_CONTACT_STATE', async () => {
-    const result = reduce(state, GeneralActions.initializeContactState(voidDefinitions)(task.taskSid));
+    const result = reduce(state, GeneralActions.initializeContactState(mockV1.tabbedForms)(task.taskSid));
     expect(result).toStrictEqual(state);
   });
 
@@ -40,7 +41,9 @@ describe('test reducer', () => {
       connectedContacts: null,
     };
 
-    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: null, caseHasBeenEdited: false } } };
+    const expected = {
+      tasks: { task1: { connectedCase, temporaryCaseInfo: null, caseHasBeenEdited: false, prevStatus: 'open' } },
+    };
 
     const result = reduce(state, actions.setConnectedCase(connectedCase, task.taskSid, false));
     expect(result).toStrictEqual(expected);
@@ -69,9 +72,11 @@ describe('test reducer', () => {
   test('should handle UPDATE_CASE_INFO', async () => {
     const info = { summary: 'Some summary', notes: ['Some note'] };
 
-    const { connectedCase, temporaryCaseInfo } = state.tasks.task1;
+    const { connectedCase, temporaryCaseInfo, prevStatus } = state.tasks.task1;
     const expected = {
-      tasks: { task1: { connectedCase: { ...connectedCase, info }, temporaryCaseInfo, caseHasBeenEdited: true } },
+      tasks: {
+        task1: { connectedCase: { ...connectedCase, info }, temporaryCaseInfo, caseHasBeenEdited: true, prevStatus },
+      },
     };
 
     const result = reduce(state, actions.updateCaseInfo(info, task.taskSid));
@@ -83,8 +88,10 @@ describe('test reducer', () => {
   test('should handle UPDATE_TEMP_INFO', async () => {
     const randomTemp = { screen: 'add-note', info: '' };
 
-    const { connectedCase } = state.tasks.task1;
-    const expected = { tasks: { task1: { connectedCase, temporaryCaseInfo: randomTemp, caseHasBeenEdited: true } } };
+    const { connectedCase, prevStatus } = state.tasks.task1;
+    const expected = {
+      tasks: { task1: { connectedCase, temporaryCaseInfo: randomTemp, caseHasBeenEdited: true, prevStatus } },
+    };
 
     const result = reduce(state, actions.updateTempInfo({ screen: 'add-note', info: '' }, task.taskSid));
     expect(result).toStrictEqual(expected);

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -176,6 +176,21 @@ const Case: React.FC<Props> = props => {
     }
   }, [definitionVersions, updateDefinitionVersion, version]);
 
+  // Memoize can function so is not re-created on every render of case view, but only when relevan case info changes
+  const { can } = React.useMemo(
+    () =>
+      getPermissionsForCase(
+        props.connectedCaseState.connectedCase.info.definitionVersion || 'za-v1',
+        props.connectedCaseState.connectedCase.twilioWorkerId,
+        props.connectedCaseState.connectedCase.status, // should this be prevStatus instead?
+      ),
+    [
+      props.connectedCaseState.connectedCase.info.definitionVersion,
+      props.connectedCaseState.connectedCase.status,
+      props.connectedCaseState.connectedCase.twilioWorkerId,
+    ],
+  );
+
   const toggleCaseMenu = e => {
     e.persist();
     setAnchorEl(e.currentTarget || e.target);
@@ -287,7 +302,7 @@ const Case: React.FC<Props> = props => {
 
   const { task, form, counselorsHash } = props;
 
-  const { connectedCase, caseHasBeenEdited } = props.connectedCaseState;
+  const { connectedCase, caseHasBeenEdited, prevStatus } = props.connectedCaseState;
 
   const getCategories = firstConnectedContact => {
     if (firstConnectedContact?.rawJson?.caseInformation) {
@@ -382,7 +397,7 @@ const Case: React.FC<Props> = props => {
     contact: firstConnectedContact,
   };
 
-  const { can } = getPermissionsForCase(connectedCase);
+  // const { can } = getPermissionsForCase(connectedCase);
 
   switch (subroute) {
     case 'add-note':
@@ -422,6 +437,7 @@ const Case: React.FC<Props> = props => {
                 caseId={connectedCase.id}
                 name={fullName}
                 status={status}
+                prevStatus={prevStatus}
                 can={can}
                 counselor={caseCounselor}
                 categories={categories}
@@ -434,7 +450,8 @@ const Case: React.FC<Props> = props => {
                 handleInfoChange={onInfoChange}
                 handleStatusChange={onStatusChange}
                 handleClickChildIsAtRisk={onClickChildIsAtRisk}
-                definitionVersion={connectedCase.info.definitionVersion}
+                definitionVersion={definitionVersion}
+                definitionVersionName={connectedCase.info.definitionVersion}
                 isOrphanedCase={!firstConnectedContact}
               />
             </Box>

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -227,7 +227,7 @@ const Case: React.FC<Props> = props => {
       const contact = await submitContactForm(task, form, connectedCase);
       await updateCase(connectedCase.id, { ...connectedCase });
       await connectToCase(contact.id, connectedCase.id);
-      props.markCaseAsUpdated(task.taskSid);
+      props.markCaseAsUpdated(task.taskSid); // (Gian): is this necessary?
       await completeTask(task);
     } catch (error) {
       console.error(error);
@@ -320,7 +320,7 @@ const Case: React.FC<Props> = props => {
 
     try {
       const updatedCase = await updateCase(connectedCase.id, { ...connectedCase });
-      props.markCaseAsUpdated(task.taskSid);
+      props.setConnectedCase(updatedCase, task.taskSid, true);
       props.updateCases(task.taskSid, updatedCase);
       // IF case has been edited from All Cases view, we should update that view
       if (props.updateAllCasesView) {
@@ -552,6 +552,7 @@ const mapDispatchToProps = {
   updateCaseInfo: CaseActions.updateCaseInfo,
   updateTempInfo: CaseActions.updateTempInfo,
   updateCaseStatus: CaseActions.updateCaseStatus,
+  setConnectedCase: CaseActions.setConnectedCase,
   markCaseAsUpdated: CaseActions.markCaseAsUpdated,
   updateCases: SearchActions.updateCases,
   updateDefinitionVersion: ConfigActions.updateDefinitionVersion,

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -182,12 +182,12 @@ const Case: React.FC<Props> = props => {
       getPermissionsForCase(
         props.connectedCaseState?.connectedCase.info.definitionVersion || 'za-v1',
         props.connectedCaseState?.connectedCase.twilioWorkerId,
-        props.connectedCaseState?.connectedCase.status, // should this be prevStatus instead?
+        props.connectedCaseState?.prevStatus,
       ),
     [
       props.connectedCaseState?.connectedCase.info.definitionVersion,
-      props.connectedCaseState?.connectedCase.status,
       props.connectedCaseState?.connectedCase.twilioWorkerId,
+      props.connectedCaseState?.prevStatus,
     ],
   );
 
@@ -227,7 +227,7 @@ const Case: React.FC<Props> = props => {
       const contact = await submitContactForm(task, form, connectedCase);
       await updateCase(connectedCase.id, { ...connectedCase });
       await connectToCase(contact.id, connectedCase.id);
-      props.markCaseAsUpdated(task.taskSid); // (Gian): is this necessary?
+      props.markCaseAsUpdated(task.taskSid);
       await completeTask(task);
     } catch (error) {
       console.error(error);
@@ -320,7 +320,7 @@ const Case: React.FC<Props> = props => {
 
     try {
       const updatedCase = await updateCase(connectedCase.id, { ...connectedCase });
-      props.setConnectedCase(updatedCase, task.taskSid, true);
+      props.setConnectedCase(updatedCase, task.taskSid, false);
       props.updateCases(task.taskSid, updatedCase);
       // IF case has been edited from All Cases view, we should update that view
       if (props.updateAllCasesView) {

--- a/plugin-hrm-form/src/components/case/Case.tsx
+++ b/plugin-hrm-form/src/components/case/Case.tsx
@@ -176,18 +176,18 @@ const Case: React.FC<Props> = props => {
     }
   }, [definitionVersions, updateDefinitionVersion, version]);
 
-  // Memoize can function so is not re-created on every render of case view, but only when relevan case info changes
+  // Memoize can function so is not re-created on every render of Case, but only when relevant case info changes
   const { can } = React.useMemo(
     () =>
       getPermissionsForCase(
-        props.connectedCaseState.connectedCase.info.definitionVersion || 'za-v1',
-        props.connectedCaseState.connectedCase.twilioWorkerId,
-        props.connectedCaseState.connectedCase.status, // should this be prevStatus instead?
+        props.connectedCaseState?.connectedCase.info.definitionVersion || 'za-v1',
+        props.connectedCaseState?.connectedCase.twilioWorkerId,
+        props.connectedCaseState?.connectedCase.status, // should this be prevStatus instead?
       ),
     [
-      props.connectedCaseState.connectedCase.info.definitionVersion,
-      props.connectedCaseState.connectedCase.status,
-      props.connectedCaseState.connectedCase.twilioWorkerId,
+      props.connectedCaseState?.connectedCase.info.definitionVersion,
+      props.connectedCaseState?.connectedCase.status,
+      props.connectedCaseState?.connectedCase.twilioWorkerId,
     ],
   );
 
@@ -396,8 +396,6 @@ const Case: React.FC<Props> = props => {
     version,
     contact: firstConnectedContact,
   };
-
-  // const { can } = getPermissionsForCase(connectedCase);
 
   switch (subroute) {
     case 'add-note':

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -3,7 +3,8 @@
 /* eslint-disable react/jsx-max-depth */
 /* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable react/no-multi-comp */
-import React, { useState } from 'react';
+/* eslint-disable react/prop-types */
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Template } from '@twilio/flex-ui';
 
@@ -19,11 +20,6 @@ import {
 import { FormOption } from '../../styles/HrmStyles';
 import { PermissionActions } from '../../permissions';
 
-const statusOptions = [
-  { label: 'Open', value: 'open', color: 'green' },
-  { label: 'Closed', value: 'closed', color: 'red' },
-];
-
 const CaseDetails = ({
   caseId,
   name,
@@ -33,6 +29,7 @@ const CaseDetails = ({
   lastUpdatedDate,
   followUpDate,
   status,
+  prevStatus,
   can,
   office,
   childIsAtRisk,
@@ -41,22 +38,45 @@ const CaseDetails = ({
   handleStatusChange,
   handleClickChildIsAtRisk,
   definitionVersion,
+  definitionVersionName,
   isOrphanedCase,
 }) => {
-  const lastUpdatedClosedDate = openedDate === lastUpdatedDate ? '—' : lastUpdatedDate;
+  const statusOptions = React.useMemo(() => {
+    const statusTransitions = [prevStatus, ...definitionVersion.caseStatus[prevStatus].transitions];
 
-  const initialColor = (statusOptions.find(x => x.value === status) || {}).color || '#000000';
+    const optionsArray = statusTransitions.reduce(
+      (acc, curr) => [...acc, { value: curr, label: definitionVersion.caseStatus[curr].label }],
+      [],
+    );
 
-  const [color, setColor] = useState(initialColor);
+    const enableBasedOnPermissions = o => {
+      if (o.value === 'closed' && prevStatus !== 'closed') return can(PermissionActions.CLOSE_CASE);
+      if (o.value !== 'closed' && prevStatus === 'closed') return can(PermissionActions.REOPEN_CASE);
+
+      return true;
+    };
+
+    const renderStatusOptions = o => {
+      const disabled = !enableBasedOnPermissions(o);
+
+      return (
+        <FormOption key={o.value} value={o.value} style={{ color: '#000000' }} disabled={disabled}>
+          {o.label}
+        </FormOption>
+      );
+    };
+
+    return optionsArray.map(renderStatusOptions);
+  }, [can, definitionVersion.caseStatus, prevStatus]);
 
   const onStatusChange = selectedOption => {
-    setColor(statusOptions.find(x => x.value === selectedOption).color);
     handleStatusChange(selectedOption);
   };
 
-  const canChangeStatus =
-    (status === 'open' && can(PermissionActions.CLOSE_CASE)) ||
-    (status === 'closed' && can(PermissionActions.REOPEN_CASE));
+  const canTransition = statusOptions.length !== 1;
+
+  const color = definitionVersion.caseStatus[status].color || '#000000';
+  const lastUpdatedClosedDate = openedDate === lastUpdatedDate ? '—' : lastUpdatedDate;
 
   return (
     <>
@@ -121,27 +141,23 @@ const CaseDetails = ({
                 <Template code="Case-CaseDetailsStatusLabel" />
               </label>
             </DetailDescription>
-            <StyledSelectWrapper disabled={!canChangeStatus}>
+            <StyledSelectWrapper disabled={!canTransition}>
               <StyledSelectField
                 id="Details_CaseStatus"
                 name="Details_CaseStatus"
                 aria-labelledby="CaseDetailsStatusLabel"
-                disabled={!canChangeStatus}
+                disabled={!canTransition}
                 onChange={e => onStatusChange(e.target.value)}
                 defaultValue={status}
                 color={color}
               >
-                {statusOptions.map(o => (
-                  <FormOption key={o.value} value={o.value} style={{ color: '#000000' }}>
-                    {o.label}
-                  </FormOption>
-                ))}
+                {statusOptions}
               </StyledSelectField>
             </StyledSelectWrapper>
           </div>
         </div>
         <div style={{ paddingTop: '15px' }}>
-          <CaseTags definitionVersion={definitionVersion} categories={categories} />
+          <CaseTags definitionVersion={definitionVersionName} categories={categories} />
         </div>
       </DetailsContainer>
     </>
@@ -156,6 +172,7 @@ CaseDetails.propTypes = {
   counselor: PropTypes.string.isRequired,
   openedDate: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
+  prevStatus: PropTypes.string.isRequired,
   can: PropTypes.func.isRequired,
   office: PropTypes.string,
   followUpDate: PropTypes.string,
@@ -165,7 +182,8 @@ CaseDetails.propTypes = {
   handleInfoChange: PropTypes.func.isRequired,
   handleStatusChange: PropTypes.func.isRequired,
   handleClickChildIsAtRisk: PropTypes.func.isRequired,
-  definitionVersion: PropTypes.string.isRequired,
+  definitionVersion: PropTypes.shape({}).isRequired,
+  definitionVersionName: PropTypes.string.isRequired,
   isOrphanedCase: PropTypes.bool,
 };
 

--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -60,7 +60,12 @@ const CaseDetails = ({
       const disabled = !enableBasedOnPermissions(o);
 
       return (
-        <FormOption key={o.value} value={o.value} style={{ color: '#000000' }} disabled={disabled}>
+        <FormOption
+          key={o.value}
+          value={o.value}
+          style={{ color: disabled ? '#000000' : definitionVersion.caseStatus[o.value].color }}
+          disabled={disabled}
+        >
           {o.label}
         </FormOption>
       );

--- a/plugin-hrm-form/src/components/case/Incidents.tsx
+++ b/plugin-hrm-form/src/components/case/Incidents.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Template } from '@twilio/flex-ui';
 
-import type { CaseInfo, IncidentEntry, CaseStatus } from '../../types/types';
+import type { CaseInfo, IncidentEntry } from '../../types/types';
 import { Box, Row } from '../../styles/HrmStyles';
 import { CaseSectionFont, TimelineRow, PlaceHolderText } from '../../styles/case';
 import CaseAddButton from './CaseAddButton';

--- a/plugin-hrm-form/src/components/caseList/CaseListTableRow.jsx
+++ b/plugin-hrm-form/src/components/caseList/CaseListTableRow.jsx
@@ -38,7 +38,7 @@ const CaseListTableRow = ({ caseItem, counselorsHash, handleClickViewCase }) => 
       ? `${format(parseISO(caseItem.info.followUpDate), 'MMM d, yyyy')}`
       : '—';
   const categories = getContactTags(caseItem.info.definitionVersion, caseItem.categories);
-  const isOpenCase = caseItem.status === caseStatuses.open;
+  const isOpenCase = caseItem.status !== caseStatuses.closed;
 
   return (
     <CLTableRow data-testid="CaseList-TableRow">

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -173,7 +173,7 @@ type StatusInfo = {
   value: string;
   label: string;
   color: string; // color that represents this status in the UI
-  transitions: [string]; // possible statuses this one can transition to (further update may be to include who can make such a transition for a more granular control)
+  transitions: string[]; // possible statuses this one can transition to (further update may be to include who can make such a transition for a more granular control)
 };
 
 /**

--- a/plugin-hrm-form/src/components/common/forms/types.ts
+++ b/plugin-hrm-form/src/components/common/forms/types.ts
@@ -169,6 +169,13 @@ export type LayoutVersion = {
   };
 };
 
+type StatusInfo = {
+  value: string;
+  label: string;
+  color: string; // color that represents this status in the UI
+  transitions: [string]; // possible statuses this one can transition to (further update may be to include who can make such a transition for a more granular control)
+};
+
 /**
  * Type that defines a complete version for all the customizable forms used across the app
  */
@@ -194,5 +201,8 @@ export type DefinitionVersion = {
   insights: {
     oneToOneConfigSpec: OneToOneConfigSpec;
     oneToManyConfigSpecs: OneToManyConfigSpecs;
+  };
+  caseStatus: {
+    [status: string]: StatusInfo;
   };
 };

--- a/plugin-hrm-form/src/formDefinitions/v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/v1/CaseStatus.json
@@ -1,0 +1,14 @@
+{
+  "open": { 
+    "value": "open", 
+    "label": "Open", 
+    "color": "green", 
+    "transitions": ["closed"] 
+  },
+  "closed": { 
+    "value": "closed", 
+    "label": "Closed", 
+    "color": "red", 
+    "transitions": ["open"] 
+  }
+} 

--- a/plugin-hrm-form/src/formDefinitions/v1/index.ts
+++ b/plugin-hrm-form/src/formDefinitions/v1/index.ts
@@ -17,7 +17,8 @@ import type {
   FormDefinition,
   CallTypeButtonsDefinitions,
 } from '../../components/common/forms/types';
-import { OneToOneConfigSpec, OneToManyConfigSpecs } from '../../insightsConfig/types';
+import type { OneToOneConfigSpec, OneToManyConfigSpecs } from '../../insightsConfig/types';
+import CaseStatus from './CaseStatus.json';
 
 const version: DefinitionVersion = {
   caseForms: {
@@ -39,6 +40,7 @@ const version: DefinitionVersion = {
     oneToOneConfigSpec: (oneToOneConfigSpec as unknown) as OneToOneConfigSpec,
     oneToManyConfigSpecs: oneToManyConfigSpecs as OneToManyConfigSpecs,
   },
+  caseStatus: (CaseStatus as unknown) as DefinitionVersion['caseStatus'],
 };
 
 export default version;

--- a/plugin-hrm-form/src/formDefinitions/v1/index.ts
+++ b/plugin-hrm-form/src/formDefinitions/v1/index.ts
@@ -40,7 +40,7 @@ const version: DefinitionVersion = {
     oneToOneConfigSpec: (oneToOneConfigSpec as unknown) as OneToOneConfigSpec,
     oneToManyConfigSpecs: oneToManyConfigSpecs as OneToManyConfigSpecs,
   },
-  caseStatus: (CaseStatus as unknown) as DefinitionVersion['caseStatus'],
+  caseStatus: CaseStatus as DefinitionVersion['caseStatus'],
 };
 
 export default version;

--- a/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
@@ -1,0 +1,20 @@
+{
+  "open": { 
+    "value": "open", 
+    "label": "Open", 
+    "color": "green", 
+    "transitions": ["inProgress", "closed"] 
+  },
+  "inProgress": { 
+    "value": "inProgress", 
+    "label": "In Progress", 
+    "color": "grey", 
+    "transitions": ["closed"] 
+  },
+  "closed": { 
+    "value": "closed", 
+    "label": "Closed", 
+    "color": "red", 
+    "transitions": ["reOpened"] 
+  }
+} 

--- a/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
@@ -15,6 +15,6 @@
     "value": "closed", 
     "label": "Closed", 
     "color": "red", 
-    "transitions": ["reOpened"] 
+    "transitions": ["open"] 
   }
 } 

--- a/plugin-hrm-form/src/formDefinitions/za-v1/index.ts
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/index.ts
@@ -46,7 +46,7 @@ const version: DefinitionVersion = {
     oneToOneConfigSpec: (oneToOneConfigSpec as unknown) as OneToOneConfigSpec,
     oneToManyConfigSpecs: oneToManyConfigSpecs as OneToManyConfigSpecs,
   },
-  caseStatus: (CaseStatus as unknown) as DefinitionVersion['caseStatus'],
+  caseStatus: CaseStatus as DefinitionVersion['caseStatus'],
 };
 
 export default version;

--- a/plugin-hrm-form/src/formDefinitions/za-v1/index.ts
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/index.ts
@@ -21,7 +21,8 @@ import type {
   OfficeDefinitions,
   CannedResponsesDefinitions,
 } from '../../components/common/forms/types';
-import { OneToOneConfigSpec, OneToManyConfigSpecs } from '../../insightsConfig/types';
+import type { OneToOneConfigSpec, OneToManyConfigSpecs } from '../../insightsConfig/types';
+import CaseStatus from './CaseStatus.json';
 
 const version: DefinitionVersion = {
   caseForms: {
@@ -45,6 +46,7 @@ const version: DefinitionVersion = {
     oneToOneConfigSpec: (oneToOneConfigSpec as unknown) as OneToOneConfigSpec,
     oneToManyConfigSpecs: oneToManyConfigSpecs as OneToManyConfigSpecs,
   },
+  caseStatus: (CaseStatus as unknown) as DefinitionVersion['caseStatus'],
 };
 
 export default version;

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -31,12 +31,14 @@ const rulesMap: { [version in Version]: Rules } = {
   'za-v1': zaV1Rules,
 };
 
-export const getPermissionsForCase = (caseObj: t.Case) => {
+export const getPermissionsForCase = (
+  version: t.Case['info']['definitionVersion'],
+  twilioWorkerId: t.Case['twilioWorkerId'],
+  status: t.Case['status'],
+) => {
   const { workerSid, isSupervisor } = getConfig();
-  const version = (caseObj.info.definitionVersion || 'za-v1') as Version;
-  const { twilioWorkerId } = caseObj;
   const isCreator = workerSid === twilioWorkerId;
-  const isCaseOpen = caseObj.status === 'open';
+  const isCaseOpen = status === 'open';
   const rules = rulesMap[version];
 
   const can = (action: PermissionActionType): boolean => {

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -36,6 +36,8 @@ export const getPermissionsForCase = (
   twilioWorkerId: t.Case['twilioWorkerId'],
   status: t.Case['status'],
 ) => {
+  if (!version || !twilioWorkerId || !status) return { can: undefined };
+
   const { workerSid, isSupervisor } = getConfig();
   const isCreator = workerSid === twilioWorkerId;
   const isCaseOpen = status === 'open';

--- a/plugin-hrm-form/src/states/case/actions.ts
+++ b/plugin-hrm-form/src/states/case/actions.ts
@@ -1,4 +1,4 @@
-import { Case, CaseInfo, CaseStatus } from '../../types/types';
+import { Case, CaseInfo } from '../../types/types';
 import {
   CaseActionType,
   TemporaryCaseInfo,
@@ -37,10 +37,10 @@ export const updateTempInfo = (value: TemporaryCaseInfo, taskId: string): CaseAc
 
 /**
  * Redux: Updates status for a provided case.
- * @param status CaseStatus (open, close, etc.)
- * @param taskId Twilio Task Id
+ * @param {string} status (open, close, etc.)
+ * @param {string} taskId Twilio Task Id
  */
-export const updateCaseStatus = (status: CaseStatus, taskId: string): CaseActionType => ({
+export const updateCaseStatus = (status: string, taskId: string): CaseActionType => ({
   type: UPDATE_CASE_STATUS,
   status,
   taskId,

--- a/plugin-hrm-form/src/states/case/reducer.ts
+++ b/plugin-hrm-form/src/states/case/reducer.ts
@@ -15,7 +15,12 @@ import { GeneralActionType, REMOVE_CONTACT_STATE } from '../types';
 
 export type CaseState = {
   tasks: {
-    [taskId: string]: { connectedCase: Case; temporaryCaseInfo?: TemporaryCaseInfo; caseHasBeenEdited: Boolean };
+    [taskId: string]: {
+      connectedCase: Case;
+      temporaryCaseInfo?: TemporaryCaseInfo;
+      caseHasBeenEdited: Boolean;
+      prevStatus: string; // the status as it comes from the DB (required as it may be locally updated in connectedCase)
+    };
   };
 };
 
@@ -34,6 +39,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
             connectedCase: action.connectedCase,
             temporaryCaseInfo: null,
             caseHasBeenEdited: action.caseHasBeenEdited,
+            prevStatus: action.connectedCase.status,
           },
         },
       };
@@ -56,6 +62,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
         tasks: {
           ...state.tasks,
           [action.taskId]: {
+            ...state.tasks[action.taskId],
             connectedCase: updatedCase,
             temporaryCaseInfo: null,
             caseHasBeenEdited: true,
@@ -82,6 +89,7 @@ export function reduce(state = initialState, action: CaseActionType | GeneralAct
         tasks: {
           ...state.tasks,
           [action.taskId]: {
+            ...state.tasks[action.taskId],
             connectedCase: updatedCase,
             caseHasBeenEdited: true,
           },

--- a/plugin-hrm-form/src/states/case/types.ts
+++ b/plugin-hrm-form/src/states/case/types.ts
@@ -69,7 +69,7 @@ type TemporaryCaseInfoAction = {
 
 type UpdateCasesStatusAction = {
   type: typeof UPDATE_CASE_STATUS;
-  status: t.CaseStatus;
+  status: string;
   taskId: string;
 };
 

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -863,8 +863,9 @@ export const FormSelect = styled('select')<FormInputProps>`
 `;
 FormSelect.displayName = 'FormSelect';
 
-// eslint-disable-next-line import/no-unused-modules
-export const FormOption = styled('option')<{ isEmptyValue: boolean }>`
+type FormOptionProps = { isEmptyValue?: boolean; disabled?: boolean };
+
+export const FormOption = styled('option')<FormOptionProps>`
   font-family: Open Sans;
   font-size: 12px;
   line-height: 1.33;
@@ -876,6 +877,7 @@ export const FormOption = styled('option')<{ isEmptyValue: boolean }>`
   padding: 0 12px;
   min-width: 0;
   ${({ isEmptyValue }) => isEmptyValue && 'color: #616161'}
+  ${props => props.disabled && `background-color: ${props.theme.colors.disabledColor};`}
 `;
 FormOption.displayName = 'FormOption';
 

--- a/plugin-hrm-form/src/types/types.ts
+++ b/plugin-hrm-form/src/types/types.ts
@@ -3,8 +3,6 @@ import { ITask } from '@twilio/flex-ui';
 
 import type { CallTypes } from '../states/DomainConstants';
 
-export type CaseStatus = 'open' | 'closed';
-
 type EntryInfo = { createdAt: string; twilioWorkerId: string };
 
 /*
@@ -56,7 +54,7 @@ export type CaseInfo = {
 
 export type Case = {
   id: number;
-  status: CaseStatus;
+  status: string;
   helpline: string;
   twilioWorkerId: string;
   info?: CaseInfo;


### PR DESCRIPTION
This PR is a reopen of https://github.com/tech-matters/flex-plugins/pull/400

Jira: https://bugs.benetech.org/browse/CHI-567

Primary reviewer: @murilovmachado 

This PR:

- Adds a new property to the case reducer: prevStatus, which stores the case status as it comes from the DB.
- Adds case statuses as part of customization (each status describes the possible transitions to other statuses).
- Using above information, decide when and to which statuses the UI allows to transition at a given time. This also takes into considerations permissions of the current counselor (please suggest changes / point to mistakes on this!).

WIP:
- ~CI.~
- ~Reflect changes on the backend.~ Done in https://github.com/tech-matters/hrm/pull/107
