### PR TITLE
Click View Records

### DIFF
--- a/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
+++ b/plugin-hrm-form/src/___tests__/components/PreviousContactsBanner.test.tsx
@@ -7,16 +7,18 @@ import { mount } from 'enzyme';
 import '../mockStyled';
 import { UnconnectedPreviousContactsBanner } from '../../components/PreviousContactsBanner';
 import { channelTypes } from '../../states/DomainConstants';
+import { SearchPages } from '../../states/search/types';
 
 expect.extend(toHaveNoViolations);
 
+const ip = 'task-ip';
 const webChatTask: any = {
   taskSid: 'task-sid',
   channelType: channelTypes.web,
   defaultFrom: 'Anonymous',
   attributes: {
     isContactlessTask: false,
-    ip: 'task-ip',
+    ip,
   },
 };
 
@@ -35,6 +37,9 @@ test('PreviousContacts initial search', () => {
       previousContacts={undefined}
       searchContacts={searchContacts}
       searchCases={searchCases}
+      changeRoute={jest.fn()}
+      handleSearchFormChange={jest.fn()}
+      changeSearchPage={jest.fn()}
     />,
   );
 
@@ -58,6 +63,9 @@ test('Dont repeat initial search calls on PreviousContacts', () => {
       previousContacts={previousContacts}
       searchContacts={searchContacts}
       searchCases={searchCases}
+      changeRoute={jest.fn()}
+      handleSearchFormChange={jest.fn()}
+      changeSearchPage={jest.fn()}
     />,
   );
 
@@ -78,6 +86,9 @@ test('Dont render PreviousContacts when there are no previous contacts', () => {
       previousContacts={previousContacts}
       searchContacts={jest.fn()}
       searchCases={jest.fn()}
+      changeRoute={jest.fn()}
+      handleSearchFormChange={jest.fn()}
+      changeSearchPage={jest.fn()}
     />,
   );
 
@@ -97,10 +108,50 @@ test('Render PreviousContacts when there are previous contacts', () => {
       previousContacts={previousContacts}
       searchContacts={jest.fn()}
       searchCases={jest.fn()}
+      changeRoute={jest.fn()}
+      handleSearchFormChange={jest.fn()}
+      changeSearchPage={jest.fn()}
     />,
   );
 
   expect(screen.getByTestId('PreviousContacts-Container')).toBeInTheDocument();
+});
+
+test('Click View Records should redirect user to search results', () => {
+  const previousContacts = {
+    contactsCount: 3,
+    casesCount: 1,
+  };
+
+  const searchContacts = jest.fn();
+  const searchCases = jest.fn();
+  const changeRoute = jest.fn();
+  const handleSearchFormChange = jest.fn();
+  const changeSearchPage = jest.fn();
+
+  render(
+    <UnconnectedPreviousContactsBanner
+      task={webChatTask}
+      counselorsHash={counselorsHash}
+      previousContacts={previousContacts}
+      searchContacts={searchContacts}
+      searchCases={searchCases}
+      changeRoute={changeRoute}
+      handleSearchFormChange={handleSearchFormChange}
+      changeSearchPage={changeSearchPage}
+    />,
+  );
+
+  expect(searchContacts).not.toHaveBeenCalled();
+  expect(searchCases).not.toHaveBeenCalled();
+
+  screen.getByTestId('PreviousContacts-ViewRecords').click();
+
+  expect(searchContacts).toHaveBeenCalled();
+  expect(searchCases).toHaveBeenCalled();
+  expect(handleSearchFormChange).toHaveBeenCalledWith('contactNumber', ip);
+  expect(changeSearchPage).toHaveBeenCalledWith(SearchPages.resultsContacts);
+  expect(changeRoute).toHaveBeenCalledWith({ route: 'tabbed-forms', subroute: 'search' });
 });
 
 test('a11y', async () => {
@@ -116,6 +167,9 @@ test('a11y', async () => {
       previousContacts={previousContacts}
       searchContacts={jest.fn()}
       searchCases={jest.fn()}
+      changeRoute={jest.fn()}
+      handleSearchFormChange={jest.fn()}
+      changeSearchPage={jest.fn()}
     />,
   );
 

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -23,7 +23,6 @@ jest.mock('../styles/HrmStyles', () => ({
   CheckboxField: 'CheckboxField',
   StyledCheckboxLabel: 'StyledCheckboxLabel',
   StyledCategoryCheckboxLabel: 'StyledCategoryCheckboxLabel',
-  TopNav: 'TopNav',
   BottomButtonBar: 'BottomButtonBar',
   NameFields: 'NameFields',
   ColumnarBlock: 'ColumnarBlock',

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -68,6 +68,7 @@ jest.mock('../styles/HrmStyles', () => ({
   TaskCanvasOverride: 'TaskCanvasOverride',
   PopoverText: 'PopoverText',
   CannedResponsesContainer: 'CannedResponsesContainer',
+  Bold: 'Bold',
 }));
 
 jest.mock('../styles/search', () => ({
@@ -125,6 +126,7 @@ jest.mock('../styles/search', () => ({
   StyledCount: 'StyledCount',
   StyledContactResultsHeader: 'StyledContactResultsHeader',
   StyledCaseResultsHeader: 'StyledCaseResultsHeader',
+  CheckboxLabel: 'CheckboxLabel',
 }));
 
 jest.mock('../styles/callTypeButtons', () => ({
@@ -185,5 +187,4 @@ jest.mock('../styles/case', () => ({
 
 jest.mock('../styles/previousContactsBanner', () => ({
   YellowBanner: 'YellowBanner',
-  Bold: 'Bold',
 }));

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -126,7 +126,6 @@ jest.mock('../styles/search', () => ({
   StyledCount: 'StyledCount',
   StyledContactResultsHeader: 'StyledContactResultsHeader',
   StyledCaseResultsHeader: 'StyledCaseResultsHeader',
-  CheckboxLabel: 'CheckboxLabel',
 }));
 
 jest.mock('../styles/callTypeButtons', () => ({

--- a/plugin-hrm-form/src/___tests__/mockStyled.js
+++ b/plugin-hrm-form/src/___tests__/mockStyled.js
@@ -19,7 +19,6 @@ jest.mock('../styles/HrmStyles', () => ({
   StyledSelect: 'StyledSelect',
   StyledMenuItem: 'StyledMenuItem',
   StyledNextStepButton: 'StyledNextStepButton',
-  TransparentButton: 'TransparentButton',
   CheckboxField: 'CheckboxField',
   StyledCheckboxLabel: 'StyledCheckboxLabel',
   StyledCategoryCheckboxLabel: 'StyledCategoryCheckboxLabel',

--- a/plugin-hrm-form/src/___tests__/search/Search.test.js
+++ b/plugin-hrm-form/src/___tests__/search/Search.test.js
@@ -20,7 +20,10 @@ jest.mock('../../services/ServerlessService', () => ({
   populateCounselors: async () => [],
 }));
 
-function createState(taskId, { currentPage, searchFormValues, currentContact, searchResult, detailsExpanded }) {
+function createState(
+  taskId,
+  { currentPage, searchFormValues, currentContact, searchResult, detailsExpanded, previousContacts },
+) {
   return {
     'plugin-hrm-form': {
       configuration: {
@@ -50,6 +53,7 @@ function createState(taskId, { currentPage, searchFormValues, currentContact, se
               dateTo: '',
             },
             searchResult: searchResult || [],
+            previousContacts,
             detailsExpanded: detailsExpanded || {},
             isRequesting: false,
             error: null,
@@ -86,6 +90,46 @@ test('<Search> should display <SearchForm />', () => {
   ).root;
 
   expect(() => component.findByType(SearchForm)).not.toThrow();
+  expect(() => component.findByType(ContactDetails)).toThrow();
+
+  const valuesProps = component.findByType(SearchForm).props.values;
+  expect(valuesProps).toEqual(searchFormValues);
+});
+
+test('<Search> should display <SearchForm /> with previous contacts checkbox', () => {
+  const currentPage = SearchPages.form;
+  const searchFormValues = {
+    firstName: 'Jill',
+    lastName: 'Smith',
+    counselor: { label: 'Counselor Name', value: 'counselor-id' },
+    phoneNumber: 'Anonymous',
+    dateFrom: '2020-03-10',
+    dateTo: '2020-03-15',
+  };
+  const task = {
+    taskSid: 'WT123',
+    attributes: {
+      isContactlessTask: false,
+      ip: 'user-ip',
+    },
+  };
+
+  const previousContacts = {
+    contactsCount: 3,
+    casesCount: 1,
+  };
+
+  const initialState = createState(task.taskSid, { currentPage, searchFormValues, detailsExpanded, previousContacts });
+  const store = mockStore(initialState);
+
+  const component = renderer.create(
+    <Provider store={store}>
+      <Search task={task} handleSelectSearchResult={() => null} handleExpandDetailsSection={() => null} />
+    </Provider>,
+  ).root;
+
+  expect(() => component.findByType(SearchForm)).not.toThrow();
+  expect(() => component.findByProps({ 'data-testid': 'Search-PreviousContactsCheckbox' })).not.toThrow();
   expect(() => component.findByType(ContactDetails)).toThrow();
 
   const valuesProps = component.findByType(SearchForm).props.values;

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -9,6 +9,7 @@ import {
   searchContacts as searchContactsAction,
   searchCases as searchCasesAction,
   handleSearchFormChange as handleSearchFormChangeAction,
+  changeSearchPage as changeSearchPageAction,
 } from '../states/search/actions';
 import { namespace, searchContactsBase, configurationBase, RootState } from '../states';
 import { getNumberFromTask } from '../services/ContactService';
@@ -18,6 +19,7 @@ import { Bold } from '../styles/HrmStyles';
 import { StyledLink } from '../styles/search';
 import { ChannelTypes, channelTypes } from '../states/DomainConstants';
 import { changeRoute as changeRouteAction } from '../states/routing/actions';
+import { SearchPages } from '../states/search/types';
 
 type OwnProps = {
   task: CustomITask;
@@ -42,6 +44,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
   searchCases,
   changeRoute,
   handleSearchFormChange,
+  changeSearchPage,
 }) => {
   useEffect(() => {
     if (task && task.attributes && !task.attributes.isContactlessTask && previousContacts === undefined) {
@@ -66,8 +69,9 @@ const PreviousContactsBanner: React.FC<Props> = ({
     const searchParams = { contactNumber };
     searchContacts(searchParams, counselorsHash, CONTACTS_PER_PAGE, 0);
     searchCases(searchParams, counselorsHash, CASES_PER_PAGE, 0);
-    changeRoute({ route: 'tabbed-forms', subroute: 'search' });
+    changeSearchPage(SearchPages.resultsContacts);
     handleSearchFormChange('contactNumber', contactNumber);
+    changeRoute({ route: 'tabbed-forms', subroute: 'search' });
   };
 
   const { contactsCount, casesCount } = previousContacts;
@@ -105,6 +109,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     searchCases: searchCasesAction(dispatch)(taskId),
     changeRoute: routing => dispatch(changeRouteAction(routing, taskId)),
     handleSearchFormChange: bindActionCreators(handleSearchFormChangeAction(taskId), dispatch),
+    changeSearchPage: bindActionCreators(changeSearchPageAction(taskId), dispatch),
   };
 };
 

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ITask, Template } from '@twilio/flex-ui';
 
-import { CustomITask } from '../types/types';
+import { CustomITask, isOfflineContactTask, isInMyBehalfITask } from '../types/types';
 import {
   searchContacts as searchContactsAction,
   searchCases as searchCasesAction,
@@ -65,7 +65,8 @@ const PreviousContactsBanner: React.FC<Props> = ({
   if (!shouldDisplayBanner) return null;
 
   const handleClickViewRecords = () => {
-    const contactNumber = getNumberFromTask(task as ITask);
+    if (isOfflineContactTask(task) || isInMyBehalfITask(task)) return;
+    const contactNumber = getNumberFromTask(task);
     const searchParams = { contactNumber };
     searchContacts(searchParams, counselorsHash, CONTACTS_PER_PAGE, 0);
     searchCases(searchParams, counselorsHash, CASES_PER_PAGE, 0);

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -1,16 +1,23 @@
 /* eslint-disable react/prop-types */
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { ITask, Template } from '@twilio/flex-ui';
 
 import { CustomITask } from '../types/types';
-import { searchContacts as searchContactsAction, searchCases as searchCasesAction } from '../states/search/actions';
+import {
+  searchContacts as searchContactsAction,
+  searchCases as searchCasesAction,
+  handleSearchFormChange as handleSearchFormChangeAction,
+} from '../states/search/actions';
 import { namespace, searchContactsBase, configurationBase, RootState } from '../states';
 import { getNumberFromTask } from '../services/ContactService';
 import { CONTACTS_PER_PAGE, CASES_PER_PAGE } from './search/SearchResults';
-import { YellowBanner, Bold } from '../styles/previousContactsBanner';
+import { YellowBanner } from '../styles/previousContactsBanner';
+import { Bold } from '../styles/HrmStyles';
 import { StyledLink } from '../styles/search';
 import { ChannelTypes, channelTypes } from '../states/DomainConstants';
+import { changeRoute as changeRouteAction } from '../states/routing/actions';
 
 type OwnProps = {
   task: CustomITask;
@@ -19,7 +26,7 @@ type OwnProps = {
 // eslint-disable-next-line no-use-before-define
 type Props = OwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
 
-const localizedSource: { [channelType in ChannelTypes]: string } = {
+export const localizedSource: { [channelType in ChannelTypes]: string } = {
   [channelTypes.web]: 'PreviousContacts-IPAddress',
   [channelTypes.voice]: 'PreviousContacts-PhoneNumber',
   [channelTypes.sms]: 'PreviousContacts-PhoneNumber',
@@ -33,6 +40,8 @@ const PreviousContactsBanner: React.FC<Props> = ({
   previousContacts,
   searchContacts,
   searchCases,
+  changeRoute,
+  handleSearchFormChange,
 }) => {
   useEffect(() => {
     if (task && task.attributes && !task.attributes.isContactlessTask && previousContacts === undefined) {
@@ -52,13 +61,22 @@ const PreviousContactsBanner: React.FC<Props> = ({
 
   if (!shouldDisplayBanner) return null;
 
+  const handleClickViewRecords = () => {
+    const contactNumber = getNumberFromTask(task as ITask);
+    const searchParams = { contactNumber };
+    searchContacts(searchParams, counselorsHash, CONTACTS_PER_PAGE, 0);
+    searchCases(searchParams, counselorsHash, CASES_PER_PAGE, 0);
+    changeRoute({ route: 'tabbed-forms', subroute: 'search' });
+    handleSearchFormChange('contactNumber', contactNumber);
+  };
+
   const { contactsCount, casesCount } = previousContacts;
 
   return (
     <YellowBanner data-testid="PreviousContacts-Container">
       {/* eslint-disable-next-line prettier/prettier */}
       <pre><Template code="PreviousContacts-ThereAre" /> <Bold>{contactsCount} <Template code="PreviousContacts-PreviousContacts" /></Bold> and <Bold>{casesCount} <Template code="PreviousContacts-Cases" /></Bold> <Template code="PreviousContacts-FromThis" /> <Template code={localizedSource[task.channelType]} />.</pre>
-      <StyledLink onClick={() => null}>
+      <StyledLink onClick={handleClickViewRecords}>
         <Template code="PreviousContacts-ViewRecords" />
       </StyledLink>
     </YellowBanner>
@@ -85,6 +103,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     searchContacts: searchContactsAction(dispatch)(taskId),
     searchCases: searchCasesAction(dispatch)(taskId),
+    changeRoute: routing => dispatch(changeRouteAction(routing, taskId)),
+    handleSearchFormChange: bindActionCreators(handleSearchFormChangeAction(taskId), dispatch),
   };
 };
 

--- a/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
+++ b/plugin-hrm-form/src/components/PreviousContactsBanner.tsx
@@ -80,7 +80,7 @@ const PreviousContactsBanner: React.FC<Props> = ({
     <YellowBanner data-testid="PreviousContacts-Container">
       {/* eslint-disable-next-line prettier/prettier */}
       <pre><Template code="PreviousContacts-ThereAre" /> <Bold>{contactsCount} <Template code="PreviousContacts-PreviousContacts" /></Bold> and <Bold>{casesCount} <Template code="PreviousContacts-Cases" /></Bold> <Template code="PreviousContacts-FromThis" /> <Template code={localizedSource[task.channelType]} />.</pre>
-      <StyledLink onClick={handleClickViewRecords}>
+      <StyledLink data-testid="PreviousContacts-ViewRecords" onClick={handleClickViewRecords}>
         <Template code="PreviousContacts-ViewRecords" />
       </StyledLink>
     </YellowBanner>

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -215,7 +215,7 @@ class SearchForm extends Component {
             <Row>
               <Box marginTop="20px">
                 <FormLabel htmlFor="Search_PreviousContacts">
-                  <FormCheckBoxWrapper>
+                  <FormCheckBoxWrapper data-testid="Search-PreviousContactsCheckbox">
                     <Box marginRight="5px">
                       <FormCheckbox
                         id="Search_PreviousContacts"

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -218,6 +218,7 @@ class SearchForm extends Component {
                         type="checkbox"
                         defaultChecked={true}
                         onChange={handleChangePreviousContactsCheckbox}
+                        blue
                       />
                     </Box>
                     <span>

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -57,7 +57,7 @@ class SearchForm extends Component {
     values: searchFormType.isRequired,
     task: taskType.isRequired,
     // eslint-disable-next-line react/forbid-prop-types
-    previousContacts: PropTypes.any,
+    previousContacts: PropTypes.any, // TODO: Transform this file into Typescript
   };
 
   static defaultProps = {
@@ -72,7 +72,16 @@ class SearchForm extends Component {
     handleFocus: () => {},
   });
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
+  get showPreviousContactsCheckbox() {
+    const { previousContacts } = this.props;
+
+    return (
+      typeof previousContacts !== 'undefined' &&
+      previousContacts &&
+      (previousContacts.contactsCount > 0 || previousContacts.casesCount > 0)
+    );
+  }
+
   render() {
     const {
       firstName,
@@ -116,12 +125,7 @@ class SearchForm extends Component {
       if (event.key === 'Enter') submitSearch();
     };
 
-    const { previousContacts, task } = this.props;
-
-    const showPreviousContactsCheckbox =
-      typeof previousContacts !== 'undefined' &&
-      previousContacts &&
-      (previousContacts.contactsCount > 0 || previousContacts.casesCount > 0);
+    const { task } = this.props;
 
     const contactNumberFromTask = getNumberFromTask(task);
 
@@ -207,7 +211,7 @@ class SearchForm extends Component {
               />
             )}
           </Row>
-          {showPreviousContactsCheckbox && (
+          {this.showPreviousContactsCheckbox && (
             <Row>
               <Box marginTop="20px">
                 <FormLabel htmlFor="Search_PreviousContacts">
@@ -216,7 +220,7 @@ class SearchForm extends Component {
                       <FormCheckbox
                         id="Search_PreviousContacts"
                         type="checkbox"
-                        defaultChecked={true}
+                        defaultChecked={contactNumber}
                         onChange={handleChangePreviousContactsCheckbox}
                         blue
                       />

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -222,7 +222,6 @@ class SearchForm extends Component {
                         type="checkbox"
                         defaultChecked={contactNumber}
                         onChange={handleChangePreviousContactsCheckbox}
-                        blue
                       />
                     </Box>
                     <span>

--- a/plugin-hrm-form/src/components/search/SearchForm/index.jsx
+++ b/plugin-hrm-form/src/components/search/SearchForm/index.jsx
@@ -12,11 +12,13 @@ import {
   StyledNextStepButton,
   Row,
   BottomButtonBar,
-  Flex,
+  Box,
+  FormLabel,
+  FormCheckBoxWrapper,
   FormCheckbox,
   Bold,
 } from '../../../styles/HrmStyles';
-import { SearchTitle, CheckboxLabel } from '../../../styles/search';
+import { SearchTitle } from '../../../styles/search';
 import { searchFormType, taskType } from '../../../types';
 import { getConfig } from '../../../HrmFormPlugin';
 import { namespace, configurationBase, searchContactsBase } from '../../../states';
@@ -207,18 +209,24 @@ class SearchForm extends Component {
           </Row>
           {showPreviousContactsCheckbox && (
             <Row>
-              <Flex alignItems="baseline" width="217px" marginTop="20px">
-                <FormCheckbox
-                  id="Search_PreviousContacts"
-                  type="checkbox"
-                  defaultChecked={true}
-                  onChange={handleChangePreviousContactsCheckbox}
-                />
-                <CheckboxLabel>
-                  <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={source} />{' '}
-                  <Bold>{contactNumberFromTask}</Bold>
-                </CheckboxLabel>
-              </Flex>
+              <Box marginTop="20px">
+                <FormLabel htmlFor="Search_PreviousContacts">
+                  <FormCheckBoxWrapper>
+                    <Box marginRight="5px">
+                      <FormCheckbox
+                        id="Search_PreviousContacts"
+                        type="checkbox"
+                        defaultChecked={true}
+                        onChange={handleChangePreviousContactsCheckbox}
+                      />
+                    </Box>
+                    <span>
+                      <Template code="PreviousContacts-OnlyShowRecordsFrom" /> <Template code={source} />{' '}
+                      <Bold>{contactNumberFromTask}</Bold>
+                    </span>
+                  </FormCheckBoxWrapper>
+                </FormLabel>
+              </Box>
             </Row>
           )}
         </Container>

--- a/plugin-hrm-form/src/components/search/index.tsx
+++ b/plugin-hrm-form/src/components/search/index.tsx
@@ -112,6 +112,7 @@ const Search: React.FC<Props> = props => {
       case SearchPages.form:
         return (
           <SearchForm
+            task={props.task}
             values={form}
             handleSearchFormChange={props.handleSearchFormChange}
             handleSearch={setSearchParamsAndHandleSearch}

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -16,7 +16,7 @@ import { changeRoute } from '../../states/routing/actions';
 import type { TaskEntry } from '../../states/contacts/reducer';
 import { TabbedFormSubroutes, NewCaseSubroutes } from '../../states/routing/types';
 import { CustomITask, isOfflineContactTask, SearchContact } from '../../types/types';
-import { TabbedFormsContainer, TopNav, TransparentButton, StyledTabs } from '../../styles/HrmStyles';
+import { TabbedFormsContainer, Box, StyledTabs } from '../../styles/HrmStyles';
 import FormTab from '../common/forms/FormTab';
 import callTypes from '../../states/DomainConstants';
 import Search from '../search';
@@ -26,7 +26,8 @@ import ContactlessTaskTab from './ContactlessTaskTab';
 import BottomBar from './BottomBar';
 import { hasTaskControl } from '../../utils/transfer';
 import { isNonDataCallType } from '../../states/ValidationRules';
-import { reRenderAgentDesktop } from '../../HrmFormPlugin';
+import { getConfig } from '../../HrmFormPlugin';
+import SearchResultsBackButton from '../search/SearchResults/SearchResultsBackButton';
 
 // eslint-disable-next-line react/display-name
 const mapTabsComponents = (errors: any) => (t: TabbedFormSubroutes) => {
@@ -153,14 +154,15 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, currentD
 
   const isDataCallType = !isNonDataCallType(contactForm.callType);
   const showSubmitButton = !isEmptyCallType(contactForm.callType) && tabIndex === tabs.length - 1;
+  const { strings } = getConfig();
 
   return (
     <FormProvider {...methods}>
       <div role="form" style={{ height: '100%' }}>
         <TabbedFormsContainer>
-          <TopNav>
-            <TransparentButton onClick={handleBackButton}>&lt; BACK</TransparentButton>
-          </TopNav>
+          <Box marginTop="10px" marginBottom="10px">
+            <SearchResultsBackButton handleBack={handleBackButton} text={strings['TabbedForms-BackButton']} />
+          </Box>
           <StyledTabs name="tab" variant="scrollable" scrollButtons="auto" value={tabIndex} onChange={handleTabsChange}>
             {tabs}
           </StyledTabs>

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -59,6 +59,8 @@ const mapTabsToIndex = (task: CustomITask, contactForm: TaskEntry): TabbedFormSu
       : ['search', 'contactlessTask', 'childInformation', 'categories', 'caseInformation'];
   }
 
+  if ([null, undefined, ''].includes(contactForm.callType)) return ['search'];
+
   return isCallerType
     ? ['search', 'callerInformation', 'childInformation', 'categories', 'caseInformation']
     : ['search', 'childInformation', 'categories', 'caseInformation'];

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import SearchIcon from '@material-ui/icons/Search';
 import { useForm, FormProvider } from 'react-hook-form';
 import { connect, ConnectedProps } from 'react-redux';
+import { Template } from '@twilio/flex-ui';
 
 import { CaseLayout } from '../../styles/case';
 import Case from '../case';
@@ -26,7 +27,6 @@ import ContactlessTaskTab from './ContactlessTaskTab';
 import BottomBar from './BottomBar';
 import { hasTaskControl } from '../../utils/transfer';
 import { isNonDataCallType } from '../../states/ValidationRules';
-import { getConfig } from '../../HrmFormPlugin';
 import SearchResultsBackButton from '../search/SearchResults/SearchResultsBackButton';
 
 // eslint-disable-next-line react/display-name
@@ -154,14 +154,13 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, currentD
 
   const isDataCallType = !isNonDataCallType(contactForm.callType);
   const showSubmitButton = !isEmptyCallType(contactForm.callType) && tabIndex === tabs.length - 1;
-  const { strings } = getConfig();
 
   return (
     <FormProvider {...methods}>
       <div role="form" style={{ height: '100%' }}>
         <TabbedFormsContainer>
           <Box marginTop="10px" marginBottom="10px">
-            <SearchResultsBackButton handleBack={handleBackButton} text={strings['TabbedForms-BackButton']} />
+            <SearchResultsBackButton handleBack={handleBackButton} text={<Template code="TabbedForms-BackButton" />} />
           </Box>
           <StyledTabs name="tab" variant="scrollable" scrollButtons="auto" value={tabIndex} onChange={handleTabsChange}>
             {tabs}

--- a/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
+++ b/plugin-hrm-form/src/components/tabbedForms/TabbedForms.tsx
@@ -48,6 +48,8 @@ const mapTabsComponents = (errors: any) => (t: TabbedFormSubroutes) => {
   }
 };
 
+const isEmptyCallType = callType => [null, undefined, ''].includes(callType);
+
 const mapTabsToIndex = (task: CustomITask, contactForm: TaskEntry): TabbedFormSubroutes[] => {
   const isCallerType = contactForm.callType === callTypes.caller;
 
@@ -59,7 +61,7 @@ const mapTabsToIndex = (task: CustomITask, contactForm: TaskEntry): TabbedFormSu
       : ['search', 'contactlessTask', 'childInformation', 'categories', 'caseInformation'];
   }
 
-  if ([null, undefined, ''].includes(contactForm.callType)) return ['search'];
+  if (isEmptyCallType(contactForm.callType)) return ['search'];
 
   return isCallerType
     ? ['search', 'callerInformation', 'childInformation', 'categories', 'caseInformation']
@@ -150,6 +152,7 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, currentD
       : undefined;
 
   const isDataCallType = !isNonDataCallType(contactForm.callType);
+  const showSubmitButton = !isEmptyCallType(contactForm.callType) && tabIndex === tabs.length - 1;
 
   return (
     <FormProvider {...methods}>
@@ -217,7 +220,7 @@ const TabbedForms: React.FC<Props> = ({ dispatch, routing, contactForm, currentD
             }
             // TODO: move this two functions to a separate file to centralize "handle task completions"
             showNextButton={tabIndex !== 0 && tabIndex < tabs.length - 1}
-            showSubmitButton={tabIndex === tabs.length - 1}
+            showSubmitButton={showSubmitButton}
             handleSubmitIfValid={methods.handleSubmit} // TODO: this should be used within BottomBar, but that requires a small refactor to make it a functional component
             optionalButtons={optionalButtons}
           />

--- a/plugin-hrm-form/src/states/search/reducer.ts
+++ b/plugin-hrm-form/src/states/search/reducer.ts
@@ -43,6 +43,7 @@ export const newTaskEntry: TaskEntry = {
     phoneNumber: '',
     dateFrom: '',
     dateTo: '',
+    contactNumber: '',
   },
   detailsExpanded: {
     [ContactDetailsSections.GENERAL_DETAILS]: true,

--- a/plugin-hrm-form/src/states/search/types.ts
+++ b/plugin-hrm-form/src/states/search/types.ts
@@ -22,6 +22,7 @@ export const newSearchFormEntry = {
   phoneNumber: '',
   dateFrom: '',
   dateTo: '',
+  contactNumber: '',
 };
 
 export type SearchFormValues = {

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -965,3 +965,9 @@ export const CannedResponsesContainer = styled('div')`
 `;
 
 CannedResponsesContainer.displayName = 'CannedResponsesContainer';
+
+export const Bold = styled('span')`
+  font-weight: 700;
+`;
+
+Bold.displayName = 'Bold';

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -272,18 +272,6 @@ export const StyledNextStepButton = styled(Button)<StyledNextStepButtonProps>`
 `;
 StyledNextStepButton.displayName = 'StyledNextStepButton';
 
-type TransparentButton = {
-  textTransform?: string;
-};
-
-export const TransparentButton = styled(Button)<TransparentButton>`
-  color: black;
-  text-transform: ${props => props.textTransform || 'uppercase'};
-  font-size: 12px;
-  letter-spacing: 2px;
-`;
-TransparentButton.displayName = 'TransparentButton';
-
 export const BottomButtonBar = styled('div')`
   display: flex;
   align-items: center;
@@ -768,10 +756,14 @@ const CheckboxBase = styled('input')<FormInputProps>`
   }
 `;
 
-export const FormCheckbox = styled(CheckboxBase)`
+type FormCheckboxProps = {
+  blue?: boolean;
+};
+
+export const FormCheckbox = styled(CheckboxBase)<FormCheckboxProps>`
   &[type='checkbox']:checked::before {
-    border-color: #5dba32;
-    background: #5dba32;
+    border-color: ${props => (props.blue ? '#1976D2' : '#5dba32')};
+    background: ${props => (props.blue ? '#1976D2' : '#5dba32')};
   }
   &[type='checkbox']:checked::after {
     font-family: 'Font Awesome 5 Free';

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -272,19 +272,17 @@ export const StyledNextStepButton = styled(Button)<StyledNextStepButtonProps>`
 `;
 StyledNextStepButton.displayName = 'StyledNextStepButton';
 
-export const TransparentButton = styled(Button)`
+type TransparentButton = {
+  textTransform?: string;
+};
+
+export const TransparentButton = styled(Button)<TransparentButton>`
   color: black;
-  text-transform: uppercase;
+  text-transform: ${props => props.textTransform || 'uppercase'};
   font-size: 12px;
   letter-spacing: 2px;
 `;
 TransparentButton.displayName = 'TransparentButton';
-
-export const TopNav = styled('div')`
-  display: flex;
-  flex-direction: row;
-`;
-TopNav.displayName = 'TopNav';
 
 export const BottomButtonBar = styled('div')`
   display: flex;

--- a/plugin-hrm-form/src/styles/HrmStyles.tsx
+++ b/plugin-hrm-form/src/styles/HrmStyles.tsx
@@ -756,14 +756,10 @@ const CheckboxBase = styled('input')<FormInputProps>`
   }
 `;
 
-type FormCheckboxProps = {
-  blue?: boolean;
-};
-
-export const FormCheckbox = styled(CheckboxBase)<FormCheckboxProps>`
+export const FormCheckbox = styled(CheckboxBase)`
   &[type='checkbox']:checked::before {
-    border-color: ${props => (props.blue ? '#1976D2' : '#5dba32')};
-    background: ${props => (props.blue ? '#1976D2' : '#5dba32')};
+    border-color: #1976d2;
+    background: #1976d2;
   }
   &[type='checkbox']:checked::after {
     font-family: 'Font Awesome 5 Free';
@@ -779,8 +775,8 @@ export const FormMixedCheckbox = styled(CheckboxBase)`
     background: #d13821;
   }
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='true']::before {
-    border-color: #5dba32;
-    background: #5dba32;
+    border-color: #1976d2;
+    background: #1976d2;
   }
   &[class~='mixed-checkbox'][type='checkbox'][aria-checked='false']::after {
     font-family: 'Font Awesome 5 Free';

--- a/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
+++ b/plugin-hrm-form/src/styles/previousContactsBanner/index.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'react-emotion';
 
 export const YellowBanner = styled('div')`
@@ -11,9 +10,3 @@ export const YellowBanner = styled('div')`
 `;
 
 YellowBanner.displayName = 'YellowBanner';
-
-export const Bold = styled('span')`
-  font-weight: 700;
-`;
-
-Bold.displayName = 'Bold';

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -489,9 +489,3 @@ export const StandaloneSearchContainer = styled(TabbedFormsContainer)`
   background-color: ${props => props.theme.colors.base2};
 `;
 StandaloneSearchContainer.displayName = 'StandaloneSearchContainer';
-
-export const CheckboxLabel = styled('span')`
-  margin-left: 5px;
-  font-size: 13px;
-`;
-CheckboxLabel.displayName = 'CheckboxLabel';

--- a/plugin-hrm-form/src/styles/search/index.tsx
+++ b/plugin-hrm-form/src/styles/search/index.tsx
@@ -489,3 +489,9 @@ export const StandaloneSearchContainer = styled(TabbedFormsContainer)`
   background-color: ${props => props.theme.colors.base2};
 `;
 StandaloneSearchContainer.displayName = 'StandaloneSearchContainer';
+
+export const CheckboxLabel = styled('span')`
+  margin-left: 5px;
+  font-size: 13px;
+`;
+CheckboxLabel.displayName = 'CheckboxLabel';

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -284,6 +284,7 @@
   "PreviousContacts-PhoneNumber": "phone number",
   "PreviousContacts-WhatsappNumber": "whatsapp number",
   "PreviousContacts-FacebookUser": "facebook user",
-  "PreviousContacts-ViewRecords": "View Records"
+  "PreviousContacts-ViewRecords": "View Records",
+  "PreviousContacts-OnlyShowRecordsFrom": "Only show records from"
 }
 

--- a/plugin-hrm-form/src/translations/en-US/flexUI.json
+++ b/plugin-hrm-form/src/translations/en-US/flexUI.json
@@ -124,6 +124,7 @@
   "TabbedForms-CategoriesTab": "Categories",
   "TabbedForms-AddCaseInfoTab": "Summary",
   "TabbedForms-AddContactInfoTab": "Contact Info",
+  "TabbedForms-BackButton": "Categorize Contact Type",
 
   "NotImplemented": "Not implemented yet!",
   "Error-Backend": "Error from backend system.",

--- a/plugin-hrm-form/src/types/index.js
+++ b/plugin-hrm-form/src/types/index.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 
 export const taskType = PropTypes.shape({
   taskSid: PropTypes.string,
+  number: PropTypes.string,
 });
 
 export const counselorType = PropTypes.shape({
@@ -166,4 +167,5 @@ export const searchFormType = PropTypes.shape({
   phoneNumber: PropTypes.string,
   dateFrom: PropTypes.string,
   dateTo: PropTypes.string,
+  contactNumber: PropTypes.string,
 });


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-596
Primary reviewer: @GPaoloni 

Implements clicking on PreviousContactsBanner **View Records**.

![image](https://user-images.githubusercontent.com/1504544/114745918-12e26d80-9d47-11eb-8ec6-7a7879057620.png)

P.S.: I've decided not to transform some files into Typescript just yet, because it would show up as more changes in Git, making it harder to review.

WIP:
- ~Bug: Blinks SearchForm before showing SearchResults~
- ~Bug: Refresh. Page > Click View Records > Click any other tabs: they have blank content~
- ~Change Checkbox color to blue~
- ~Change Back label to Categorize Contact~
- ~Bug: checkbox state gets incorrect when coming back from search results~
- ~Tests~
