### PR TITLE
Revert plugin-flex to point to latest beta version and feature flag for previous contacts

### DIFF
--- a/.github/workflows/plugin-hrm-form-ci.yml
+++ b/.github/workflows/plugin-hrm-form-ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install the Twilio CLI and plugins
-      run: npm install twilio-cli -g && twilio plugins:install @twilio-labs/plugin-flex@4.6.0-beta.0
+      run: npm install twilio-cli -g && twilio plugins:install @twilio-labs/plugin-flex@beta
     - name: Create Temp Files
       run: |
         touch ./public/appConfig.js

--- a/plugin-hrm-form/src/components/TaskView.tsx
+++ b/plugin-hrm-form/src/components/TaskView.tsx
@@ -10,7 +10,7 @@ import * as GeneralActions from '../states/actions';
 import { hasTaskControl } from '../utils/transfer';
 import type { ContactFormDefinition } from '../states/types';
 import { CustomITask, isOfflineContactTask, isInMyBehalfITask } from '../types/types';
-import { reRenderAgentDesktop } from '../HrmFormPlugin';
+import { reRenderAgentDesktop, getConfig } from '../HrmFormPlugin';
 import PreviousContactsBanner from './PreviousContactsBanner';
 import { Flex } from '../styles/HrmStyles';
 
@@ -46,9 +46,11 @@ const TaskView: React.FC<Props> = props => {
 
   if (!show) return null;
 
+  const { featureFlags } = getConfig();
+
   return (
     <Flex flexDirection="column" height="100%">
-      <PreviousContactsBanner task={task} />
+      {featureFlags.enable_previous_contacts && <PreviousContactsBanner task={task} />}
       {!hasTaskControl(task) && <FormNotEditable />}
       <HrmForm task={task} />
     </Flex>


### PR DESCRIPTION
Twilio has fixed the issues on `plugin-flex` and we can point to its latest beta version again.
This PR also wraps previous contacts on a feature flag.