### PR TITLE
Case status Changes

### DIFF
--- a/plugin-hrm-form/src/components/case/CaseDetails.jsx
+++ b/plugin-hrm-form/src/components/case/CaseDetails.jsx
@@ -40,6 +40,7 @@ const CaseDetails = ({
   definitionVersion,
   definitionVersionName,
   isOrphanedCase,
+  // eslint-disable-next-line sonarjs/cognitive-complexity
 }) => {
   const statusOptions = React.useMemo(() => {
     const statusTransitions = [prevStatus, ...definitionVersion.caseStatus[prevStatus].transitions];
@@ -50,28 +51,24 @@ const CaseDetails = ({
     );
 
     const enableBasedOnPermissions = o => {
+      if (o.value === prevStatus) return true;
       if (o.value === 'closed' && prevStatus !== 'closed') return can(PermissionActions.CLOSE_CASE);
       if (o.value !== 'closed' && prevStatus === 'closed') return can(PermissionActions.REOPEN_CASE);
 
-      return true;
+      return can(PermissionActions.CASE_STATUS_TRANSITION);
     };
 
     const renderStatusOptions = o => {
       const disabled = !enableBasedOnPermissions(o);
 
-      return (
-        <FormOption
-          key={o.value}
-          value={o.value}
-          style={{ color: disabled ? '#000000' : definitionVersion.caseStatus[o.value].color }}
-          disabled={disabled}
-        >
+      return disabled ? null : (
+        <FormOption key={o.value} value={o.value} style={{ color: definitionVersion.caseStatus[o.value].color }}>
           {o.label}
         </FormOption>
       );
     };
 
-    return optionsArray.map(renderStatusOptions);
+    return optionsArray.map(renderStatusOptions).filter(Boolean);
   }, [can, definitionVersion.caseStatus, prevStatus]);
 
   const onStatusChange = selectedOption => {

--- a/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
+++ b/plugin-hrm-form/src/formDefinitions/za-v1/CaseStatus.json
@@ -8,7 +8,7 @@
   "inProgress": { 
     "value": "inProgress", 
     "label": "In Progress", 
-    "color": "grey", 
+    "color": "green", 
     "transitions": ["closed"] 
   },
   "closed": { 

--- a/plugin-hrm-form/src/permissions/index.ts
+++ b/plugin-hrm-form/src/permissions/index.ts
@@ -6,6 +6,7 @@ import * as zaV1Rules from './za-v1';
 export const PermissionActions = {
   CLOSE_CASE: 'closeCase',
   REOPEN_CASE: 'reopenCase',
+  CASE_STATUS_TRANSITION: 'caseStatusTransition',
   ADD_NOTE: 'addNote',
   ADD_REFERRAL: 'addReferral',
   ADD_HOUSEHOLD: 'addHousehold',
@@ -40,7 +41,7 @@ export const getPermissionsForCase = (
 
   const { workerSid, isSupervisor } = getConfig();
   const isCreator = workerSid === twilioWorkerId;
-  const isCaseOpen = status === 'open';
+  const isCaseOpen = status !== 'closed';
   const rules = rulesMap[version];
 
   const can = (action: PermissionActionType): boolean => {


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-613
Primary reviewer: @murilovmachado 

This PR:
- Introduces `PermissionActions.CASE_STATUS_TRANSITION` to handle transitions that are not `CLOSE_CASE` nor `REOPEN_CASE` (e.g. `open -> inProgress` transition), and treats them same way as `canEditGenericField` type rules.
- Adapts case status UI to above change.
- Changes `inProgress` status color to be the same as `open` in za-v1 specs.