### PR TITLE
Removing translations included in serverless (CHI-528)

### DIFF
--- a/plugin-hrm-form/src/translations/Bemba/messages.json
+++ b/plugin-hrm-form/src/translations/Bemba/messages.json
@@ -1,4 +1,0 @@
-{
-  "WelcomeMsg": "Mulishani,ine ndi Chimbusa,nalamwafwilishako shani mukwai?",
-  "GoodbyeMsg": "Ichimbusa chapwisha imilimo yakulanda.Twatotela pakutuma kuno.Mukatutumine nakabili nga mwafwaya ubwafwilisho kuli baifwe."
-}

--- a/plugin-hrm-form/src/translations/Kaonde/messages.json
+++ b/plugin-hrm-form/src/translations/Kaonde/messages.json
@@ -1,4 +1,0 @@
-{
-  "WelcomeMsg": "Baji byepi amuwa nenkwasho,ne mikwashe byepi?",
-  "GoodbyeMsg": "Nkwasho wafumapo twasanta pakufika kwiatweba, mwakonsha kutuma lamya kimye kiji kyonse nga mwena kukeba bukwasho buji bonse."
-}

--- a/plugin-hrm-form/src/translations/Lozi/messages.json
+++ b/plugin-hrm-form/src/translations/Lozi/messages.json
@@ -1,4 +1,0 @@
-{
-  "WelcomeMsg": "Ha, kina mwelezi nikatusa cwani?",
-  "GoodbyeMsg": "Mwelezi ufelize kwambola.Nitumezi ku amboliÂsana,nikupa kuti ululizeze a katokwa tuso."
-}

--- a/plugin-hrm-form/src/translations/Lunda/messages.json
+++ b/plugin-hrm-form/src/translations/Lunda/messages.json
@@ -1,4 +1,0 @@
-{
-  "WelcomeMsg": "Nayimushi mwani ami nidi nkhong'u chuyikwashiku mwani?",
-  "GoodbyeMsg": "Ankhong'u adihu wanyi kusakililaku mwani, hakushika kudechu, mwani anachweshi kuchuma mpinji yidi yakazhima yana kukeng'a wukwashu."
-}

--- a/plugin-hrm-form/src/translations/Nyanja/messages.json
+++ b/plugin-hrm-form/src/translations/Nyanja/messages.json
@@ -1,4 +1,0 @@
-{
-  "WelcomeMsg": "Hello ine ndine wauphungu kodi tingakuthandizeni bwanji?",
-  "GoodbyeMsg": "Wauphungu achoka mkukambitsana nanu. Zikomo kwambili pa kukwanisa kukambisana ndi ife. Telo muli omasuka kutuma phone nthawi ina yonse pa thandizo lililonse?"
-}

--- a/plugin-hrm-form/src/translations/Tonga/messages.json
+++ b/plugin-hrm-form/src/translations/Tonga/messages.json
@@ -1,4 +1,0 @@
-{
-  "WelcomeMsg": "Mooni,ndime sikulaya naa sikuyumyayumya. Inga ndamugwasya buti?",
-  "GoodbyeMsg": "Sikulaya/sikuyumyayumya wazwa lino amubandi. Twalumba kukwabana andiswe,Inga mwatuma lubo naa muciyanda lumbi lugwasyo."
-}


### PR DESCRIPTION
Jira: [CHI-528](https://bugs.benetech.org/browse/CHI-528)

These translations are not handled by Flex-plugins, instead of that, they are included in `serverless`.

Primary reviewer: @nickhurlburt 

Related to:
- [serverless](https://github.com/tech-matters/serverless/pull/51)
- [webchat](https://github.com/tech-matters/webchat/pull/28)